### PR TITLE
GetAttributesByType

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -263,6 +263,10 @@ GSErrCode Initialize (void)
 
     { // Attribute Commands
         CommandGroup attributeCommands ("Attribute Commands");
+        err |= RegisterCommand<GetAttributesByTypeCommand> (
+            attributeCommands, "1.1.3",
+            "Returns the details of every attribute of the given type."
+        );
         err |= RegisterCommand<CreateLayersCommand> (
             attributeCommands, "1.0.3",
             "Creates Layer attributes based on the given parameters."

--- a/archicad-addon/Sources/AttributeCommands.cpp
+++ b/archicad-addon/Sources/AttributeCommands.cpp
@@ -3,18 +3,8 @@
 
 static bool GetAttributeIndexFromAttributeId (const GS::ObjectState& attributeId, API_AttrTypeID attributeType, API_AttributeIndex& attributeIndex)
 {
-    GS::ObjectState attributeIdInner;
-    if (!attributeId.Get ("attributeId", attributeIdInner)) {
-        return false;
-    }
-
-    GS::String attributeGuidString;
-    if (!attributeIdInner.Get ("guid", attributeGuidString)) {
-        return false;
-    }
-
     API_Attribute attribute = {};
-    attribute.header.guid = APIGuidFromString (attributeGuidString.ToCStr ());
+    attribute.header.guid = GetGuidFromAttributesArrayItem (attributeId);
     attribute.header.typeID = attributeType;
     if (ACAPI_Attribute_Get (&attribute) != NoError) {
         return false;
@@ -22,6 +12,126 @@ static bool GetAttributeIndexFromAttributeId (const GS::ObjectState& attributeId
 
     attributeIndex = attribute.header.index;
     return true;
+}
+
+static API_AttrTypeID ConvertAttributeTypeStringToID (const GS::UniString& typeStr)
+{
+    if (typeStr == "Layer")
+        return API_LayerID;
+    if (typeStr == "Line")
+        return API_LinetypeID;
+    if (typeStr == "Fill")
+        return API_FilltypeID;
+    if (typeStr == "Composite")
+        return API_CompWallID;
+    if (typeStr == "Surface")
+        return API_MaterialID;
+    if (typeStr == "LayerCombination")
+        return API_LayerCombID;
+    if (typeStr == "ZoneCategory")
+        return API_ZoneCatID;
+    if (typeStr == "Profile")
+        return API_ProfileID;
+    if (typeStr == "PenTable")
+        return API_PenTableID;
+    if (typeStr == "MEPSystem")
+        return API_MEPSystemID;
+    if (typeStr == "OperationProfile")
+        return API_OperationProfileID;
+    if (typeStr == "BuildingMaterial")
+        return API_BuildingMaterialID;
+    return API_ZombieAttrID;
+}
+
+GetAttributesByTypeCommand::GetAttributesByTypeCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String GetAttributesByTypeCommand::GetName () const
+{
+    return "GetAttributesByType";
+}
+
+GS::Optional<GS::UniString> GetAttributesByTypeCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "attributeType": {
+                "$ref": "#/AttributeType"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "attributeType"
+        ]
+    })";
+}
+
+GS::Optional<GS::UniString> GetAttributesByTypeCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "attributes" : {
+                "type": "array",
+                "description" : "Details of attributes.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "attributeDetails": {
+                            "type": "object",
+                            "description": "Details of an attribute.",
+                            "properties": {
+                                "attributeId": {
+                                    "$ref": "#/AttributeId"
+                                },
+                                "index": {
+                                    "type": "number",
+                                    "description": "Index of the attribute."
+                                },
+                                "name": {
+                                    "type": "number",
+                                    "description": "Name of the attribute."
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "attributes"
+        ]
+    })";
+}
+
+GS::ObjectState GetAttributesByTypeCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::UniString typeStr;
+    parameters.Get ("attributeType", typeStr);
+
+    API_AttrTypeID typeID = ConvertAttributeTypeStringToID (typeStr);
+
+    GS::ObjectState response;
+    const auto& attributes = response.AddList<GS::ObjectState> ("attributes");
+
+    GS::Array<API_Attribute> attrs;
+    ACAPI_Attribute_GetAttributesByType (typeID, attrs);
+
+    for (API_Attribute& attr : attrs) {
+        GS::ObjectState attributeDetails;
+        attributeDetails.Add ("attributeId", CreateGuidObjectState (attr.header.guid));
+        attributeDetails.Add ("index", GetAttributeIndex (attr.header.index));
+        attributeDetails.Add ("name", attr.header.name);
+        attributes (attributeDetails);
+
+        DisposeAttribute (attr);
+    }
+
+    return response;
 }
 
 GetBuildingMaterialPhysicalPropertiesCommand::GetBuildingMaterialPhysicalPropertiesCommand () :

--- a/archicad-addon/Sources/AttributeCommands.hpp
+++ b/archicad-addon/Sources/AttributeCommands.hpp
@@ -2,6 +2,16 @@
 
 #include "CommandBase.hpp"
 
+class GetAttributesByTypeCommand : public CommandBase
+{
+public:
+    GetAttributesByTypeCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
 class GetBuildingMaterialPhysicalPropertiesCommand : public CommandBase
 {
 public:

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -287,3 +287,30 @@ inline Int32 GetAttributeIndex (const API_AttributeIndex& index)
     return index;
 #endif
 }
+
+#ifndef ServerMainVers_2700
+inline GSErrCode ACAPI_Attribute_GetAttributesByType (API_AttrTypeID typeID, GS::Array<API_Attribute>& attributes)
+{
+    API_AttributeIndex count;
+    GSErrCode err = ACAPI_Attribute_GetNum (typeID, &count);
+
+    for (API_AttributeIndex i = 1; i <= count; ++i) {
+        API_Attribute attr = {};
+        attr.header.typeID = typeID;
+        attr.header.index = i;
+
+        if (ACAPI_Attribute_Get (&attr) == NoError) {
+            attributes.Push (attr);
+        }
+    }
+
+    return err;
+}
+#endif
+
+inline void DisposeAttribute (API_Attribute& attr)
+{
+    if (attr.header.typeID == API_MaterialID) {
+        delete attr.material.texture.fileLoc;
+    }
+}

--- a/archicad-addon/Sources/RFIX/Schemas/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Schemas/CommonSchemaDefinitions.json
@@ -31,6 +31,24 @@
             "guid"
         ]
     },
+    "AttributeType": {
+        "type": "string",
+        "description": "The type of an attribute.",
+        "enum": [
+            "Layer",
+            "Line",
+            "Fill",
+            "Composite",
+            "Surface",
+            "LayerCombination",
+            "ZoneCategory",
+            "Profile",
+            "PenTable",
+            "MEPSystem",
+            "OperationProfile",
+            "BuildingMaterial"
+        ]
+    },
     "AttributeIds": {
         "type": "array",
         "description": "A list of attributes.",

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/AttributeTypeValueList.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/AttributeTypeValueList.cs
@@ -1,0 +1,45 @@
+﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel.Special;
+using Grasshopper.GUI;
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using System.Runtime.CompilerServices;
+
+namespace TapirGrasshopperPlugin.Components.AttributesComponents
+{
+    public enum AttributeType
+    {
+        Layer,
+        Line,
+        Fill,
+        Composite,
+        Surface,
+        LayerCombination,
+        ZoneCategory,
+        Profile,
+        PenTable,
+        MEPSystem,
+        OperationProfile,
+        BuildingMaterial
+    }
+
+    public class AttributeTypeValueList : ValueList
+    {
+        public AttributeTypeValueList () :
+            base ("Attribute Type", "", "Value List for Archicad Attribute Types.", "Attributes")
+        {
+        }
+
+        public override void RefreshItems ()
+        {
+            ListItems.Clear ();
+            AddEnumItems (defaultSelected: AttributeType.Surface);
+            ExpireSolution (true);
+        }
+
+        //protected override System.Drawing.Bitmap Icon => TapirGrasshopperPlugin.Properties.Resources.AttributeType;
+
+        public override Guid ComponentGuid => new Guid ("0f6abd5b-6efe-4699-8e0f-ac67eea42890");
+    }
+}

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/GetAttributesByTypeComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/GetAttributesByTypeComponent.cs
@@ -1,0 +1,82 @@
+﻿using Grasshopper.Kernel;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using TapirGrasshopperPlugin.Data;
+using TapirGrasshopperPlugin.Utilities;
+
+namespace TapirGrasshopperPlugin.Components.AttributesComponents
+{
+    public class AttributesByTypeObj
+    {
+        [JsonProperty ("attributeType")]
+        public string AttributeType;
+    }
+
+    public class GetAttributesByTypeComponent : ArchicadAccessorComponent
+    {
+        public GetAttributesByTypeComponent ()
+          : base (
+                "Attributes By Type",
+                "AttributesByType",
+                "Get all attributes by type.",
+                "Attributes"
+            )
+        {
+        }
+
+        protected override void RegisterInputParams (GH_InputParamManager pManager)
+        {
+            pManager.AddTextParameter ("Type", "Type", "Attribute type.", GH_ParamAccess.item);
+        }
+
+        protected override void RegisterOutputParams (GH_OutputParamManager pManager)
+        {
+            pManager.AddGenericParameter ("AttributeIds", "AttributeIds", "List of attribute ids.", GH_ParamAccess.list);
+            pManager.AddGenericParameter ("AttributeIndices", "AttributeIndices", "List of attribute indices.", GH_ParamAccess.list);
+            pManager.AddGenericParameter ("AttributeNames", "AttributeNames", "List of attribute names.", GH_ParamAccess.list);
+        }
+
+        public override void AddedToDocument (GH_Document document)
+        {
+            base.AddedToDocument (document);
+
+            new AttributeTypeValueList ().AddAsSource (this, 0);
+        }
+
+        protected override void Solve (IGH_DataAccess DA)
+        {
+            string attrType = "";
+            if (!DA.GetData (0, ref attrType)) {
+                return;
+            }
+
+            AttributesByTypeObj attributesByType = new AttributesByTypeObj () {
+                AttributeType = attrType
+            };
+            JObject attributesByTypeObj = JObject.FromObject (attributesByType);
+            CommandResponse response = SendArchicadAddOnCommand ("TapirCommand", "GetAttributesByType", attributesByTypeObj);
+            if (!response.Succeeded) {
+                AddRuntimeMessage (GH_RuntimeMessageLevel.Error, response.GetErrorMessage ());
+                return;
+            }
+            AttributesObj attributes = response.Result.ToObject<AttributesObj> ();
+            List<AttributeIdObj> attributeIds = new List<AttributeIdObj> ();
+            List<uint> attributeIndices = new List<uint> ();
+            List<string> attributeNames = new List<string> ();
+            foreach (AttributeDetail attributeDetail in attributes.Attributes) {
+                attributeIds.Add (attributeDetail.AttributeId);
+                attributeIndices.Add (attributeDetail.Index);
+                attributeNames.Add (attributeDetail.Name);
+            }
+            DA.SetDataList (0, attributeIds);
+            DA.SetDataList (1, attributeIndices);
+            DA.SetDataList (2, attributeNames);
+        }
+
+        //protected override System.Drawing.Bitmap Icon => TapirGrasshopperPlugin.Properties.Resources.AttributesByType;
+
+        public override Guid ComponentGuid => new Guid ("f974c9ec-e3ec-4cf2-a576-b7a8548c9883");
+    }
+}

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Data/AttributeData.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Data/AttributeData.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace TapirGrasshopperPlugin.Data
+{
+    public class AttributeIdObj : IdObj<AttributeIdObj> { }
+
+    public class AttributeDetail
+    {
+        [JsonProperty ("attributeId")]
+        public AttributeIdObj AttributeId;
+
+        [JsonProperty ("index")]
+        public uint Index;
+
+        [JsonProperty ("name")]
+        public string Name;
+    }
+
+    public class AttributesObj
+    {
+        [JsonProperty ("attributes")]
+        public List<AttributeDetail> Attributes;
+    }
+}


### PR DESCRIPTION
New Tapir command:
* GetAttributesByType: returns the guid+index+name of the attributes with the given type

New GH components:
* AttributeTypeValueList: prebuilt list with the attribute types
* GetAttributesByType: 1 input: type, 3 outputs: guids, indices, names


https://github.com/user-attachments/assets/0444ca87-26e4-4246-afd0-d8fa9c8eee6e

