### PR TITLE
Command result clean-up

### DIFF
--- a/python-package/examples/all_commands.py
+++ b/python-package/examples/all_commands.py
@@ -1,0 +1,65 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'src'))
+from tapir_py import core
+
+ac = core.Command.create()
+
+print('IsAlive')
+isAlive = ac.IsAlive()
+print('\t{0}'.format(isAlive))
+
+print('GetProductInfo')
+productInfo = ac.GetProductInfo()
+print('\t{0}'.format(productInfo))
+
+print('GetProjectInfo')
+projectInfo = ac.GetProjectInfo()
+print('\tisUntitled: {0}'.format(projectInfo.isUntitled))
+print('\tisTeamwork: {0}'.format(projectInfo.isTeamwork))
+if not projectInfo.isUntitled:
+    print('\tprojectName: {0}'.format(projectInfo.projectName))
+    print('\tprojectPath: {0}'.format(projectInfo.projectPath))
+    print('\tprojectLocation: {0}'.format(projectInfo.projectLocation))
+
+print('GetAllElements')
+allElements = ac.GetAllElements()
+for element in allElements:
+    print('\t{0}'.format(element.guid))
+
+print('GetElementsByType')
+wallElements = ac.GetElementsByType(core.Element.ELEMENT_TYPE.Wall)
+for element in wallElements:
+    print('\t{0}'.format(element.guid))
+
+print('GetSelectedElements')
+selectedElements = ac.GetSelectedElements()
+for element in selectedElements:
+    print('\t{0}'.format(element.guid))
+
+print('GetAllClassificationSystems')
+systems = ac.GetAllClassificationSystems()
+for system in systems:
+    print('\t{0}'.format(system.name))
+    items = ac.GetAllClassificationsInSystem(system.guid)
+    for item in items:
+        print('\t{0}'.format(item.id))
+
+print('Get2DBoundingBoxes')
+boxes2D = ac.Get2DBoundingBoxes(wallElements)
+for box2D in boxes2D:
+    print('\t{0}'.format(box2D))
+
+print('Get3DBoundingBoxes')
+boxes3D = ac.Get3DBoundingBoxes(wallElements)
+for box3D in boxes3D:
+    print('\t{0}'.format(box3D))
+
+print('GetAddOnVersion')
+addOnVersion = ac.GetAddOnVersion()
+print('\t{0}'.format(addOnVersion))
+
+print('GetArchicadLocation')
+archicadLocation = ac.GetArchicadLocation()
+print('\t{0}'.format(archicadLocation))

--- a/python-package/src/tapir_py/parts.py
+++ b/python-package/src/tapir_py/parts.py
@@ -31,7 +31,7 @@ class Element(dotNETBase):
         if id: return cls(id)
     
     @staticmethod
-    def from_command_result(result):
+    def list_from_command_result(result):
         return [Element.FromDictionary(data) for data in result.get('elements', [])]
 
     def __str__(self):
@@ -68,7 +68,7 @@ class ClassificationSystem(dotNETBase):
             raise ValueError('json_data must be a dictionary')
 
     @staticmethod
-    def from_command_result(result):
+    def list_from_command_result(result):
         return [ClassificationSystem.FromDictionary(data) for data in result.get('classificationSystems', [])]
 
     def __str__(self):
@@ -103,11 +103,11 @@ class ClassificationItem(dotNETBase):
         if isinstance(json_data, dict):
             itemData = json_data.get('classificationItem')
             guid = itemData.get('classificationItemId',{}).get('guid')
-            id= itemData.get('id')
+            id = itemData.get('id')
             name = itemData.get('name')
             description = itemData.get('description')
             children = []
-            hasChildren = itemData.has_key('children')
+            hasChildren = ('children' in itemData)
             if hasChildren:
                 for data in itemData.get('children'):
                     childItem = ClassificationItem.FromDictionary(data)
@@ -115,9 +115,9 @@ class ClassificationItem(dotNETBase):
             return cls(guid,id,name,description,children)
         else:
             raise ValueError('json_data must be a dictionary')
-    @staticmethod
-    def from_command_result(result):
 
+    @staticmethod
+    def list_from_command_result(result):
         return [ClassificationItem.FromDictionary(classItemData) for classItemData in result.get('classificationItems',[])]
 
     def __str__(self):
@@ -192,15 +192,13 @@ class BoundingBox(dotNETBase):
             raise ValueError('json_data must be a dictionary')
 
     @staticmethod
-    def from_command_result(result):
+    def list_from_command_result(result):
         if 'boundingBoxes2D' in result.keys():
             key = 'boundingBox2D'
             bounding_boxes = result['boundingBoxes2D']
         else:
             key = 'boundingBox3D'
             bounding_boxes = result['boundingBoxes3D']
-
-
         return [BoundingBox.FromDictionary(data.get(key, {})) for data in bounding_boxes]
 
     def __str__(self):


### PR DESCRIPTION
A minor clean-up around the `CommandResult` class:
- Added a `get_result` function that throws an exception in case of errors. With this change it's easier to write new commands since commands should not case about error handling.
- Removed part specific functions from `CommandResult`. Now commands converting the result to the desired type on their own, and `CommandResult` became a generic utility class that doesn't now anything about the data content. I think it makes write commands easier, too, since you don't have to touch `CommandResult` to write a new command.
- Renamed `from_command_result` functions to `list_from_command_result` since the previous name was misleading for me.

@thekaushikls what do you think?