### PR TITLE
Created UpdateDrawings command

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -23,6 +23,7 @@
 #include "ClassificationCommands.hpp"
 #include "FavoritesCommands.hpp"
 #include "MigrationHelper.hpp"
+#include "NavigatorCommands.hpp"
 
 template <typename CommandType>
 GSErrCode RegisterCommand (CommandGroup& group, const GS::UniString& version, const GS::UniString& description)
@@ -126,10 +127,6 @@ GSErrCode Initialize (void)
         err |= RegisterCommand<GetHotlinksCommand> (
             projectCommands, "0.1.0",
             "Gets the file system locations (path) of the hotlink modules. The hotlinks can have tree hierarchy in the project."
-        );
-        err |= RegisterCommand<PublishPublisherSetCommand> (
-            projectCommands, "0.1.0",
-            "Performs a publish operation on the currently opened project. Only the given publisher set will be published."
         );
         err |= RegisterCommand<OpenProjectCommand> (
             projectCommands, "1.0.7",
@@ -314,6 +311,19 @@ GSErrCode Initialize (void)
             "Performs a receive operation on the currently opened Teamwork project."
         );
         AddCommandGroup (teamworkCommands);
+    }
+
+    { // Navigator Commands
+        CommandGroup navigatorCommands ("Navigator Commands");
+        err |= RegisterCommand<PublishPublisherSetCommand> (
+            navigatorCommands, "0.1.0",
+            "Performs a publish operation on the currently opened project. Only the given publisher set will be published."
+        );
+        err |= RegisterCommand<UpdateDrawingsCommand> (
+            navigatorCommands, "1.1.4",
+            "Performs a drawing update on the given elements."
+        );
+        AddCommandGroup (navigatorCommands);
     }
 
     { // Issue Management Commands

--- a/archicad-addon/Sources/NavigatorCommands.cpp
+++ b/archicad-addon/Sources/NavigatorCommands.cpp
@@ -1,0 +1,134 @@
+#include "NavigatorCommands.hpp"
+#include "MigrationHelper.hpp"
+
+static GS::HashTable<GS::UniString, API_Guid> GetPublisherSetNameGuidTable()
+{
+    GS::HashTable<GS::UniString, API_Guid> table;
+
+    Int32 numberOfPublisherSets = 0;
+    ACAPI_Navigator_GetNavigatorSetNum(&numberOfPublisherSets);
+
+    API_NavigatorSet set = {};
+    for (Int32 ii = 0; ii < numberOfPublisherSets; ++ii) {
+        set.mapId = API_PublisherSets;
+        GSErrCode err = ACAPI_Navigator_GetNavigatorSet(&set, &ii);
+        if (err == NoError) {
+            table.Add(set.name, set.rootGuid);
+        }
+    }
+
+    return table;
+}
+
+PublishPublisherSetCommand::PublishPublisherSetCommand() :
+    CommandBase(CommonSchema::NotUsed)
+{
+}
+
+GS::String PublishPublisherSetCommand::GetName() const
+{
+    return "PublishPublisherSet";
+}
+
+GS::Optional<GS::UniString> PublishPublisherSetCommand::GetInputParametersSchema() const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "publisherSetName": {
+                "type": "string",
+                "description": "The name of the publisher set.",
+                "minLength": 1
+            },
+            "outputPath": {
+                "type": "string",
+                "description": "Full local or LAN path for publishing. Optional, by default the path set in the settings of the publiser set will be used.",
+                "minLength": 1
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "publisherSetName"
+        ]
+    })";
+}
+
+GS::ObjectState PublishPublisherSetCommand::Execute(const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::UniString publisherSetName;
+    parameters.Get("publisherSetName", publisherSetName);
+
+    const auto publisherSetNameGuidTable = GetPublisherSetNameGuidTable();
+    if (!publisherSetNameGuidTable.ContainsKey(publisherSetName)) {
+        return CreateErrorResponse(Error, "Not valid publisher set name.");
+    }
+
+    API_PublishPars publishPars = {};
+    publishPars.guid = publisherSetNameGuidTable.Get(publisherSetName);
+
+    if (parameters.Contains("outputPath")) {
+        GS::UniString outputPath;
+        parameters.Get("outputPath", outputPath);
+        publishPars.path = new IO::Location(outputPath);
+    }
+
+    GSErrCode err = ACAPI_ProjectOperation_Publish(&publishPars);
+    delete publishPars.path;
+
+    if (err != NoError) {
+        return CreateErrorResponse(err, "Publishing failed. Check output path!");
+    }
+
+    return {};
+}
+
+UpdateDrawingsCommand::UpdateDrawingsCommand() :
+    CommandBase(CommonSchema::Used)
+{
+}
+
+GS::String UpdateDrawingsCommand::GetName() const
+{
+    return "UpdateDrawings";
+}
+
+GS::Optional<GS::UniString> UpdateDrawingsCommand::GetInputParametersSchema() const
+{
+    return R"({
+    "type": "object",
+    "properties": {
+        "elements": {
+            "$ref": "#/Elements"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "elements"
+    ]
+})";
+}
+
+GS::Optional<GS::UniString> UpdateDrawingsCommand::GetResponseSchema() const
+{
+    return R"({
+        "$ref": "#/ExecutionResult"
+    })";
+}
+
+GS::ObjectState UpdateDrawingsCommand::Execute(const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+#ifdef ServerMainVers_2700
+    GS::Array<GS::ObjectState> elements;
+    parameters.Get("elements", elements);
+
+    const GS::Array<API_Guid> elemIds = elements.Transform<API_Guid>(GetGuidFromElementsArrayItem);
+    GSErrCode err = ACAPI_Drawing_Update_Drawings(elemIds);
+
+    return err == NoError
+        ? CreateSuccessfulExecutionResult()
+        : CreateFailedExecutionResult(err, "Failed to update drawings.");
+#else
+    (void) parameters;
+    return CreateFailedExecutionResult (APIERR_NOTSUPPORTED, "DrawingUpdateCommand is not supported in Archicad versions earlier than 27.");
+#endif
+}

--- a/archicad-addon/Sources/NavigatorCommands.hpp
+++ b/archicad-addon/Sources/NavigatorCommands.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CommandBase.hpp"
+
+class PublishPublisherSetCommand : public CommandBase
+{
+public:
+    PublishPublisherSetCommand();
+    virtual GS::String GetName() const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema() const override;
+    virtual GS::ObjectState Execute(const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class UpdateDrawingsCommand : public CommandBase
+{
+public:
+    UpdateDrawingsCommand();
+    virtual GS::String GetName() const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema() const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema() const override;
+    virtual GS::ObjectState Execute(const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -1,25 +1,6 @@
 #include "ProjectCommands.hpp"
 #include "MigrationHelper.hpp"
 
-static GS::HashTable<GS::UniString, API_Guid> GetPublisherSetNameGuidTable ()
-{
-    GS::HashTable<GS::UniString, API_Guid> table;
-
-    Int32 numberOfPublisherSets = 0;
-    ACAPI_Navigator_GetNavigatorSetNum (&numberOfPublisherSets);
-
-    API_NavigatorSet set = {};
-    for (Int32 ii = 0; ii < numberOfPublisherSets; ++ii) {
-        set.mapId = API_PublisherSets;
-        GSErrCode err = ACAPI_Navigator_GetNavigatorSet (&set, &ii);
-        if (err == NoError) {
-            table.Add (set.name, set.rootGuid);
-        }
-    }
-
-    return table;
-}
-
 GetProjectInfoCommand::GetProjectInfoCommand () :
     CommandBase (CommonSchema::NotUsed)
 {
@@ -308,68 +289,6 @@ GS::ObjectState GetHotlinksCommand::Execute (const GS::ObjectState& /*parameters
     }
 
     return response;
-}
-
-PublishPublisherSetCommand::PublishPublisherSetCommand () :
-    CommandBase (CommonSchema::NotUsed)
-{
-}
-
-GS::String PublishPublisherSetCommand::GetName () const
-{
-    return "PublishPublisherSet";
-}
-
-GS::Optional<GS::UniString> PublishPublisherSetCommand::GetInputParametersSchema () const
-{
-    return R"({
-        "type": "object",
-        "properties": {
-            "publisherSetName": {
-                "type": "string",
-                "description": "The name of the publisher set.",
-                "minLength": 1
-            },
-            "outputPath": {
-                "type": "string",
-                "description": "Full local or LAN path for publishing. Optional, by default the path set in the settings of the publiser set will be used.",
-                "minLength": 1
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "publisherSetName"
-        ]
-    })";
-}
-
-GS::ObjectState PublishPublisherSetCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
-{
-    GS::UniString publisherSetName;
-    parameters.Get ("publisherSetName", publisherSetName);
-
-    const auto publisherSetNameGuidTable = GetPublisherSetNameGuidTable ();
-    if (!publisherSetNameGuidTable.ContainsKey (publisherSetName)) {
-        return CreateErrorResponse (Error, "Not valid publisher set name.");
-    }
-
-    API_PublishPars publishPars = {};
-    publishPars.guid = publisherSetNameGuidTable.Get (publisherSetName);
-
-    if (parameters.Contains ("outputPath")) {
-        GS::UniString outputPath;
-        parameters.Get ("outputPath", outputPath);
-        publishPars.path = new IO::Location (outputPath);
-    }
-
-    GSErrCode err = ACAPI_ProjectOperation_Publish (&publishPars);
-    delete publishPars.path;
-
-    if (err != NoError) {
-        return CreateErrorResponse (err, "Publishing failed. Check output path!");
-    }
-
-    return {};
 }
 
 GetStoryInfoCommand::GetStoryInfoCommand () :

--- a/archicad-addon/Sources/ProjectCommands.hpp
+++ b/archicad-addon/Sources/ProjectCommands.hpp
@@ -38,15 +38,6 @@ public:
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
-class PublishPublisherSetCommand : public CommandBase
-{
-public:
-    PublishPublisherSetCommand ();
-    virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
-};
-
 class GetStoryInfoCommand : public CommandBase
 {
 public:

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -253,30 +253,6 @@ var gCommands = [{
         ]
     }
             },{
-                "name": "PublishPublisherSet",
-                "version": "0.1.0",
-                "description": "Performs a publish operation on the currently opened project. Only the given publisher set will be published.",
-                "inputScheme": {
-        "type": "object",
-        "properties": {
-            "publisherSetName": {
-                "type": "string",
-                "description": "The name of the publisher set.",
-                "minLength": 1
-            },
-            "outputPath": {
-                "type": "string",
-                "description": "Full local or LAN path for publishing. Optional, by default the path set in the settings of the publiser set will be used.",
-                "minLength": 1
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "publisherSetName"
-        ]
-    },
-                "outputScheme": null
-            },{
                 "name": "OpenProject",
                 "version": "1.0.7",
                 "description": "Opens the given project.",
@@ -2269,6 +2245,52 @@ var gCommands = [{
                 "description": "Performs a receive operation on the currently opened Teamwork project.",
                 "inputScheme": null,
                 "outputScheme": null
+            }]
+        },{
+            "name": "Navigator Commands",
+            "commands": [{
+                "name": "PublishPublisherSet",
+                "version": "0.1.0",
+                "description": "Performs a publish operation on the currently opened project. Only the given publisher set will be published.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "publisherSetName": {
+                "type": "string",
+                "description": "The name of the publisher set.",
+                "minLength": 1
+            },
+            "outputPath": {
+                "type": "string",
+                "description": "Full local or LAN path for publishing. Optional, by default the path set in the settings of the publiser set will be used.",
+                "minLength": 1
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "publisherSetName"
+        ]
+    },
+                "outputScheme": null
+            },{
+                "name": "UpdateDrawings",
+                "version": "1.1.4",
+                "description": "Performs a drawing update on the given elements.",
+                "inputScheme": {
+    "type": "object",
+    "properties": {
+        "elements": {
+            "$ref": "#/Elements"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "elements"
+    ]
+},
+                "outputScheme": {
+        "$ref": "#/ExecutionResult"
+    }
             }]
         },{
             "name": "Issue Management Commands",


### PR DESCRIPTION
Moved PublishPublisherSETCommand to the new group
Created NavigatorCommands CommandGroup

Test script is not included, as UpdateDrawings needs a GetElementIdFromNavigatorItemId or OpenNavigatorItem to use.