### PR TITLE
Rename issue commands.

### DIFF
--- a/archicad-addon/Examples/issue_management.py
+++ b/archicad-addon/Examples/issue_management.py
@@ -37,7 +37,7 @@ print (json.dumps (response, indent = 4))
 # print (json.dumps (response, indent = 4))
 
 
-# commandName = 'AddComment'
+# commandName = 'AddCommentToIssue'
 # commandParameters = {'issueId': 'B0D7E9D6-56E8-4432-AC74-DE7C3083015F', 'text': 'dropped da comment here', 'author': 'python', 'status': 2}
 
 # print ('Command: {commandName}'.format (commandName = commandName))
@@ -49,7 +49,7 @@ print (json.dumps (response, indent = 4))
 # print (json.dumps (response, indent = 4))
 
 
-# commandName = 'GetComments'
+# commandName = 'GetCommentsFromIssue'
 # commandParameters = {'issueId': 'B0D7E9D6-56E8-4432-AC74-DE7C3083015F'}
 
 # print ('Command: {commandName}'.format (commandName = commandName))
@@ -61,7 +61,7 @@ print (json.dumps (response, indent = 4))
 # print (json.dumps (response, indent = 4))
 
 
-# commandName = 'AttachElements'
+# commandName = 'AttachElementsToIssue'
 # commandParameters = {'issueId': 'B0D7E9D6-56E8-4432-AC74-DE7C3083015F', 'elementsIds': ['22F534EF-F3CE-4A99-9E54-125E899E6AA2',], 'type': 0}
 
 # print ('Command: {commandName}'.format (commandName = commandName))
@@ -73,7 +73,7 @@ print (json.dumps (response, indent = 4))
 # print (json.dumps (response, indent = 4))
 
 
-# commandName = 'DetachElements'
+# commandName = 'DetachElementsFromIssue'
 # commandParameters = {'issueId': 'B0D7E9D6-56E8-4432-AC74-DE7C3083015F', 'elementsIds': ['22F534EF-F3CE-4A99-9E54-125E899E6AA2',]}
 
 # print ('Command: {commandName}'.format (commandName = commandName))
@@ -85,7 +85,7 @@ print (json.dumps (response, indent = 4))
 # print (json.dumps (response, indent = 4))
 
 
-# commandName = 'GetAttachedElements'
+# commandName = 'GetElementsAttachedToIssue'
 # commandParameters = {'issueId': 'B0D7E9D6-56E8-4432-AC74-DE7C3083015F', 'type': 1}
 
 # print ('Command: {commandName}'.format (commandName = commandName))
@@ -97,7 +97,7 @@ print (json.dumps (response, indent = 4))
 # print (json.dumps (response, indent = 4))
 
 
-# commandName = 'ExportToBCF'
+# commandName = 'ExportIssuesToBCF'
 # commandParameters = {'issuesIds': ['B0D7E9D6-56E8-4432-AC74-DE7C3083015F', '50D45AAD-9581-4275-A503-4E82C974C03B'], 'exportPath': 'C:\\Users\\i.yurasov\\Desktop\\dev\\issues_test6.bcfzip', 'useExternalId': False, 'alignBySurveyPoint': True}
 
 # print ('Command: {commandName}'.format (commandName = commandName))
@@ -109,7 +109,7 @@ print (json.dumps (response, indent = 4))
 # print (json.dumps (response, indent = 4))
 
 
-# commandName = 'ImportFromBCF'
+# commandName = 'ImportIssuesFromBCF'
 # commandParameters = {'importPath': 'C:\\Users\\i.yurasov\\Desktop\\dev\\issues_test5.bcfzip', 'alignBySurveyPoint': True}
 
 # print ('Command: {commandName}'.format (commandName = commandName))

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -45,13 +45,13 @@ GSErrCode Initialize (void)
 #ifdef ServerMainVers_2600
     err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<HighlightElementsCommand> ());
 #endif
-	err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<MoveElementsCommand> ());
-	err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<GetGDLParametersOfElementsCommand> ());
-	err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<SetGDLParametersOfElementsCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<MoveElementsCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<GetGDLParametersOfElementsCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<SetGDLParametersOfElementsCommand> ());
 
-	err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<CreateColumnsCommand> ());
-	err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<CreateSlabsCommand> ());
-	err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<CreateObjectsCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<CreateColumnsCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<CreateSlabsCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<CreateObjectsCommand> ());
 
     err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<CreateBuildingMaterialsCommand> ());
     err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<CreateLayersCommand> ());
@@ -66,13 +66,13 @@ GSErrCode Initialize (void)
     err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<CreateIssueCommand> ());
     err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<DeleteIssueCommand> ());
     err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<GetIssuesCommand> ());
-    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<AddCommentCommand> ());
-    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<GetCommentsCommand> ());
-    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<AttachElementsCommand> ());
-    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<DetachElementsCommand> ());
-    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<GetAttachedElementsCommand> ());
-    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<ExportToBCFCommand> ());
-    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<ImportFromBCFCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<AddCommentToIssueCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<GetCommentsFromIssueCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<AttachElementsToIssueCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<DetachElementsFromIssueCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<GetElementsAttachedToIssueCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<ExportIssuesToBCFCommand> ());
+    err |= ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (GS::NewOwned<ImportIssuesFromBCFCommand> ());
 
     return err;
 }

--- a/archicad-addon/Sources/IssueCommands.cpp
+++ b/archicad-addon/Sources/IssueCommands.cpp
@@ -285,17 +285,17 @@ GS::ObjectState GetIssuesCommand::Execute (const GS::ObjectState& /*parameters*/
     return response;
 }
 
-AddCommentCommand::AddCommentCommand () :
+AddCommentToIssueCommand::AddCommentToIssueCommand () :
     CommandBase (CommonSchema::NotUsed)
 {
 }
 
-GS::String AddCommentCommand::GetName () const
+GS::String AddCommentToIssueCommand::GetName () const
 {
-    return "AddComment";
+    return "AddCommentToIssue";
 }
 
-GS::Optional<GS::UniString> AddCommentCommand::GetInputParametersSchema () const
+GS::Optional<GS::UniString> AddCommentToIssueCommand::GetInputParametersSchema () const
 {
     return R"({
         "type": "object",
@@ -325,7 +325,7 @@ GS::Optional<GS::UniString> AddCommentCommand::GetInputParametersSchema () const
     })";
 }
 
-GS::ObjectState AddCommentCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+GS::ObjectState AddCommentToIssueCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
     GS::UniString issueIdStr;
     GS::UniString text;
@@ -358,17 +358,17 @@ GS::ObjectState AddCommentCommand::Execute (const GS::ObjectState& parameters, G
     return {};
 }
 
-GetCommentsCommand::GetCommentsCommand () :
+GetCommentsFromIssueCommand::GetCommentsFromIssueCommand () :
     CommandBase (CommonSchema::NotUsed)
 {
 }
 
-GS::String GetCommentsCommand::GetName () const
+GS::String GetCommentsFromIssueCommand::GetName () const
 {
-    return "GetComments";
+    return "GetCommentsFromIssue";
 }
 
-GS::Optional<GS::UniString> GetCommentsCommand::GetInputParametersSchema () const
+GS::Optional<GS::UniString> GetCommentsFromIssueCommand::GetInputParametersSchema () const
 {
     return R"({
         "type": "object",
@@ -385,7 +385,7 @@ GS::Optional<GS::UniString> GetCommentsCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> GetCommentsCommand::GetResponseSchema () const
+GS::Optional<GS::UniString> GetCommentsFromIssueCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -435,7 +435,7 @@ GS::Optional<GS::UniString> GetCommentsCommand::GetResponseSchema () const
     })";
 }
 
-GS::ObjectState GetCommentsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+GS::ObjectState GetCommentsFromIssueCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
     GS::UniString issueIdStr;
     if (!parameters.Get ("issueId", issueIdStr)) {
@@ -471,17 +471,17 @@ GS::ObjectState GetCommentsCommand::Execute (const GS::ObjectState& parameters, 
     return response;
 }
 
-AttachElementsCommand::AttachElementsCommand () :
+AttachElementsToIssueCommand::AttachElementsToIssueCommand () :
     CommandBase (CommonSchema::NotUsed)
 {
 }
 
-GS::String AttachElementsCommand::GetName () const
+GS::String AttachElementsToIssueCommand::GetName () const
 {
-    return "AttachElements";
+    return "AttachElementsToIssue";
 }
 
-GS::Optional<GS::UniString> AttachElementsCommand::GetInputParametersSchema () const
+GS::Optional<GS::UniString> AttachElementsToIssueCommand::GetInputParametersSchema () const
 {
     return R"({
         "type": "object",
@@ -507,7 +507,7 @@ GS::Optional<GS::UniString> AttachElementsCommand::GetInputParametersSchema () c
     })";
 }
 
-GS::ObjectState AttachElementsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
+GS::ObjectState AttachElementsToIssueCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
 {
     int type;
     GS::UniString issueIdStr;
@@ -537,17 +537,17 @@ GS::ObjectState AttachElementsCommand::Execute (const GS::ObjectState& parameter
     return {};
 }
 
-DetachElementsCommand::DetachElementsCommand () :
+DetachElementsFromIssueCommand::DetachElementsFromIssueCommand () :
     CommandBase (CommonSchema::NotUsed)
 {
 }
 
-GS::String DetachElementsCommand::GetName () const
+GS::String DetachElementsFromIssueCommand::GetName () const
 {
-    return "DetachElements";
+    return "DetachElementsFromIssue";
 }
 
-GS::Optional<GS::UniString> DetachElementsCommand::GetInputParametersSchema () const
+GS::Optional<GS::UniString> DetachElementsFromIssueCommand::GetInputParametersSchema () const
 {
     return R"({
         "type": "object",
@@ -568,7 +568,7 @@ GS::Optional<GS::UniString> DetachElementsCommand::GetInputParametersSchema () c
     })";
 }
 
-GS::ObjectState DetachElementsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+GS::ObjectState DetachElementsFromIssueCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
     GS::UniString issueIdStr;
     API_Guid issueId;
@@ -592,17 +592,17 @@ GS::ObjectState DetachElementsCommand::Execute (const GS::ObjectState& parameter
     return {};
 }
 
-GetAttachedElementsCommand::GetAttachedElementsCommand () :
+GetElementsAttachedToIssueCommand::GetElementsAttachedToIssueCommand () :
     CommandBase (CommonSchema::NotUsed)
 {
 }
 
-GS::String GetAttachedElementsCommand::GetName () const
+GS::String GetElementsAttachedToIssueCommand::GetName () const
 {
-    return "GetAttachedElements";
+    return "GetElementsAttachedToIssue";
 }
 
-GS::Optional<GS::UniString> GetAttachedElementsCommand::GetInputParametersSchema () const
+GS::Optional<GS::UniString> GetElementsAttachedToIssueCommand::GetInputParametersSchema () const
 {
     return R"({
         "type": "object",
@@ -624,7 +624,7 @@ GS::Optional<GS::UniString> GetAttachedElementsCommand::GetInputParametersSchema
     })";
 }
 
-GS::Optional<GS::UniString> GetAttachedElementsCommand::GetResponseSchema () const
+GS::Optional<GS::UniString> GetElementsAttachedToIssueCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -640,7 +640,7 @@ GS::Optional<GS::UniString> GetAttachedElementsCommand::GetResponseSchema () con
     })";
 }
 
-GS::ObjectState GetAttachedElementsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+GS::ObjectState GetElementsAttachedToIssueCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
     int type;
     GS::ObjectState response;
@@ -669,17 +669,17 @@ GS::ObjectState GetAttachedElementsCommand::Execute (const GS::ObjectState& para
     return response;
 }
 
-ExportToBCFCommand::ExportToBCFCommand () :
+ExportIssuesToBCFCommand::ExportIssuesToBCFCommand () :
     CommandBase (CommonSchema::NotUsed)
 {
 }
 
-GS::String ExportToBCFCommand::GetName () const
+GS::String ExportIssuesToBCFCommand::GetName () const
 {
-    return "ExportToBCF";
+    return "ExportIssuesToBCF";
 }
 
-GS::Optional<GS::UniString> ExportToBCFCommand::GetInputParametersSchema () const
+GS::Optional<GS::UniString> ExportIssuesToBCFCommand::GetInputParametersSchema () const
 {
     return R"({
         "type": "object",
@@ -714,7 +714,7 @@ GS::Optional<GS::UniString> ExportToBCFCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::ObjectState ExportToBCFCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+GS::ObjectState ExportIssuesToBCFCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
     GS::UniString exportPath;
     GS::Array<GS::UniString> issueIdsStr;
@@ -751,17 +751,17 @@ GS::ObjectState ExportToBCFCommand::Execute (const GS::ObjectState& parameters, 
     return {};
 }
 
-ImportFromBCFCommand::ImportFromBCFCommand () :
+ImportIssuesFromBCFCommand::ImportIssuesFromBCFCommand () :
     CommandBase (CommonSchema::NotUsed)
 {
 }
 
-GS::String ImportFromBCFCommand::GetName () const
+GS::String ImportIssuesFromBCFCommand::GetName () const
 {
-    return "ImportFromBCF";
+    return "ImportIssuesFromBCF";
 }
 
-GS::Optional<GS::UniString> ImportFromBCFCommand::GetInputParametersSchema () const
+GS::Optional<GS::UniString> ImportIssuesFromBCFCommand::GetInputParametersSchema () const
 {
     return R"({
         "type": "object",
@@ -783,7 +783,7 @@ GS::Optional<GS::UniString> ImportFromBCFCommand::GetInputParametersSchema () co
     })";
 }
 
-GS::ObjectState ImportFromBCFCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+GS::ObjectState ImportIssuesFromBCFCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
     bool alignBySurveyPoint = true;
     GS::UniString importPath;

--- a/archicad-addon/Sources/IssueCommands.hpp
+++ b/archicad-addon/Sources/IssueCommands.hpp
@@ -29,66 +29,66 @@ public:
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
-class AddCommentCommand : public CommandBase
+class AddCommentToIssueCommand : public CommandBase
 {
 public:
-    AddCommentCommand ();
+    AddCommentToIssueCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
-class GetCommentsCommand : public CommandBase
+class GetCommentsFromIssueCommand : public CommandBase
 {
 public:
-    GetCommentsCommand ();
-    virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
-    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
-};
-
-class AttachElementsCommand : public CommandBase
-{
-public:
-    AttachElementsCommand ();
-    virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
-};
-
-class DetachElementsCommand : public CommandBase
-{
-public:
-    DetachElementsCommand ();
-    virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
-};
-
-class GetAttachedElementsCommand : public CommandBase
-{
-public:
-    GetAttachedElementsCommand ();
+    GetCommentsFromIssueCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
-class ExportToBCFCommand : public CommandBase
+class AttachElementsToIssueCommand : public CommandBase
 {
 public:
-    ExportToBCFCommand ();
+    AttachElementsToIssueCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
-class ImportFromBCFCommand : public CommandBase
+class DetachElementsFromIssueCommand : public CommandBase
 {
 public:
-    ImportFromBCFCommand ();
+    DetachElementsFromIssueCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class GetElementsAttachedToIssueCommand : public CommandBase
+{
+public:
+    GetElementsAttachedToIssueCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class ExportIssuesToBCFCommand : public CommandBase
+{
+public:
+    ExportIssuesToBCFCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class ImportIssuesFromBCFCommand : public CommandBase
+{
+public:
+    ImportIssuesFromBCFCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -1239,8 +1239,8 @@
                 }           
             },
             {
-                name : "AddComment",
-                version : "1.0.2",
+                name : "AddCommentToIssue",
+                version : "1.0.6",
                 description : "Adds a new comment to the chosen issue.",
                 inputScheme : {
 			        "type": "object",
@@ -1271,8 +1271,8 @@
                 outputScheme : null
             },
             {
-                name : "GetComments",
-                version : "1.0.2",
+                name : "GetCommentsFromIssue",
+                version : "1.0.6",
                 description : "Retrieves comments information of the chosen issue.",
                 inputScheme : {
 			        "type": "object",
@@ -1335,8 +1335,8 @@
                 }
             },
             {
-                name : "AttachElements",
-                version : "1.0.2",
+                name : "AttachElementsToIssue",
+                version : "1.0.6",
                 description : "Attaches elements to the chosen issue.",
                 inputScheme : {
 			        "type": "object",
@@ -1363,8 +1363,8 @@
                 outputScheme : null
             },
             {
-                name : "DetachElements",
-                version : "1.0.2",
+                name : "DetachElementsFromIssue",
+                version : "1.0.6",
                 description : "Detaches elements from the chosen issue.",
                 inputScheme : {
 			        "type": "object",
@@ -1386,8 +1386,8 @@
                 outputScheme : null
             },
             {
-                name : "GetAttachedElements",
-                version : "1.0.2",
+                name : "GetElementsAttachedToIssue",
+                version : "1.0.6",
                 description : "Retrieves attached elements of the chosen issue, filtered by attachment type.",
                 inputScheme : {
 			        "type": "object",
@@ -1421,8 +1421,8 @@
                 }
             },
             {
-                name : "ExportToBCF",
-                version : "1.0.2",
+                name : "ExportIssuesToBCF",
+                version : "1.0.6",
                 description : "Exports chosen issues to the bcf file.",
                 inputScheme : {
 			        "type": "object",
@@ -1457,8 +1457,8 @@
                 outputScheme : null
             },
             {
-                name : "ImportFromBCF",
-                version : "1.0.2",
+                name : "ImportIssuesFromBCF",
+                version : "1.0.6",
                 description : "Imports issues from the chosen bcf file.",
                 inputScheme : {
 			        "type": "object",


### PR DESCRIPTION
I've renamed some issue-related commands to make it easier to understand them just by looking at the name of the command. Now all command names clearly indicate that they are related to issue management.

⚠️ This is an incompatible change, sorry for that, but I think the new version is easier to understand.