### PR TITLE
Grasshopper plugin: small changes based on the first impressions

### DIFF
--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/Get3DBoundingBoxesOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/Get3DBoundingBoxesOfElementsComponent.cs
@@ -14,8 +14,8 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
     {
         public Get3DBoundingBoxesOfElementsComponent ()
           : base (
-                "Elems 3D Bounding Boxes",
-                "Elems3DBoxes",
+                "Elem 3D Bounding Boxes",
+                "Elem3DBoxes",
                 "Get 3D bounding boxes of elements.",
                 "Elements"
             )

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/SetPropertyValuesOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/SetPropertyValuesOfElementsComponent.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using TapirGrasshopperPlugin.Data;
 using TapirGrasshopperPlugin.Utilities;
 
-namespace TapirGrasshopperPlugin.Components.ElementsComponents
+namespace TapirGrasshopperPlugin.Components.PropertiesComponents
 {
     public class SetPropertyValuesOfElementsComponent : Component
     {
@@ -14,7 +14,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Set Property Values",
                 "SetPropertyValues",
                 "Set property values of elements.",
-                "Elements"
+                "Properties"
             )
         {
         }
@@ -73,7 +73,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             }
         }
 
-        protected override System.Drawing.Bitmap Icon => TapirGrasshopperPlugin.Properties.Resources.SetPropertyValues;
+        protected override System.Drawing.Bitmap Icon => Properties.Resources.SetPropertyValues;
 
         public override Guid ComponentGuid => new Guid ("5d2aa76e-4a59-4b58-a5ce-51878c1478d0");
     }

--- a/grasshopper-plugin/TapirGrasshopperPlugin/TapirGrasshopperPluginInfo.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/TapirGrasshopperPluginInfo.cs
@@ -13,7 +13,7 @@ namespace Tapir
         public override Bitmap Icon => null;
 
         //Return a short string describing the purpose of this GHA library.
-        public override string Description => "Grasshopper components to access Archicad via JSON interface.";
+        public override string Description => "Grasshopper components for connecting to Archicad.";
 
         public override Guid Id => new Guid ("54b11162-627b-455b-b9c0-963e76b36dc7");
 

--- a/grasshopper-plugin/YakPackage/manifest.yml
+++ b/grasshopper-plugin/YakPackage/manifest.yml
@@ -2,7 +2,7 @@ name: Tapir
 version: 1.1.2
 authors:
 - Enzyme APD
-description: Grasshopper components to access Archicad via JSON interface.
+description: Grasshopper components for connecting to Archicad. The Tapir Archicad Add-On must be installed for full functionality. It can be downloaded from the given URL.
 url: https://github.com/ENZYME-APD/tapir-archicad-automation
 icon: icon.png
 keywords:


### PR DESCRIPTION
- Rename `Elems3DBoxes` to `Elem3DBoxes` for consistency with other components.
- Move `SetPropertyValues` to the Properties group.
- Extend plugin description to explain that an Archicad Add-On is needed for full functionality.