### PR TITLE
Add property full name as an output

### DIFF
--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/GetAllPropertiesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/GetAllPropertiesComponent.cs
@@ -27,7 +27,8 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
         {
             pManager.AddGenericParameter ("PropertyId", "PropertyId", "Property id.", GH_ParamAccess.list);
             pManager.AddTextParameter ("GroupName", "GroupName", "Property group name.", GH_ParamAccess.list);
-            pManager.AddTextParameter ("Name", "Name", "Property name.", GH_ParamAccess.list);
+            pManager.AddTextParameter ("PropertyName", "PropertyName", "Property name.", GH_ParamAccess.list);
+            pManager.AddTextParameter ("FullName", "FullName", "Full name containing the group and the property name.", GH_ParamAccess.list);
         }
 
         protected override void SolveInstance (IGH_DataAccess DA)
@@ -42,15 +43,18 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
             List<PropertyIdObj> propertyIds = new List<PropertyIdObj> ();
             List<string> propertyGroupNames = new List<string> ();
             List<string> propertyNames = new List<string> ();
+            List<string> fullNames = new List<string> ();
             foreach (PropertyDetailsObj detail in properties.Properties) {
                 propertyIds.Add (detail.PropertyId);
                 propertyGroupNames.Add (detail.PropertyGroupName);
                 propertyNames.Add (detail.PropertyName);
+                fullNames.Add (ArchicadUtils.JoinNames (detail.PropertyGroupName, detail.PropertyName));
             }
 
             DA.SetDataList (0, propertyIds);
             DA.SetDataList (1, propertyGroupNames);
             DA.SetDataList (2, propertyNames);
+            DA.SetDataList (3, fullNames);
         }
 
         protected override System.Drawing.Bitmap Icon => TapirGrasshopperPlugin.Properties.Resources.GetAllProperties;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Utilities/ArchicadUtils.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Utilities/ArchicadUtils.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TapirGrasshopperPlugin.Utilities
+{
+    internal class ArchicadUtils
+    {
+        public static string JoinNames (string a, string b)
+        {
+            return a + "/" + b;
+        }
+    }
+}


### PR DESCRIPTION
It makes searching properties by their fully qualified name easier using the "Key/Value Search" component.

![image](https://github.com/user-attachments/assets/9767f1ef-092c-4295-9880-5752c60d1987)
