### PR TITLE
Create element id input from multiple sources.

### DIFF
--- a/archicad-addon/Examples/get_classifications_of_mainelements_and_subelements.py
+++ b/archicad-addon/Examples/get_classifications_of_mainelements_and_subelements.py
@@ -2,11 +2,11 @@ import aclib
 
 mainElements = aclib.RunCommand ('API.GetAllElements', {})['elements']
 response = aclib.RunTapirCommand ('GetSubelementsOfHierarchicalElements', {
-        'hierarchicalElements' : mainElements
+        'elements' : mainElements
     })
 
 allSubElements = []
-for subelementGroups in response['subelementsOfHierarchicalElements']:
+for subelementGroups in response['subelements']:
     for subelements in subelementGroups.values():
         for subelement in subelements:
             if 'elementId' in subelement:

--- a/archicad-addon/Examples/set_classifications_of_all_curtainwallframes.py
+++ b/archicad-addon/Examples/set_classifications_of_all_curtainwallframes.py
@@ -9,8 +9,8 @@ print('Project contains {} Curtain Wall(s)'.format(len(allCurtainWalls)))
 
 allCWSubelements = aclib.RunTapirCommand (
     'GetSubelementsOfHierarchicalElements', {
-        'hierarchicalElements': allCurtainWalls
-    }, debug=False)['subelementsOfHierarchicalElements']
+        'elements': allCurtainWalls
+    }, debug=False)['subelements']
 
 allCWFrameSubelements = [subelement for subelements in allCWSubelements for subelement in subelements['cWallFrames']]
 print('Project contains {} Curtain Wall Frame(s)'.format(len(allCWFrameSubelements)))

--- a/archicad-addon/Examples/set_elementid_of_cwsubelements_based_on_boundingboxes.py
+++ b/archicad-addon/Examples/set_elementid_of_cwsubelements_based_on_boundingboxes.py
@@ -7,8 +7,8 @@ allCurtainWalls = aclib.RunTapirCommand (
 
 allCWSubelements = aclib.RunTapirCommand (
     'GetSubelementsOfHierarchicalElements', {
-        'hierarchicalElements': allCurtainWalls
-    })['subelementsOfHierarchicalElements']
+        'elements': allCurtainWalls
+    })['subelements']
 
 elementIdPropertyId = aclib.RunCommand ('API.GetPropertyIds', {'properties': [{"type": "BuiltIn", "nonLocalizedName": "General_ElementID"}]})['properties'][0]['propertyId']
 

--- a/archicad-addon/Examples/set_properties_of_subelements.py
+++ b/archicad-addon/Examples/set_properties_of_subelements.py
@@ -7,8 +7,8 @@ allCurtainWalls = aclib.RunCommand (
 
 allCWSubelements = aclib.RunTapirCommand (
     'GetSubelementsOfHierarchicalElements', {
-        'hierarchicalElements': allCurtainWalls
-    })['subelementsOfHierarchicalElements']
+        'elements': allCurtainWalls
+    })['subelements']
 
 allCWFrameSubelements = [subelement for subelements in allCWSubelements for subelement in subelements['cWallFrames']]
 

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -692,13 +692,13 @@ GS::Optional<GS::UniString> GetSubelementsOfHierarchicalElementsCommand::GetInpu
     return R"({
         "type": "object",
         "properties": {
-            "hierarchicalElements": {
+            "elements": {
                 "$ref": "#/Elements"
             }
         },
         "additionalProperties": false,
         "required": [
-            "hierarchicalElements"
+            "elements"
         ]
     })";
 }
@@ -708,7 +708,7 @@ GS::Optional<GS::UniString> GetSubelementsOfHierarchicalElementsCommand::GetResp
     return R"({
         "type": "object",
         "properties": {
-            "subelementsOfHierarchicalElements": {
+            "subelements": {
                 "type": "array",
                 "items": {
                     "type": "object",
@@ -801,7 +801,7 @@ GS::Optional<GS::UniString> GetSubelementsOfHierarchicalElementsCommand::GetResp
         },
         "additionalProperties": false,
         "required": [
-            "subelementsOfHierarchicalElements"
+            "subelements"
         ]
     })";
 }
@@ -822,13 +822,13 @@ static void AddSubelementsToObjectState (GS::ObjectState& subelements, APIElemTy
 
 GS::ObjectState GetSubelementsOfHierarchicalElementsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
-    GS::Array<GS::ObjectState> hierarchicalElements;
-    parameters.Get ("hierarchicalElements", hierarchicalElements);
+    GS::Array<GS::ObjectState> elements;
+    parameters.Get ("elements", elements);
 
     GS::ObjectState response;
-    const auto& subelementsOfHierarchicalElements = response.AddList<GS::ObjectState> ("subelementsOfHierarchicalElements");
+    const auto& subelementsOfHierarchicalElements = response.AddList<GS::ObjectState> ("subelements");
 
-    for (const GS::ObjectState& hierarchicalElement : hierarchicalElements) {
+    for (const GS::ObjectState& hierarchicalElement : elements) {
         const GS::ObjectState* elementId = hierarchicalElement.Get ("elementId");
         if (elementId == nullptr) {
             subelementsOfHierarchicalElements (CreateErrorResponse (APIERR_BADPARS, "elementId of hierarchicalElement is missing"));

--- a/archicad-addon/Test/ExpectedOutputs/get_classifications_of_mainelements_and_subelements.py.output
+++ b/archicad-addon/Test/ExpectedOutputs/get_classifications_of_mainelements_and_subelements.py.output
@@ -1,7 +1,7 @@
 Command: GetSubelementsOfHierarchicalElements
 Parameters:
 {
-    "hierarchicalElements": [
+    "elements": [
         {
             "elementId": {
                 "guid": "<GUID>"
@@ -71,7 +71,7 @@ Parameters:
 }
 Response:
 {
-    "subelementsOfHierarchicalElements": [
+    "subelements": [
         {},
         {},
         {},

--- a/archicad-addon/Test/ExpectedOutputs/set_elementid_of_cwsubelements_based_on_boundingboxes.py.output
+++ b/archicad-addon/Test/ExpectedOutputs/set_elementid_of_cwsubelements_based_on_boundingboxes.py.output
@@ -16,7 +16,7 @@ Response:
 Command: GetSubelementsOfHierarchicalElements
 Parameters:
 {
-    "hierarchicalElements": [
+    "elements": [
         {
             "elementId": {
                 "guid": "<GUID>"
@@ -26,7 +26,7 @@ Parameters:
 }
 Response:
 {
-    "subelementsOfHierarchicalElements": [
+    "subelements": [
         {
             "cWallSegments": [
                 {

--- a/archicad-addon/Test/ExpectedOutputs/set_properties_of_subelements.py.output
+++ b/archicad-addon/Test/ExpectedOutputs/set_properties_of_subelements.py.output
@@ -1,7 +1,7 @@
 Command: GetSubelementsOfHierarchicalElements
 Parameters:
 {
-    "hierarchicalElements": [
+    "elements": [
         {
             "elementId": {
                 "guid": "<GUID>"
@@ -11,7 +11,7 @@ Parameters:
 }
 Response:
 {
-    "subelementsOfHierarchicalElements": [
+    "subelements": [
         {
             "cWallSegments": [
                 {

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -687,19 +687,19 @@ var gCommands = [{
                 "inputScheme": {
         "type": "object",
         "properties": {
-            "hierarchicalElements": {
+            "elements": {
                 "$ref": "#/Elements"
             }
         },
         "additionalProperties": false,
         "required": [
-            "hierarchicalElements"
+            "elements"
         ]
     },
                 "outputScheme": {
         "type": "object",
         "properties": {
-            "subelementsOfHierarchicalElements": {
+            "subelements": {
                 "type": "array",
                 "items": {
                     "type": "object",
@@ -792,7 +792,7 @@ var gCommands = [{
         },
         "additionalProperties": false,
         "required": [
-            "subelementsOfHierarchicalElements"
+            "subelements"
         ]
     }
             },{

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/Get3DBoundingBoxesOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/Get3DBoundingBoxesOfElementsComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Rhino.Geometry;
@@ -34,14 +35,11 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
         protected override void SolveInstance (IGH_DataAccess DA)
         {
-            List<ElementIdItemObj> elements = new List<ElementIdItemObj> ();
-            if (!DA.GetDataList (0, elements)) {
+            ElementsObj inputElements = ElementsObj.Create (DA, 0);
+            if (inputElements == null) {
+                AddRuntimeMessage (GH_RuntimeMessageLevel.Error, "Input ElementIds failed to collect data.");
                 return;
             }
-
-            ElementsObj inputElements = new ElementsObj () {
-                Elements = elements
-            };
 
             JObject inputElementsObj = JObject.FromObject (inputElements);
             CommandResponse response = SendArchicadAddOnCommand ("TapirCommand", "Get3DBoundingBoxes", inputElementsObj);

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetDetailsOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetDetailsOfElementsComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Rhino.Geometry;
@@ -58,14 +59,11 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
         protected override void SolveInstance (IGH_DataAccess DA)
         {
-            List<ElementIdItemObj> elements = new List<ElementIdItemObj> ();
-            if (!DA.GetDataList (0, elements)) {
+            ElementsObj inputElements = ElementsObj.Create (DA, 0);
+            if (inputElements == null) {
+                AddRuntimeMessage (GH_RuntimeMessageLevel.Error, "Input ElementIds failed to collect data.");
                 return;
             }
-
-            ElementsObj inputElements = new ElementsObj () {
-                Elements = elements
-            };
 
             JObject inputElementsObj = JObject.FromObject (inputElements);
             CommandResponse response = SendArchicadAddOnCommand ("TapirCommand", "GetDetailsOfElements", inputElementsObj);
@@ -87,7 +85,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                     continue;
                 }
                 validElements.Add (new ElementIdItemObj () {
-                    ElementId = elements[i].ElementId
+                    ElementId = inputElements.Elements[i].ElementId
                 });
                 elemTypes.Add (detailsOfElement.Type);
                 storyIndices.Add (detailsOfElement.FloorIndex);
@@ -133,14 +131,11 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
         protected override void SolveInstance (IGH_DataAccess DA)
         {
-            List<ElementIdItemObj> elements = new List<ElementIdItemObj> ();
-            if (!DA.GetDataList (0, elements)) {
+            ElementsObj inputElements = ElementsObj.Create (DA, 0);
+            if (inputElements == null) {
+                AddRuntimeMessage (GH_RuntimeMessageLevel.Error, "Input ElementIds failed to collect data.");
                 return;
             }
-
-            ElementsObj inputElements = new ElementsObj () {
-                Elements = elements
-            };
 
             JObject inputElementsObj = JObject.FromObject (inputElements);
             CommandResponse response = SendArchicadAddOnCommand ("TapirCommand", "GetDetailsOfElements", inputElementsObj);
@@ -166,7 +161,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                     continue;
                 }
                 walls.Add (new ElementIdItemObj () {
-                    ElementId = elements[i].ElementId
+                    ElementId = inputElements.Elements[i].ElementId
                 });
                 begCoords.Add (new Point2d (wallDetails.BegCoordinate.X, wallDetails.BegCoordinate.Y));
                 endCoords.Add (new Point2d (wallDetails.EndCoordinate.X, wallDetails.EndCoordinate.Y));

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetGDLParametersOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetGDLParametersOfElementsComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -40,8 +41,9 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
         protected override void SolveInstance (IGH_DataAccess DA)
         {
-            List<ElementIdItemObj> elements = new List<ElementIdItemObj> ();
-            if (!DA.GetDataList (0, elements)) {
+            ElementsObj inputElements = ElementsObj.Create (DA, 0);
+            if (inputElements == null) {
+                AddRuntimeMessage (GH_RuntimeMessageLevel.Error, "Input ElementIds failed to collect data.");
                 return;
             }
 
@@ -51,9 +53,6 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             }
             paramName = paramName.ToLower ();
 
-            ElementsObj inputElements = new ElementsObj () {
-                Elements = elements
-            };
             JObject inputElementsObj = JObject.FromObject (inputElements);
 
             CommandResponse response = SendArchicadAddOnCommand ("TapirCommand", "GetGDLParametersOfElements", inputElementsObj);

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetSubelementsOfHierarchicalElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetSubelementsOfHierarchicalElementsComponent.cs
@@ -1,6 +1,7 @@
 ﻿using Grasshopper;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
+using Grasshopper.Kernel.Types;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -42,8 +43,9 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
         protected override void SolveInstance (IGH_DataAccess DA)
         {
-            List<ElementIdItemObj> elements = new List<ElementIdItemObj> ();
-            if (!DA.GetDataList (0, elements)) {
+            ElementsObj inputHierarchicalElements = ElementsObj.Create (DA, 0);
+            if (inputHierarchicalElements == null) {
+                AddRuntimeMessage (GH_RuntimeMessageLevel.Error, "Input ElementIds failed to collect data.");
                 return;
             }
 
@@ -51,10 +53,6 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             if (!DA.GetData (1, ref subelemType)) {
                 return;
             }
-
-            HierarchicalElementsObj inputHierarchicalElements = new HierarchicalElementsObj () {
-                Elements = elements
-            };
 
             JObject inputHierarchicalElementsObj = JObject.FromObject (inputHierarchicalElements);
             CommandResponse response = SendArchicadAddOnCommand ("TapirCommand", "GetSubelementsOfHierarchicalElements", inputHierarchicalElementsObj);
@@ -127,7 +125,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                     continue;
                 }
                 hierarchicalElements.Add (new ElementIdItemObj () {
-                    ElementId = elements[i].ElementId
+                    ElementId = inputHierarchicalElements.Elements[i].ElementId
                 });
                 subelementsOfHierarchicals.AddRange (subelements, new GH_Path (i));
             }

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetSubelementsOfHierarchicalElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetSubelementsOfHierarchicalElementsComponent.cs
@@ -43,8 +43,8 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
         protected override void SolveInstance (IGH_DataAccess DA)
         {
-            ElementsObj inputHierarchicalElements = ElementsObj.Create (DA, 0);
-            if (inputHierarchicalElements == null) {
+            ElementsObj inputElements = ElementsObj.Create (DA, 0);
+            if (inputElements == null) {
                 AddRuntimeMessage (GH_RuntimeMessageLevel.Error, "Input ElementIds failed to collect data.");
                 return;
             }
@@ -54,8 +54,8 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 return;
             }
 
-            JObject inputHierarchicalElementsObj = JObject.FromObject (inputHierarchicalElements);
-            CommandResponse response = SendArchicadAddOnCommand ("TapirCommand", "GetSubelementsOfHierarchicalElements", inputHierarchicalElementsObj);
+            JObject inputElementsObj = JObject.FromObject (inputElements);
+            CommandResponse response = SendArchicadAddOnCommand ("TapirCommand", "GetSubelementsOfHierarchicalElements", inputElementsObj);
             if (!response.Succeeded) {
                 AddRuntimeMessage (GH_RuntimeMessageLevel.Error, response.GetErrorMessage ());
                 return;
@@ -63,69 +63,69 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
             List<ElementIdItemObj> hierarchicalElements = new List<ElementIdItemObj> ();
             DataTree<ElementIdItemObj> subelementsOfHierarchicals = new DataTree<ElementIdItemObj> ();
-            SubelementsOfHierarchicalElementsObj subelementsOfHierarchicalElementsObj = response.Result.ToObject<SubelementsOfHierarchicalElementsObj> ();
-            for (int i = 0; i < subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements.Count; i++) {
+            SubelementsObj subElementsObj = response.Result.ToObject<SubelementsObj> ();
+            for (int i = 0; i < subElementsObj.Subelements.Count; i++) {
                 List<ElementIdItemObj> subelements = null;
                 if (subelemType == "CurtainWallSegment") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].CurtainWallSegments;
+                    subelements = subElementsObj.Subelements[i].CurtainWallSegments;
                 } else if (subelemType == "CurtainWallFrame") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].CurtainWallFrames;
+                    subelements = subElementsObj.Subelements[i].CurtainWallFrames;
                 } else if (subelemType == "CurtainWallPanel") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].CurtainWallPanels;
+                    subelements = subElementsObj.Subelements[i].CurtainWallPanels;
                 } else if (subelemType == "CurtainWallJunction") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].CurtainWallJunctions;
+                    subelements = subElementsObj.Subelements[i].CurtainWallJunctions;
                 } else if (subelemType == "CurtainWallAccessory") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].CurtainWallAccessories;
+                    subelements = subElementsObj.Subelements[i].CurtainWallAccessories;
                 } else if (subelemType == "StairRiser") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].StairRisers;
+                    subelements = subElementsObj.Subelements[i].StairRisers;
                 } else if (subelemType == "StairTread") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].StairTreads;
+                    subelements = subElementsObj.Subelements[i].StairTreads;
                 } else if (subelemType == "StairStructure") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].StairStructures;
+                    subelements = subElementsObj.Subelements[i].StairStructures;
                 } else if (subelemType == "RailingNode") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingNodes;
+                    subelements = subElementsObj.Subelements[i].RailingNodes;
                 } else if (subelemType == "RailingSegment") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingSegments;
+                    subelements = subElementsObj.Subelements[i].RailingSegments;
                 } else if (subelemType == "RailingPost") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingPosts;
+                    subelements = subElementsObj.Subelements[i].RailingPosts;
                 } else if (subelemType == "RailingRailEnd") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingRailEnds;
+                    subelements = subElementsObj.Subelements[i].RailingRailEnds;
                 } else if (subelemType == "RailingRailConnection") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingRailConnections;
+                    subelements = subElementsObj.Subelements[i].RailingRailConnections;
                 } else if (subelemType == "RailingHandrailEnd") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingHandrailEnds;
+                    subelements = subElementsObj.Subelements[i].RailingHandrailEnds;
                 } else if (subelemType == "RailingHandrailConnection") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingHandrailConnections;
+                    subelements = subElementsObj.Subelements[i].RailingHandrailConnections;
                 } else if (subelemType == "RailingToprailEnd") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingToprailEnds;
+                    subelements = subElementsObj.Subelements[i].RailingToprailEnds;
                 } else if (subelemType == "RailingToprailConnection") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingToprailConnections;
+                    subelements = subElementsObj.Subelements[i].RailingToprailConnections;
                 } else if (subelemType == "RailingRail") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingRails;
+                    subelements = subElementsObj.Subelements[i].RailingRails;
                 } else if (subelemType == "RailingToprail") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingToprails;
+                    subelements = subElementsObj.Subelements[i].RailingToprails;
                 } else if (subelemType == "RailingHandrail") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingHandrails;
+                    subelements = subElementsObj.Subelements[i].RailingHandrails;
                 } else if (subelemType == "RailingPattern") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingPatterns;
+                    subelements = subElementsObj.Subelements[i].RailingPatterns;
                 } else if (subelemType == "RailingInnerPost") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingInnerPosts;
+                    subelements = subElementsObj.Subelements[i].RailingInnerPosts;
                 } else if (subelemType == "RailingPanel") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingPanels;
+                    subelements = subElementsObj.Subelements[i].RailingPanels;
                 } else if (subelemType == "RailingBalusterSet") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingBalusterSets;
+                    subelements = subElementsObj.Subelements[i].RailingBalusterSets;
                 } else if (subelemType == "RailingBaluster") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].RailingBalusters;
+                    subelements = subElementsObj.Subelements[i].RailingBalusters;
                 } else if (subelemType == "BeamSegment") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].BeamSegments;
+                    subelements = subElementsObj.Subelements[i].BeamSegments;
                 } else if (subelemType == "ColumnSegment") {
-                    subelements = subelementsOfHierarchicalElementsObj.SubelementsOfHierarchicalElements[i].ColumnSegments;
+                    subelements = subElementsObj.Subelements[i].ColumnSegments;
                 }
                 if (subelements == null || subelements.Count == 0) {
                     continue;
                 }
                 hierarchicalElements.Add (new ElementIdItemObj () {
-                    ElementId = inputHierarchicalElements.Elements[i].ElementId
+                    ElementId = inputElements.Elements[i].ElementId
                 });
                 subelementsOfHierarchicals.AddRange (subelements, new GH_Path (i));
             }

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/SetPropertyValuesOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/SetPropertyValuesOfElementsComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -37,15 +38,18 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
             if (!DA.GetData (0, ref propertyId)) {
                 return;
             }
-            List<ElementIdItemObj> elements = new List<ElementIdItemObj> ();
-            if (!DA.GetDataList (1, elements)) {
+            ElementsObj elements = ElementsObj.Create (DA, 1);
+            if (elements == null) {
+                AddRuntimeMessage (GH_RuntimeMessageLevel.Error, "Input ElementIds failed to collect data.");
                 return;
             }
             List<string> values = new List<string> ();
             if (!DA.GetDataList (2, values)) {
                 return;
             }
-            if (values.Count != 1 && elements.Count != values.Count) {
+
+
+            if (values.Count != 1 && elements.Elements.Count != values.Count) {
                 AddRuntimeMessage (GH_RuntimeMessageLevel.Error, "The count of Values must be 1 or the same as the count of ElementIds.");
                 return;
             }
@@ -53,8 +57,8 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
             ElementPropertyValuesObj elemPropertyValues = new ElementPropertyValuesObj ();
             elemPropertyValues.ElementPropertyValues = new List<ElementPropertyValueObj> ();
 
-            for (int i = 0; i < elements.Count; i++) {
-                ElementIdItemObj elementId = elements[i];
+            for (int i = 0; i < elements.Elements.Count; i++) {
+                ElementIdItemObj elementId = elements.Elements[i];
                 ElementPropertyValueObj elemPropertyValue = new ElementPropertyValueObj () {
                     ElementId = elementId.ElementId,
                     PropertyId = propertyId,

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Data/ElementData.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Data/ElementData.cs
@@ -142,7 +142,7 @@ namespace TapirGrasshopperPlugin.Data
         public List<DetailsOfElementObj> DetailsOfElements;
     }
 
-    public class SubelementsObj
+    public class SubelementsItemObj
     {
         [JsonProperty ("cWallSegments")]
         public List<ElementIdItemObj> CurtainWallSegments;
@@ -226,10 +226,10 @@ namespace TapirGrasshopperPlugin.Data
         public List<ElementIdItemObj> ColumnSegments;
     }
 
-    public class SubelementsOfHierarchicalElementsObj
+    public class SubelementsObj
     {
-        [JsonProperty ("subelementsOfHierarchicalElements")]
-        public List<SubelementsObj> SubelementsOfHierarchicalElements;
+        [JsonProperty ("subelements")]
+        public List<SubelementsItemObj> Subelements;
     }
 
     public class GDLParameterDetailsObj

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Data/ElementData.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Data/ElementData.cs
@@ -1,18 +1,39 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Security.Policy;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Linq;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace TapirGrasshopperPlugin.Data
 {
     public class ElementIdObj
     {
+        public static ElementIdObj Create (GH_ObjectWrapper obj)
+        {
+            if (obj.Value is ElementIdObj) {
+                return obj.Value as ElementIdObj;
+            } else if (obj.Value is GH_String) {
+                GH_String stringValue = obj.Value as GH_String;
+                return CreateFromGuidString (stringValue.ToString ());
+            } else if (obj.Value.GetType ().GetProperty ("Guid") != null) {
+                return CreateFromGuidString (obj.Value.GetType ().GetProperty ("Guid").ToString ());
+            } else {
+                return null;
+            }
+        }
+
+        public static ElementIdObj CreateFromGuidString (string guidString)
+        {
+            if (System.Guid.TryParse (guidString, out _)) {
+                return new ElementIdObj () {
+                    Guid = guidString
+                };
+            } else {
+                return null;
+            }
+        }
+
         public override string ToString ()
         {
             return Guid;
@@ -24,6 +45,22 @@ namespace TapirGrasshopperPlugin.Data
 
     public class ElementIdItemObj
     {
+        public static ElementIdItemObj Create (GH_ObjectWrapper obj)
+        {
+            if (obj.Value is ElementIdItemObj) {
+                return obj.Value as ElementIdItemObj;
+            } else {
+                ElementIdObj elementId = ElementIdObj.Create (obj);
+                if (elementId != null) {
+                    return new ElementIdItemObj () {
+                        ElementId = elementId
+                    };
+                } else {
+                    return null;
+                }
+            }
+        }
+
         public override string ToString ()
         {
             return ElementId.ToString ();
@@ -35,6 +72,30 @@ namespace TapirGrasshopperPlugin.Data
 
     public class ElementsObj
     {
+        public static ElementsObj Create (IGH_DataAccess DA, int index)
+        {
+            List<GH_ObjectWrapper> elements = new List<GH_ObjectWrapper> ();
+            if (!DA.GetDataList (index, elements)) {
+                return null;
+            }
+            return Create (elements);
+        }
+
+        public static ElementsObj Create (List<GH_ObjectWrapper> objects)
+        {
+            ElementsObj elements = new ElementsObj ();
+            elements.Elements = new List<ElementIdItemObj> ();
+            foreach (GH_ObjectWrapper obj in objects) {
+                ElementIdItemObj elementId = ElementIdItemObj.Create (obj);
+                if (elementId != null) {
+                    elements.Elements.Add (elementId);
+                } else {
+                    return null;
+                }
+            }
+            return elements;
+        }
+
         [JsonProperty ("elements")]
         public List<ElementIdItemObj> Elements;
     }


### PR DESCRIPTION
The solution is based on the approach of @SzamosiMate. The goal is to allow multiple inputs for every input that requires a list of element ids.

The valid inputs are:
- An `ElementIdItemObj` instance.
- An `ElementIdObj` instance.
- A string containing a guid.
- Any object with a `Guid` property.

Also added a utility function to get a list of element ids from an input without the need to care about casting.
```csharp
ElementsObj inputElements = ElementsObj.Create (DA, 0);
if (inputElements == null) {
    AddRuntimeMessage (GH_RuntimeMessageLevel.Error, "Input ElementIds failed to collect data.");
    return;
}
```
