### PR TITLE
Nem command: Get3DBoundingBoxes

### DIFF
--- a/archicad-addon/Examples/set_elementid_of_cwsubelements_based_on_boundingboxes.py
+++ b/archicad-addon/Examples/set_elementid_of_cwsubelements_based_on_boundingboxes.py
@@ -1,0 +1,34 @@
+import aclib
+
+allCurtainWalls = aclib.RunTapirCommand (
+    'GetElementsByType', {
+        'elementType': 'CurtainWall'
+    })['elements']
+
+allCWSubelements = aclib.RunTapirCommand (
+    'GetSubelementsOfHierarchicalElements', {
+        'hierarchicalElements': allCurtainWalls
+    })['subelementsOfHierarchicalElements']
+
+elementIdPropertyId = aclib.RunCommand ('API.GetPropertyIds', {'properties': [{"type": "BuiltIn", "nonLocalizedName": "General_ElementID"}]})['properties'][0]['propertyId']
+
+for subelementsOfCurrCW in allCWSubelements:
+    for subelementType in subelementsOfCurrCW.keys():
+        subelements = subelementsOfCurrCW[subelementType]
+        boundingBoxes = aclib.RunTapirCommand (
+            'Get3DBoundingBoxes', {
+                'elements' : subelements
+            })['boundingBoxes3D']
+        subelementsPairedWithboundingBoxes = [(subelements[i],boundingBoxes[i]) for i in range(len(subelements))]
+        subelementsPairedWithboundingBoxes.sort (key=lambda pair:pair[1]['boundingBox3D']['xMin'])
+        subelementsPairedWithboundingBoxes.sort (key=lambda pair:pair[1]['boundingBox3D']['yMin'])
+        subelementsPairedWithboundingBoxes.sort (key=lambda pair:pair[1]['boundingBox3D']['zMin'])
+
+        response = aclib.RunTapirCommand (
+            'SetPropertyValuesOfElements', {
+                'elementPropertyValues' : [{
+                    'elementId': subelementsPairedWithboundingBoxes[i][0]['elementId'],
+                    'propertyId': elementIdPropertyId,
+                    'propertyValue': {'value': '{}-{:03d}'.format(subelementType, i+1)}
+                } for i in range(len(subelementsPairedWithboundingBoxes))]
+            })

--- a/archicad-addon/Examples/set_elementid_of_cwsubelements_based_on_boundingboxes.py
+++ b/archicad-addon/Examples/set_elementid_of_cwsubelements_based_on_boundingboxes.py
@@ -12,23 +12,35 @@ allCWSubelements = aclib.RunTapirCommand (
 
 elementIdPropertyId = aclib.RunCommand ('API.GetPropertyIds', {'properties': [{"type": "BuiltIn", "nonLocalizedName": "General_ElementID"}]})['properties'][0]['propertyId']
 
+subelementTypeToElementIdPrefixAndStartingID = {
+    'cWallPanels':      ['CWPanel',     1],
+    'cWallFrames':      ['CWFrame',     1],
+    'cWallJunctions':   ['CWJunction',  1],
+    'cWallAccessories': ['CWAccessory', 1]
+}
+
 for subelementsOfCurrCW in allCWSubelements:
     for subelementType in subelementsOfCurrCW.keys():
+        if subelementType not in subelementTypeToElementIdPrefixAndStartingID:
+            continue
+        elementIdPrefixAndStartingID = subelementTypeToElementIdPrefixAndStartingID[subelementType]
+
         subelements = subelementsOfCurrCW[subelementType]
         boundingBoxes = aclib.RunTapirCommand (
             'Get3DBoundingBoxes', {
                 'elements' : subelements
             })['boundingBoxes3D']
-        subelementsPairedWithboundingBoxes = [(subelements[i],boundingBoxes[i]) for i in range(len(subelements))]
-        subelementsPairedWithboundingBoxes.sort (key=lambda pair:pair[1]['boundingBox3D']['xMin'])
-        subelementsPairedWithboundingBoxes.sort (key=lambda pair:pair[1]['boundingBox3D']['yMin'])
-        subelementsPairedWithboundingBoxes.sort (key=lambda pair:pair[1]['boundingBox3D']['zMin'])
+        subelementsPairedWithBoundingBoxes = [(subelements[i],boundingBoxes[i]) for i in range(len(subelements))]
+        subelementsPairedWithBoundingBoxes.sort (key=lambda pair:pair[1]['boundingBox3D']['xMin'])
+        subelementsPairedWithBoundingBoxes.sort (key=lambda pair:pair[1]['boundingBox3D']['yMin'])
+        subelementsPairedWithBoundingBoxes.sort (key=lambda pair:pair[1]['boundingBox3D']['zMin'])
 
-        response = aclib.RunTapirCommand (
+        aclib.RunTapirCommand (
             'SetPropertyValuesOfElements', {
                 'elementPropertyValues' : [{
-                    'elementId': subelementsPairedWithboundingBoxes[i][0]['elementId'],
+                    'elementId': subelementsPairedWithBoundingBoxes[i][0]['elementId'],
                     'propertyId': elementIdPropertyId,
-                    'propertyValue': {'value': '{}-{:03d}'.format(subelementType, i+1)}
-                } for i in range(len(subelementsPairedWithboundingBoxes))]
+                    'propertyValue': {'value': '{}-{:03d}'.format (elementIdPrefixAndStartingID[0], i + elementIdPrefixAndStartingID[1])}
+                } for i in range(len(subelementsPairedWithBoundingBoxes))]
             })
+        elementIdPrefixAndStartingID[1] += len(subelementsPairedWithBoundingBoxes)

--- a/archicad-addon/Examples/set_properties_of_subelements.py
+++ b/archicad-addon/Examples/set_properties_of_subelements.py
@@ -1,16 +1,9 @@
-import json
 import aclib
-
 
 allCurtainWalls = aclib.RunCommand (
     'API.GetElementsByType', {
         'elementType': 'CurtainWall'
     })['elements']
-
-commandName = 'GetSubelementsOfHierarchicalElements'
-commandParameters = {
-    'hierarchicalElements' : allCurtainWalls
-}
 
 allCWSubelements = aclib.RunTapirCommand (
     'GetSubelementsOfHierarchicalElements', {
@@ -20,16 +13,6 @@ allCWSubelements = aclib.RunTapirCommand (
 allCWFrameSubelements = [subelement for subelements in allCWSubelements for subelement in subelements['cWallFrames']]
 
 elementIdPropertyId = aclib.RunCommand ('API.GetPropertyIds', {'properties': [{"type": "BuiltIn", "nonLocalizedName": "General_ElementID"}]})['properties'][0]['propertyId']
-
-commandName = 'GetPropertyValuesOfElements'
-commandParameters = {
-    'elements' : [{
-        'elementId': subelement['elementId']
-    } for subelement in allCWFrameSubelements],
-    'properties' : [{
-        'propertyId': elementIdPropertyId
-    }]
-}
 
 response = aclib.RunTapirCommand (
     'GetPropertyValuesOfElements', {

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -167,6 +167,10 @@ GSErrCode Initialize (void)
             elementCommands, "1.0.7",
             "Sets the details of the given elements (floor, layer, order etc)."
         );
+        err |= RegisterCommand<Get3DBoundingBoxesCommand> (
+            elementCommands, "1.1.2",
+            "Get the 3D bounding box of elements. The bounding box is calculated from the global origin in the 3D view. The output is the array of the bounding boxes respective to the input array of elements."
+        );
         err |= RegisterCommand<GetSubelementsOfHierarchicalElementsCommand> (
             elementCommands, "1.0.6",
             "Gets the subelements of the given hierarchical elements."

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -1307,9 +1307,9 @@ GS::ObjectState Get3DBoundingBoxesCommand::Execute (const GS::ObjectState& param
             continue;
         }
 
-        API_Elem_Head elemHead;
+        API_Elem_Head elemHead = {};
         elemHead.guid = GetGuidFromObjectState (*elementId);
-        API_Box3D box3D;
+        API_Box3D box3D = {};
         GSErrCode err = ACAPI_Element_CalcBounds (&elemHead, &box3D);
         if (err != NoError) {
             boundingBoxes3D (CreateErrorResponse (err, "Failed to get the 3D bounding box"));

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -1249,3 +1249,81 @@ GS::ObjectState HighlightElementsCommand::Execute (const GS::ObjectState& /*para
 }
 
 #endif
+
+Get3DBoundingBoxesCommand::Get3DBoundingBoxesCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String Get3DBoundingBoxesCommand::GetName () const
+{
+    return "Get3DBoundingBoxes";
+}
+
+GS::Optional<GS::UniString> Get3DBoundingBoxesCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/Elements"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "elements"
+        ]
+    })";
+}
+
+GS::Optional<GS::UniString> Get3DBoundingBoxesCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+            "properties": {
+            "boundingBoxes3D": {
+                "$ref": "#/BoundingBoxes3D"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "boundingBoxes3D"
+        ]
+    })";
+}
+
+GS::ObjectState Get3DBoundingBoxesCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::ObjectState> elements;
+    parameters.Get ("elements", elements);
+
+    GS::ObjectState response;
+    const auto& boundingBoxes3D = response.AddList<GS::ObjectState> ("boundingBoxes3D");
+
+    for (const GS::ObjectState& element : elements) {
+        const GS::ObjectState* elementId = element.Get ("elementId");
+        if (elementId == nullptr) {
+            boundingBoxes3D (CreateErrorResponse (APIERR_BADPARS, "elementId is missing"));
+            continue;
+        }
+
+        API_Elem_Head elemHead;
+        elemHead.guid = GetGuidFromObjectState (*elementId);
+        API_Box3D box3D;
+        GSErrCode err = ACAPI_Element_CalcBounds (&elemHead, &box3D);
+        if (err != NoError) {
+            boundingBoxes3D (CreateErrorResponse (err, "Failed to get the 3D bounding box"));
+            continue;
+        }
+
+        GS::ObjectState boundingBox3D ("xMin", box3D.xMin,
+                                       "xMax", box3D.xMax,
+                                       "yMin", box3D.yMin,
+                                       "yMax", box3D.yMax,
+                                       "zMin", box3D.zMin,
+                                       "zMax", box3D.zMax);
+        boundingBoxes3D (GS::ObjectState ("boundingBox3D", boundingBox3D));
+    }
+
+    return response;
+}

--- a/archicad-addon/Sources/ElementCommands.hpp
+++ b/archicad-addon/Sources/ElementCommands.hpp
@@ -97,3 +97,13 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+
+class Get3DBoundingBoxesCommand : public CommandBase
+{
+public:
+    Get3DBoundingBoxesCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -38,6 +38,8 @@
 
 #define ACAPI_Command_GetHttpConnectionPort(par1) ACAPI_Goodies (APIAny_GetHttpConnectionPortID, par1)
 
+#define ACAPI_Element_CalcBounds(par1,par2) ACAPI_Database (APIDb_CalcBoundsID, par1, par2)
+
 inline API_AttributeIndex ACAPI_CreateAttributeIndex (Int32 index)
 {
     return index;

--- a/archicad-addon/Sources/RFIX/Schemas/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Schemas/CommonSchemaDefinitions.json
@@ -1405,5 +1405,71 @@
         "items": {
             "$ref": "#/ElementClassification"
         }
+    },
+    "BoundingBox3D": {
+        "type": "object",
+        "description": "A 3D bounding box of an element.",
+        "properties": {
+            "xMin": {
+                "type": "number",
+                "description": "The minimum X value of the bounding box."
+            },
+            "yMin": {
+                "type": "number",
+                "description": "The minimum Y value of the bounding box."
+            },
+            "zMin": {
+                "type": "number",
+                "description": "The minimum Z value of the bounding box."
+            },
+            "xMax": {
+                "type": "number",
+                "description": "The maximum X value of the bounding box."
+            },
+            "yMax": {
+                "type": "number",
+                "description": "The maximum Y value of the bounding box."
+            },
+            "zMax": {
+                "type": "number",
+                "description": "The maximum Z value of the bounding box."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "xMin",
+            "yMin",
+            "zMin",
+            "xMax",
+            "yMax",
+            "zMax"
+        ]
+    },
+    "BoundingBox3DOrError": {
+        "type": "object",
+        "description": "A 3D bounding box or an error.",
+        "oneOf": [
+            {
+                "title": "boundingBox3D",
+                "properties": {
+                    "boundingBox3D": {
+                        "$ref": "#/BoundingBox3D"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [ "boundingBox3D" ]
+            },
+            {
+                "title": "error",
+                "$ref": "#/ErrorItem"
+            }
+        ]
+    },
+    "BoundingBoxes3D": {
+        "type": "array",
+        "description": "A list of 3D bounding boxes.",
+        "items": {
+            "$ref": "#/BoundingBox3DOrError"
+        }
     }
 }

--- a/archicad-addon/Test/ExpectedOutputs/set_elementid_of_cwsubelements_based_on_boundingboxes.py.output
+++ b/archicad-addon/Test/ExpectedOutputs/set_elementid_of_cwsubelements_based_on_boundingboxes.py.output
@@ -1,0 +1,921 @@
+Command: GetElementsByType
+Parameters:
+{
+    "elementType": "CurtainWall"
+}
+Response:
+{
+    "elements": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        }
+    ]
+}
+Command: GetSubelementsOfHierarchicalElements
+Parameters:
+{
+    "hierarchicalElements": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        }
+    ]
+}
+Response:
+{
+    "subelementsOfHierarchicalElements": [
+        {
+            "cWallSegments": [
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                }
+            ],
+            "cWallFrames": [
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                }
+            ],
+            "cWallPanels": [
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                },
+                {
+                    "elementId": {
+                        "guid": "<GUID>"
+                    }
+                }
+            ]
+        }
+    ]
+}
+Command: Get3DBoundingBoxes
+Parameters:
+{
+    "elements": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        }
+    ]
+}
+Response:
+{
+    "boundingBoxes3D": [
+        {
+            "boundingBox3D": {
+                "xMin": -0.25,
+                "xMax": 1.45,
+                "yMin": 2.5,
+                "yMax": 3,
+                "zMin": -0.25,
+                "zMax": 3.25
+            }
+        }
+    ]
+}
+Command: SetPropertyValuesOfElements
+Parameters:
+{
+    "elementPropertyValues": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallSegments-001"
+            }
+        }
+    ]
+}
+Response:
+{
+    "executionResults": [
+        {
+            "success": true
+        }
+    ]
+}
+Command: Get3DBoundingBoxes
+Parameters:
+{
+    "elements": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        }
+    ]
+}
+Response:
+{
+    "boundingBoxes3D": [
+        {
+            "boundingBox3D": {
+                "xMin": -0.05,
+                "xMax": 0.9,
+                "yMin": 2.7,
+                "yMax": 3,
+                "zMin": -0.05,
+                "zMax": 0.05
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": -0.05,
+                "xMax": 0.05,
+                "yMin": 2.7,
+                "yMax": 3,
+                "zMin": -0.05,
+                "zMax": 0.9
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0.9,
+                "xMax": 1.25,
+                "yMin": 2.7,
+                "yMax": 3,
+                "zMin": -0.05,
+                "zMax": 0.05
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 1.15,
+                "xMax": 1.25,
+                "yMin": 2.7,
+                "yMax": 3,
+                "zMin": -0.05,
+                "zMax": 0.9
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0.86,
+                "xMax": 0.94,
+                "yMin": 2.7,
+                "yMax": 2.95,
+                "zMin": 0,
+                "zMax": 0.9
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0,
+                "xMax": 0.9,
+                "yMin": 2.75,
+                "yMax": 2.86,
+                "zMin": 0.87,
+                "zMax": 0.93
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": -0.05,
+                "xMax": 0.05,
+                "yMin": 2.7,
+                "yMax": 3,
+                "zMin": 0.9,
+                "zMax": 2.4
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0.9,
+                "xMax": 1.2,
+                "yMin": 2.75,
+                "yMax": 2.86,
+                "zMin": 0.87,
+                "zMax": 0.93
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 1.15,
+                "xMax": 1.25,
+                "yMin": 2.7,
+                "yMax": 3,
+                "zMin": 0.9,
+                "zMax": 2.4
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0.86,
+                "xMax": 0.94,
+                "yMin": 2.7,
+                "yMax": 2.95,
+                "zMin": 0.9,
+                "zMax": 2.4
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0,
+                "xMax": 0.9,
+                "yMin": 2.75,
+                "yMax": 2.86,
+                "zMin": 2.37,
+                "zMax": 2.43
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": -0.05,
+                "xMax": 0.9,
+                "yMin": 2.7,
+                "yMax": 3,
+                "zMin": 2.95,
+                "zMax": 3.05
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": -0.05,
+                "xMax": 0.05,
+                "yMin": 2.7,
+                "yMax": 3,
+                "zMin": 2.4,
+                "zMax": 3.05
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0.9,
+                "xMax": 1.2,
+                "yMin": 2.75,
+                "yMax": 2.86,
+                "zMin": 2.37,
+                "zMax": 2.43
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 1.15,
+                "xMax": 1.25,
+                "yMin": 2.7,
+                "yMax": 3,
+                "zMin": 2.4,
+                "zMax": 3.05
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0.9,
+                "xMax": 1.25,
+                "yMin": 2.7,
+                "yMax": 3,
+                "zMin": 2.95,
+                "zMax": 3.05
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0.86,
+                "xMax": 0.94,
+                "yMin": 2.7,
+                "yMax": 2.95,
+                "zMin": 2.4,
+                "zMax": 3
+            }
+        }
+    ]
+}
+Command: SetPropertyValuesOfElements
+Parameters:
+{
+    "elementPropertyValues": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-001"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-002"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-003"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-004"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-005"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-006"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-007"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-008"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-009"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-010"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-011"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-012"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-013"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-014"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-015"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-016"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallFrames-017"
+            }
+        }
+    ]
+}
+Response:
+{
+    "executionResults": [
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        }
+    ]
+}
+Command: Get3DBoundingBoxes
+Parameters:
+{
+    "elements": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        }
+    ]
+}
+Response:
+{
+    "boundingBoxes3D": [
+        {
+            "boundingBox3D": {
+                "xMin": 0.050000004,
+                "xMax": 0.860000004,
+                "yMin": 2.74,
+                "yMax": 2.76,
+                "zMin": 0.050000004,
+                "zMax": 0.87
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0.939999996,
+                "xMax": 1.149999996,
+                "yMin": 2.74,
+                "yMax": 2.76,
+                "zMin": 0.050000004,
+                "zMax": 0.87
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0.05,
+                "xMax": 0.86,
+                "yMin": 2.74,
+                "yMax": 2.76,
+                "zMin": 0.93,
+                "zMax": 2.37
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0.94,
+                "xMax": 1.15,
+                "yMin": 2.74,
+                "yMax": 2.76,
+                "zMin": 0.93,
+                "zMax": 2.37
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0.050000004,
+                "xMax": 0.860000004,
+                "yMin": 2.74,
+                "yMax": 2.76,
+                "zMin": 2.43,
+                "zMax": 2.949999996
+            }
+        },
+        {
+            "boundingBox3D": {
+                "xMin": 0.94,
+                "xMax": 1.15,
+                "yMin": 2.74,
+                "yMax": 2.76,
+                "zMin": 2.43,
+                "zMax": 2.95
+            }
+        }
+    ]
+}
+Command: SetPropertyValuesOfElements
+Parameters:
+{
+    "elementPropertyValues": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallPanels-001"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallPanels-002"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallPanels-003"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallPanels-004"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallPanels-005"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "propertyId": {
+                "guid": "<GUID>"
+            },
+            "propertyValue": {
+                "value": "cWallPanels-006"
+            }
+        }
+    ]
+}
+Response:
+{
+    "executionResults": [
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        }
+    ]
+}

--- a/archicad-addon/Test/ExpectedOutputs/set_elementid_of_cwsubelements_based_on_boundingboxes.py.output
+++ b/archicad-addon/Test/ExpectedOutputs/set_elementid_of_cwsubelements_based_on_boundingboxes.py.output
@@ -165,57 +165,6 @@ Parameters:
             "elementId": {
                 "guid": "<GUID>"
             }
-        }
-    ]
-}
-Response:
-{
-    "boundingBoxes3D": [
-        {
-            "boundingBox3D": {
-                "xMin": -0.25,
-                "xMax": 1.45,
-                "yMin": 2.5,
-                "yMax": 3,
-                "zMin": -0.25,
-                "zMax": 3.25
-            }
-        }
-    ]
-}
-Command: SetPropertyValuesOfElements
-Parameters:
-{
-    "elementPropertyValues": [
-        {
-            "elementId": {
-                "guid": "<GUID>"
-            },
-            "propertyId": {
-                "guid": "<GUID>"
-            },
-            "propertyValue": {
-                "value": "cWallSegments-001"
-            }
-        }
-    ]
-}
-Response:
-{
-    "executionResults": [
-        {
-            "success": true
-        }
-    ]
-}
-Command: Get3DBoundingBoxes
-Parameters:
-{
-    "elements": [
-        {
-            "elementId": {
-                "guid": "<GUID>"
-            }
         },
         {
             "elementId": {
@@ -486,7 +435,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-001"
+                "value": "CWFrame-001"
             }
         },
         {
@@ -497,7 +446,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-002"
+                "value": "CWFrame-002"
             }
         },
         {
@@ -508,7 +457,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-003"
+                "value": "CWFrame-003"
             }
         },
         {
@@ -519,7 +468,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-004"
+                "value": "CWFrame-004"
             }
         },
         {
@@ -530,7 +479,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-005"
+                "value": "CWFrame-005"
             }
         },
         {
@@ -541,7 +490,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-006"
+                "value": "CWFrame-006"
             }
         },
         {
@@ -552,7 +501,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-007"
+                "value": "CWFrame-007"
             }
         },
         {
@@ -563,7 +512,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-008"
+                "value": "CWFrame-008"
             }
         },
         {
@@ -574,7 +523,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-009"
+                "value": "CWFrame-009"
             }
         },
         {
@@ -585,7 +534,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-010"
+                "value": "CWFrame-010"
             }
         },
         {
@@ -596,7 +545,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-011"
+                "value": "CWFrame-011"
             }
         },
         {
@@ -607,7 +556,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-012"
+                "value": "CWFrame-012"
             }
         },
         {
@@ -618,7 +567,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-013"
+                "value": "CWFrame-013"
             }
         },
         {
@@ -629,7 +578,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-014"
+                "value": "CWFrame-014"
             }
         },
         {
@@ -640,7 +589,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-015"
+                "value": "CWFrame-015"
             }
         },
         {
@@ -651,7 +600,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-016"
+                "value": "CWFrame-016"
             }
         },
         {
@@ -662,7 +611,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallFrames-017"
+                "value": "CWFrame-017"
             }
         }
     ]
@@ -836,7 +785,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallPanels-001"
+                "value": "CWPanel-001"
             }
         },
         {
@@ -847,7 +796,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallPanels-002"
+                "value": "CWPanel-002"
             }
         },
         {
@@ -858,7 +807,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallPanels-003"
+                "value": "CWPanel-003"
             }
         },
         {
@@ -869,7 +818,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallPanels-004"
+                "value": "CWPanel-004"
             }
         },
         {
@@ -880,7 +829,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallPanels-005"
+                "value": "CWPanel-005"
             }
         },
         {
@@ -891,7 +840,7 @@ Parameters:
                 "guid": "<GUID>"
             },
             "propertyValue": {
-                "value": "cWallPanels-006"
+                "value": "CWPanel-006"
             }
         }
     ]

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -653,6 +653,34 @@ var gCommands = [{
         ]
     }
             },{
+                "name": "Get3DBoundingBoxes",
+                "version": "1.1.2",
+                "description": "Get the 3D bounding box of elements. The bounding box is calculated from the global origin in the 3D view. The output is the array of the bounding boxes respective to the input array of elements.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/Elements"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "elements"
+        ]
+    },
+                "outputScheme": {
+        "type": "object",
+            "properties": {
+            "boundingBoxes3D": {
+                "$ref": "#/BoundingBoxes3D"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "boundingBoxes3D"
+        ]
+    }
+            },{
                 "name": "GetSubelementsOfHierarchicalElements",
                 "version": "1.0.6",
                 "description": "Gets the subelements of the given hierarchical elements.",

--- a/docs/archicad-addon/common_schema_definitions.js
+++ b/docs/archicad-addon/common_schema_definitions.js
@@ -1405,5 +1405,71 @@ var gSchemaDefinitions = {
         "items": {
             "$ref": "#/ElementClassification"
         }
+    },
+    "BoundingBox3D": {
+        "type": "object",
+        "description": "A 3D bounding box of an element.",
+        "properties": {
+            "xMin": {
+                "type": "number",
+                "description": "The minimum X value of the bounding box."
+            },
+            "yMin": {
+                "type": "number",
+                "description": "The minimum Y value of the bounding box."
+            },
+            "zMin": {
+                "type": "number",
+                "description": "The minimum Z value of the bounding box."
+            },
+            "xMax": {
+                "type": "number",
+                "description": "The maximum X value of the bounding box."
+            },
+            "yMax": {
+                "type": "number",
+                "description": "The maximum Y value of the bounding box."
+            },
+            "zMax": {
+                "type": "number",
+                "description": "The maximum Z value of the bounding box."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "xMin",
+            "yMin",
+            "zMin",
+            "xMax",
+            "yMax",
+            "zMax"
+        ]
+    },
+    "BoundingBox3DOrError": {
+        "type": "object",
+        "description": "A 3D bounding box or an error.",
+        "oneOf": [
+            {
+                "title": "boundingBox3D",
+                "properties": {
+                    "boundingBox3D": {
+                        "$ref": "#/BoundingBox3D"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [ "boundingBox3D" ]
+            },
+            {
+                "title": "error",
+                "$ref": "#/ErrorItem"
+            }
+        ]
+    },
+    "BoundingBoxes3D": {
+        "type": "array",
+        "description": "A list of 3D bounding boxes.",
+        "items": {
+            "$ref": "#/BoundingBox3DOrError"
+        }
     }
 };

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/Get3DBoundingBoxesOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/Get3DBoundingBoxesOfElementsComponent.cs
@@ -44,7 +44,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             };
 
             JObject inputElementsObj = JObject.FromObject (inputElements);
-            CommandResponse response = SendArchicadCommand ("Get3DBoundingBoxes", inputElementsObj);
+            CommandResponse response = SendArchicadAddOnCommand ("TapirCommand", "Get3DBoundingBoxes", inputElementsObj);
             if (!response.Succeeded) {
                 AddRuntimeMessage (GH_RuntimeMessageLevel.Error, response.GetErrorMessage ());
                 return;


### PR DESCRIPTION
The input/output schemas of this new Get3DBoundingBoxes command is the same as the schemas of the "official" Get3DBoundingBoxes command.
I've implemented [set_elementid_of_cwsubelements_based_on_boundingboxes.py](https://github.com/ENZYME-APD/tapir-archicad-automation/compare/main...tlorantfy:tapir-archicad-automation:main?expand=1#diff-6039d5264b39d26a3c7bdb4d7dbda4a2a9062f3863ba21ee16e15fb0b164547a) example script which gets bounding boxes for all CW subelements and sets Element ID properties of all subelements based on the bounding boxes.