### PR TITLE
Implemented GetDatabaseIdFromNavigatorItemId Command

### DIFF
--- a/archicad-addon/Examples/update_drawings.py
+++ b/archicad-addon/Examples/update_drawings.py
@@ -26,7 +26,7 @@ databases = aclib.RunTapirCommand(command='GetDatabaseIdFromNavigatorItemId',
 
 drawings = aclib.RunTapirCommand(command='GetElementsByType',
                                  parameters={'elementType': 'Drawing',
-                                             'databases': databases['databases']} )
+                                             'databases': databases['databases']} )['elements']
 
 aclib.RunTapirCommand(command='UpdateDrawings',
-                      parameters={'elements' : drawings['elements']}, debug=True)
+                      parameters={'elements' : drawings}, debug=True)

--- a/archicad-addon/Examples/update_drawings.py
+++ b/archicad-addon/Examples/update_drawings.py
@@ -1,0 +1,32 @@
+import aclib
+
+def get_drawing_guids_from_tree(current_branch, drawing_guids, navigator_item_type):
+    for navigator_item in current_branch:
+        navigator_item = navigator_item['navigatorItem']
+        if navigator_item['type'] == navigator_item_type:
+            drawing_guids.append(navigator_item['navigatorItemId'])
+        children = navigator_item.get('children')
+        if children:
+            get_drawing_guids_from_tree(children, drawing_guids, navigator_item_type)
+
+
+navigator_tree_id = {'navigatorTreeId': {'type': 'LayoutBook'}}
+
+navigator_tree = aclib.RunCommand(command='API.GetNavigatorItemTree',
+                                  parameters=navigator_tree_id)
+
+drawing_gids = []
+get_drawing_guids_from_tree(navigator_tree['navigatorTree']['rootItem']['children'],
+                            drawing_gids, navigator_item_type='LayoutItem')
+
+drawing_elements = [{'navigatorItemId': guid} for guid in drawing_gids]
+
+databases = aclib.RunTapirCommand(command='GetDatabaseIdFromNavigatorItemId',
+                                  parameters={'navigatorItemIds': drawing_elements}, debug=True)
+
+drawings = aclib.RunTapirCommand(command='GetElementsByType',
+                                 parameters={'elementType': 'Drawing',
+                                             'databases': databases['databases']} )
+
+aclib.RunTapirCommand(command='UpdateDrawings',
+                      parameters=drawings, debug=True)

--- a/archicad-addon/Examples/update_drawings.py
+++ b/archicad-addon/Examples/update_drawings.py
@@ -1,13 +1,13 @@
 import aclib
 
-def get_drawing_guids_from_tree(current_branch, drawing_guids, navigator_item_type):
+def get_navigator_item_guids_from_tree(current_branch, navigator_item_guids, navigator_item_type):
     for navigator_item in current_branch:
         navigator_item = navigator_item['navigatorItem']
         if navigator_item['type'] == navigator_item_type:
-            drawing_guids.append(navigator_item['navigatorItemId'])
+            navigator_item_guids.append(navigator_item['navigatorItemId'])
         children = navigator_item.get('children')
         if children:
-            get_drawing_guids_from_tree(children, drawing_guids, navigator_item_type)
+            get_navigator_item_guids_from_tree(children, navigator_item_guids, navigator_item_type)
 
 
 navigator_tree_id = {'navigatorTreeId': {'type': 'LayoutBook'}}
@@ -15,18 +15,18 @@ navigator_tree_id = {'navigatorTreeId': {'type': 'LayoutBook'}}
 navigator_tree = aclib.RunCommand(command='API.GetNavigatorItemTree',
                                   parameters=navigator_tree_id)
 
-drawing_gids = []
-get_drawing_guids_from_tree(navigator_tree['navigatorTree']['rootItem']['children'],
-                            drawing_gids, navigator_item_type='LayoutItem')
+layout_guids = []
+get_navigator_item_guids_from_tree(navigator_tree['navigatorTree']['rootItem']['children'],
+                            layout_guids, navigator_item_type='LayoutItem')
 
-drawing_elements = [{'navigatorItemId': guid} for guid in drawing_gids]
+layout_elements = [{'navigatorItemId': guid} for guid in layout_guids]
 
 databases = aclib.RunTapirCommand(command='GetDatabaseIdFromNavigatorItemId',
-                                  parameters={'navigatorItemIds': drawing_elements}, debug=True)
+                                  parameters={'navigatorItemIds': layout_elements}, debug=True)
 
 drawings = aclib.RunTapirCommand(command='GetElementsByType',
                                  parameters={'elementType': 'Drawing',
                                              'databases': databases['databases']} )
 
 aclib.RunTapirCommand(command='UpdateDrawings',
-                      parameters=drawings, debug=True)
+                      parameters={'elements' : drawings['elements']}, debug=True)

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -331,6 +331,10 @@ GSErrCode Initialize (void)
             navigatorCommands, "1.1.4",
             "Performs a drawing update on the given elements."
         );
+        err |= RegisterCommand<GetDatabaseIdFromNavigatorItemIdCommand> (
+            navigatorCommands, "1.1.4",
+            "Gets the ID of the database associated with the supplied navigator item id"
+        );
         AddCommandGroup (navigatorCommands);
     }
 

--- a/archicad-addon/Sources/CommandBase.hpp
+++ b/archicad-addon/Sources/CommandBase.hpp
@@ -36,9 +36,11 @@ GS::ObjectState CreateSuccessfulExecutionResult ();
 
 API_Guid    GetGuidFromObjectState (const GS::ObjectState& os);
 API_Guid    GetGuidFromArrayItem (const GS::String& idFieldName, const GS::ObjectState& os);
-inline API_Guid GetGuidFromElementsArrayItem (const GS::ObjectState& os)   { return GetGuidFromArrayItem ("elementId", os); }
-inline API_Guid GetGuidFromAttributesArrayItem (const GS::ObjectState& os) { return GetGuidFromArrayItem ("attributeId", os); }
-inline API_Guid GetGuidFromIssuesArrayItem (const GS::ObjectState& os)     { return GetGuidFromArrayItem ("issueId", os); }
+inline API_Guid GetGuidFromElementsArrayItem (const GS::ObjectState& os)        { return GetGuidFromArrayItem ("elementId", os); }
+inline API_Guid GetGuidFromAttributesArrayItem (const GS::ObjectState& os)      { return GetGuidFromArrayItem ("attributeId", os); }
+inline API_Guid GetGuidFromIssuesArrayItem (const GS::ObjectState& os)          { return GetGuidFromArrayItem ("issueId", os); }
+inline API_Guid GetGuidFromNavigatorItemIdArrayItem (const GS::ObjectState& os) { return GetGuidFromArrayItem ("navigatorItemId", os); }
+inline API_Guid GetGuidFromBatabaseArrayItem (const GS::ObjectState& os)      { return GetGuidFromArrayItem ("databaseId", os); }
 API_Coord   Get2DCoordinateFromObjectState (const GS::ObjectState& objectState);
 API_Coord3D Get3DCoordinateFromObjectState (const GS::ObjectState& objectState);
 GS::ObjectState Create2DCoordinateObjectState (const API_Coord& c);
@@ -49,6 +51,7 @@ GS::ObjectState CreateIdObjectState (const GS::String& idFieldName, const API_Gu
 inline GS::ObjectState CreateElementIdObjectState (const API_Guid& guid)   { return CreateIdObjectState ("elementId", guid); }
 inline GS::ObjectState CreateAttributeIdObjectState (const API_Guid& guid) { return CreateIdObjectState ("attributeId", guid); }
 inline GS::ObjectState CreateIssueIdObjectState (const API_Guid& guid)     { return CreateIdObjectState ("issueId", guid); }
+inline GS::ObjectState CreateDatabaseIdObjectState (const API_Guid& guid)  { return CreateIdObjectState ("databaseId", guid); }
 
 struct Story {
     Story (short _index, double _level)

--- a/archicad-addon/Sources/CommandBase.hpp
+++ b/archicad-addon/Sources/CommandBase.hpp
@@ -40,7 +40,7 @@ inline API_Guid GetGuidFromElementsArrayItem (const GS::ObjectState& os)        
 inline API_Guid GetGuidFromAttributesArrayItem (const GS::ObjectState& os)      { return GetGuidFromArrayItem ("attributeId", os); }
 inline API_Guid GetGuidFromIssuesArrayItem (const GS::ObjectState& os)          { return GetGuidFromArrayItem ("issueId", os); }
 inline API_Guid GetGuidFromNavigatorItemIdArrayItem (const GS::ObjectState& os) { return GetGuidFromArrayItem ("navigatorItemId", os); }
-inline API_Guid GetGuidFromBatabaseArrayItem (const GS::ObjectState& os)      { return GetGuidFromArrayItem ("databaseId", os); }
+inline API_Guid GetGuidFromDatabaseArrayItem (const GS::ObjectState& os)        { return GetGuidFromArrayItem ("databaseId", os); }
 API_Coord   Get2DCoordinateFromObjectState (const GS::ObjectState& objectState);
 API_Coord3D Get3DCoordinateFromObjectState (const GS::ObjectState& objectState);
 GS::ObjectState Create2DCoordinateObjectState (const API_Coord& c);

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -151,8 +151,7 @@ GS::Optional<GS::UniString> GetElementsByTypeCommand::GetResponseSchema () const
         },
         "additionalProperties": false,
         "required": [
-            "elements",
-            "executionResultForDatabases"
+            "elements"
         ]
     })";
 }
@@ -167,7 +166,6 @@ GS::ObjectState GetElementsByTypeCommand::Execute (const GS::ObjectState& parame
     bool databasesParameterExists = parameters.Get ("databases", databases);
     if (!databasesParameterExists) {
         GetElementsFromCurrentDatabase (parameters, elements);
-        executionResultForDatabases (CreateSuccessfulExecutionResult());
     }
     else {
         const GS::Array<API_Guid> databaseIds = databases.Transform<API_Guid> (GetGuidFromDatabaseArrayItem);

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -165,6 +165,26 @@ inline GSErrCode ACAPI_LibraryPart_CloseParameters ()
     return ACAPI_Goodies (APIAny_CloseParametersID);
 }
 
+inline GSErrCode ACAPI_Navigator_GetNavigatorItem (const API_Guid* par1, API_NavigatorItem* par2)
+{
+    return ACAPI_Navigator (APINavigator_GetNavigatorItemID, (void*) par1, (void*) par2);
+}
+
+inline GSErrCode ACAPI_Database_ChangeCurrentDatabase (API_DatabaseInfo* par1)
+{
+    return ACAPI_Database (APIDb_ChangeCurrentDatabaseID, (void*) par1);
+}
+
+inline GSErrCode ACAPI_Database_GetCurrentDatabase (API_DatabaseInfo* par1)
+{
+    return ACAPI_Database (APIDb_GetCurrentDatabaseID, (void*) par1);
+}
+
+inline GSErrCode ACAPI_Window_GetDatabaseInfo (API_DatabaseInfo* par1)
+{
+    return ACAPI_Database (APIDb_GetDatabaseInfoID, (void*) par1, nullptr);
+}
+
 #endif
 
 #ifndef ServerMainVers_2600

--- a/archicad-addon/Sources/NavigatorCommands.hpp
+++ b/archicad-addon/Sources/NavigatorCommands.hpp
@@ -20,3 +20,13 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema() const override;
     virtual GS::ObjectState Execute(const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+
+class GetDatabaseIdFromNavigatorItemIdCommand : public CommandBase
+{
+public:
+    GetDatabaseIdFromNavigatorItemIdCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};

--- a/archicad-addon/Sources/RFIX/Schemas/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Schemas/CommonSchemaDefinitions.json
@@ -1,1636 +1,1636 @@
 {
-  "Elements": {
-    "type": "array",
-    "description": "A list of elements.",
-    "items": {
-      "$ref": "#/ElementIdArrayItem"
-    }
-  },
-  "ElementIdArrayItem": {
-    "type": "object",
-    "properties": {
-      "elementId": {
-        "$ref": "#/ElementId"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "elementId"
-    ]
-  },
-  "ElementId": {
-    "type": "object",
-    "description": "The identifier of an element.",
-    "properties": {
-      "guid": {
-        "$ref": "#/Guid"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "guid"
-    ]
-  },
-  "AttributeType": {
-    "type": "string",
-    "description": "The type of an attribute.",
-    "enum": [
-      "Layer",
-      "Line",
-      "Fill",
-      "Composite",
-      "Surface",
-      "LayerCombination",
-      "ZoneCategory",
-      "Profile",
-      "PenTable",
-      "MEPSystem",
-      "OperationProfile",
-      "BuildingMaterial"
-    ]
-  },
-  "AttributeIds": {
-    "type": "array",
-    "description": "A list of attributes.",
-    "items": {
-      "$ref": "#/AttributeIdArrayItem"
-    }
-  },
-  "AttributeIdArrayItem": {
-    "type": "object",
-    "properties": {
-      "attributeId": {
-        "$ref": "#/AttributeId"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "attributeId"
-    ]
-  },
-  "AttributeId": {
-    "type": "object",
-    "description": "The identifier of an attribute.",
-    "properties": {
-      "guid": {
-        "$ref": "#/Guid"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "guid"
-    ]
-  },
-  "Guid": {
-    "type": "string",
-    "description": "A Globally Unique Identifier (or Universally Unique Identifier) in its string representation as defined in RFC 4122.",
-    "format": "uuid",
-    "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-  },
-  "Hotlinks": {
-    "type": "array",
-    "description": "A list of hotlink nodes.",
-    "items": {
-      "$ref": "#/Hotlink"
-    }
-  },
-  "Hotlink": {
-    "type": "object",
-    "description": "The details of a hotlink node.",
-    "properties": {
-      "location": {
-        "type": "string",
-        "description": "The path of the hotlink file."
-      },
-      "children": {
-        "$ref": "#/Hotlinks",
-        "description": "The children of the hotlink node if it has any."
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "location"
-    ]
-  },
-  "GDLParameterList": {
-    "type": "object",
-    "description": "The list of GDL parameters.",
-    "properties": {
-      "parameters": {
+    "Elements": {
         "type": "array",
+        "description": "A list of elements.",
+        "items": {
+            "$ref": "#/ElementIdArrayItem"
+        }
+    },
+    "ElementIdArrayItem": {
+        "type": "object",
+        "properties": {
+            "elementId": {
+                "$ref": "#/ElementId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "elementId"
+        ]
+    },
+    "ElementId": {
+        "type": "object",
+        "description": "The identifier of an element.",
+        "properties": {
+            "guid": {
+                "$ref": "#/Guid"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "guid"
+        ]
+    },
+    "AttributeType": {
+        "type": "string",
+        "description": "The type of an attribute.",
+        "enum": [
+            "Layer",
+            "Line",
+            "Fill",
+            "Composite",
+            "Surface",
+            "LayerCombination",
+            "ZoneCategory",
+            "Profile",
+            "PenTable",
+            "MEPSystem",
+            "OperationProfile",
+            "BuildingMaterial"
+        ]
+    },
+    "AttributeIds": {
+        "type": "array",
+        "description": "A list of attributes.",
+        "items": {
+            "$ref": "#/AttributeIdArrayItem"
+        }
+    },
+    "AttributeIdArrayItem": {
+        "type": "object",
+        "properties": {
+            "attributeId": {
+                "$ref": "#/AttributeId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "attributeId"
+        ]
+    },
+    "AttributeId": {
+        "type": "object",
+        "description": "The identifier of an attribute.",
+        "properties": {
+            "guid": {
+                "$ref": "#/Guid"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "guid"
+        ]
+    },
+    "Guid": {
+        "type": "string",
+        "description": "A Globally Unique Identifier (or Universally Unique Identifier) in its string representation as defined in RFC 4122.",
+        "format": "uuid",
+        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    },
+    "Hotlinks": {
+        "type": "array",
+        "description": "A list of hotlink nodes.",
+        "items": {
+            "$ref": "#/Hotlink"
+        }
+    },
+    "Hotlink": {
+        "type": "object",
+        "description": "The details of a hotlink node.",
+        "properties": {
+            "location": {
+                "type": "string",
+                "description": "The path of the hotlink file."
+            },
+            "children": {
+                "$ref": "#/Hotlinks",
+                "description": "The children of the hotlink node if it has any."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "location"
+        ]
+    },
+    "GDLParameterList": {
+        "type": "object",
         "description": "The list of GDL parameters.",
+        "properties": {
+            "parameters": {
+                "type": "array",
+                "description": "The list of GDL parameters.",
+                "items": {
+                    "$ref": "#/GDLParameterDetails"
+                }
+            }
+        },
+        "required": [
+            "parameters"
+        ]
+    },
+    "GDLParameterDetails": {
+        "type": "object",
+        "description": "Details of a GDL parameter.",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "The name of the parameter."
+            },
+            "index": {
+                "type": "string",
+                "description": "The index of the parameter."
+            },
+            "type": {
+                "type": "string",
+                "description": "The type of the parameter."
+            },
+            "dimension1": {
+                "type": "number",
+                "description": "The 1st dimension of array (in case of array value)."
+            },
+            "dimension2": {
+                "type": "number",
+                "description": "The 2nd dimension of array (in case of array value)."
+            },
+            "value": {
+                "description": "The value of the parameter."
+            }
+        },
+        "additionalProperties": true,
+        "required": [
+            "index",
+            "type",
+            "value"
+        ]
+    },
+    "2DCoordinate": {
+        "type": "object",
+        "description": "2D coordinate.",
+        "properties": {
+            "x": {
+                "type": "number",
+                "description": "X value of the coordinate."
+            },
+            "y": {
+                "type": "number",
+                "description": "Y value of the coordinate."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "x",
+            "y"
+        ]
+    },
+    "3DCoordinate": {
+        "type": "object",
+        "description": "3D coordinate.",
+        "properties": {
+            "x": {
+                "type": "number",
+                "description": "X value of the coordinate."
+            },
+            "y": {
+                "type": "number",
+                "description": "Y value of the coordinate."
+            },
+            "z": {
+                "type": "number",
+                "description": "Z value of the coordinate."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "x",
+            "y",
+            "z"
+        ]
+    },
+    "3DDimensions": {
+        "type": "object",
+        "description": "Dimensions in 3D.",
+        "properties": {
+            "x": {
+                "type": "number",
+                "description": "X dimension."
+            },
+            "y": {
+                "type": "number",
+                "description": "Y dimension."
+            },
+            "z": {
+                "type": "number",
+                "description": "Z dimension."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "x",
+            "y",
+            "z"
+        ]
+    },
+    "Error": {
+        "type": "object",
+        "description": "The details of an error.",
+        "properties": {
+            "code": {
+                "type": "integer",
+                "description": "The code of the error."
+            },
+            "message": {
+                "type": "string",
+                "description": "The error message."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "code",
+            "message"
+        ]
+    },
+    "ErrorItem": {
+        "type": "object",
+        "properties": {
+            "error": {
+                "$ref": "#/Error"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "error" ]
+    },
+    "SuccessfulExecutionResult": {
+        "type": "object",
+        "description": "The result of a successful execution.",
+        "properties": {
+            "success": {
+                "type": "boolean",
+                "enum": [ true ]
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "success"
+        ]
+    },
+    "FailedExecutionResult": {
+        "type": "object",
+        "description": "The result of a failed execution.",
+        "properties": {
+            "success": {
+                "type": "boolean",
+                "enum": [ false ]
+            },
+            "error": {
+                "$ref": "#/Error",
+                "description": "The details of an execution failure."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "success",
+            "error"
+        ]
+    },
+    "ExecutionResult": {
+        "type": "object",
+        "description": "The result of the execution.",
+        "oneOf": [
+            {
+                "$ref": "#/SuccessfulExecutionResult"
+            },
+            {
+                "$ref": "#/FailedExecutionResult"
+            }
+        ]
+    },
+    "ExecutionResults": {
+        "type": "array",
+        "description": "A list of execution results.",
         "items": {
-          "$ref": "#/GDLParameterDetails"
+            "$ref": "#/ExecutionResult"
         }
-      }
     },
-    "required": [
-      "parameters"
-    ]
-  },
-  "GDLParameterDetails": {
-    "type": "object",
-    "description": "Details of a GDL parameter.",
-    "properties": {
-      "name": {
+    "ElementType": {
         "type": "string",
-        "description": "The name of the parameter."
-      },
-      "index": {
+        "description": "The type of an element.",
+        "enum": [
+            "Wall",
+            "Column",
+            "Beam",
+            "Window",
+            "Door",
+            "Object",
+            "Lamp",
+            "Slab",
+            "Roof",
+            "Mesh",
+            "Dimension",
+            "RadialDimension",
+            "LevelDimension",
+            "AngleDimension",
+            "Text",
+            "Label",
+            "Zone",
+            "Hatch",
+            "Line",
+            "PolyLine",
+            "Arc",
+            "Circle",
+            "Spline",
+            "Hotspot",
+            "CutPlane",
+            "Camera",
+            "CamSet",
+            "Group",
+            "SectElem",
+            "Drawing",
+            "Picture",
+            "Detail",
+            "Elevation",
+            "InteriorElevation",
+            "Worksheet",
+            "Hotlink",
+            "CurtainWall",
+            "CurtainWallSegment",
+            "CurtainWallFrame",
+            "CurtainWallPanel",
+            "CurtainWallJunction",
+            "CurtainWallAccessory",
+            "Shell",
+            "Skylight",
+            "Morph",
+            "ChangeMarker",
+            "Stair",
+            "Riser",
+            "Tread",
+            "StairStructure",
+            "Railing",
+            "RailingToprail",
+            "RailingHandrail",
+            "RailingRail",
+            "RailingPost",
+            "RailingInnerPost",
+            "RailingBaluster",
+            "RailingPanel",
+            "RailingSegment",
+            "RailingNode",
+            "RailingBalusterSet",
+            "RailingPattern",
+            "RailingToprailEnd",
+            "RailingHandrailEnd",
+            "RailingRailEnd",
+            "RailingToprailConnection",
+            "RailingHandrailConnection",
+            "RailingRailConnection",
+            "RailingEndFinish",
+            "BeamSegment",
+            "ColumnSegment",
+            "Opening",
+            "Unknown"
+        ]
+    },
+    "ElementFilter": {
         "type": "string",
-        "description": "The index of the parameter."
-      },
-      "type": {
+        "description": "A filter type for an element.",
+        "enum": [
+            "IsEditable",
+            "IsVisibleByLayer",
+            "IsVisibleByRenovation",
+            "IsVisibleByStructureDisplay",
+            "IsVisibleIn3D",
+            "OnActualFloor",
+            "OnActualLayout",
+            "InMyWorkspace",
+            "IsIndependent",
+            "InCroppedView",
+            "HasAccessRight",
+            "IsOverriddenByRenovation"
+        ]
+    },
+    "WindowType": {
         "type": "string",
-        "description": "The type of the parameter."
-      },
-      "dimension1": {
-        "type": "number",
-        "description": "The 1st dimension of array (in case of array value)."
-      },
-      "dimension2": {
-        "type": "number",
-        "description": "The 2nd dimension of array (in case of array value)."
-      },
-      "value": {
-        "description": "The value of the parameter."
-      }
+        "description": "The type of a window.",
+        "enum": [
+            "FloorPlan",
+            "Section",
+            "Details",
+            "3DModel",
+            "Layout",
+            "Drawing",
+            "CustomText",
+            "CustomDraw",
+            "MasterLayout",
+            "Elevation",
+            "InteriorElevation",
+            "Worksheet",
+            "Report",
+            "3DDocument",
+            "External3D",
+            "Movie3D",
+            "MovieRendering",
+            "Rendering",
+            "ModelCompare",
+            "Interactive Schedule",
+            "Unknown"
+        ]
     },
-    "additionalProperties": true,
-    "required": [
-      "index",
-      "type",
-      "value"
-    ]
-  },
-  "2DCoordinate": {
-    "type": "object",
-    "description": "2D coordinate.",
-    "properties": {
-      "x": {
-        "type": "number",
-        "description": "X value of the coordinate."
-      },
-      "y": {
-        "type": "number",
-        "description": "Y value of the coordinate."
-      }
+    "IssueId": {
+        "type": "object",
+        "description": "The identifier of an issue.",
+        "properties": {
+            "guid": {
+                "$ref": "#/Guid"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "guid"
+        ]
     },
-    "additionalProperties": false,
-    "required": [
-      "x",
-      "y"
-    ]
-  },
-  "3DCoordinate": {
-    "type": "object",
-    "description": "3D coordinate.",
-    "properties": {
-      "x": {
-        "type": "number",
-        "description": "X value of the coordinate."
-      },
-      "y": {
-        "type": "number",
-        "description": "Y value of the coordinate."
-      },
-      "z": {
-        "type": "number",
-        "description": "Z value of the coordinate."
-      }
+    "IssueIdArrayItem": {
+        "type": "object",
+        "properties": {
+            "issueId": {
+                "$ref": "#/IssueId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "issueId"
+        ]
     },
-    "additionalProperties": false,
-    "required": [
-      "x",
-      "y",
-      "z"
-    ]
-  },
-  "3DDimensions": {
-    "type": "object",
-    "description": "Dimensions in 3D.",
-    "properties": {
-      "x": {
-        "type": "number",
-        "description": "X dimension."
-      },
-      "y": {
-        "type": "number",
-        "description": "Y dimension."
-      },
-      "z": {
-        "type": "number",
-        "description": "Z dimension."
-      }
+    "Issues": {
+        "type": "array",
+        "description": "A list of Issues.",
+        "items": {
+            "$ref": "#/IssueIdArrayItem"
+        }
     },
-    "additionalProperties": false,
-    "required": [
-      "x",
-      "y",
-      "z"
-    ]
-  },
-  "Error": {
-    "type": "object",
-    "description": "The details of an error.",
-    "properties": {
-      "code": {
-        "type": "integer",
-        "description": "The code of the error."
-      },
-      "message": {
+    "IssueElementType": {
         "type": "string",
-        "description": "The error message."
-      }
+        "description": "The attachment type of an element component of an issue.",
+        "enum": [
+            "Creation",
+            "Highlight",
+            "Deletion",
+            "Modification"
+        ]
     },
-    "additionalProperties": false,
-    "required": [
-      "code",
-      "message"
-    ]
-  },
-  "ErrorItem": {
-    "type": "object",
-    "properties": {
-      "error": {
-        "$ref": "#/Error"
-      }
+    "IssueCommentStatus": {
+        "type": "string",
+        "description": "The status of an issue comment.",
+        "enum": [
+            "Error",
+            "Warning",
+            "Info",
+            "Unknown"
+        ]
     },
-    "additionalProperties": false,
-    "required": [ "error" ]
-  },
-  "SuccessfulExecutionResult": {
-    "type": "object",
-    "description": "The result of a successful execution.",
-    "properties": {
-      "success": {
-        "type": "boolean",
-        "enum": [ true ]
-      }
+    "PropertyId": {
+        "type": "object",
+        "description": "The identifier of a property.",
+        "properties": {
+            "guid": {
+                "$ref": "#/Guid"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "guid"
+        ]
     },
-    "additionalProperties": false,
-    "required": [
-      "success"
-    ]
-  },
-  "FailedExecutionResult": {
-    "type": "object",
-    "description": "The result of a failed execution.",
-    "properties": {
-      "success": {
-        "type": "boolean",
-        "enum": [ false ]
-      },
-      "error": {
-        "$ref": "#/Error",
-        "description": "The details of an execution failure."
-      }
+    "PropertyGroupId": {
+        "type": "object",
+        "description": "The identifier of a property group.",
+        "properties": {
+            "guid": {
+                "$ref": "#/Guid"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "guid"
+        ]
     },
-    "additionalProperties": false,
-    "required": [
-      "success",
-      "error"
-    ]
-  },
-  "ExecutionResult": {
-    "type": "object",
-    "description": "The result of the execution.",
-    "oneOf": [
-      {
-        "$ref": "#/SuccessfulExecutionResult"
-      },
-      {
-        "$ref": "#/FailedExecutionResult"
-      }
-    ]
-  },
-  "ExecutionResults": {
-    "type": "array",
-    "description": "A list of execution results.",
-    "items": {
-      "$ref": "#/ExecutionResult"
-    }
-  },
-  "ElementType": {
-    "type": "string",
-    "description": "The type of an element.",
-    "enum": [
-      "Wall",
-      "Column",
-      "Beam",
-      "Window",
-      "Door",
-      "Object",
-      "Lamp",
-      "Slab",
-      "Roof",
-      "Mesh",
-      "Dimension",
-      "RadialDimension",
-      "LevelDimension",
-      "AngleDimension",
-      "Text",
-      "Label",
-      "Zone",
-      "Hatch",
-      "Line",
-      "PolyLine",
-      "Arc",
-      "Circle",
-      "Spline",
-      "Hotspot",
-      "CutPlane",
-      "Camera",
-      "CamSet",
-      "Group",
-      "SectElem",
-      "Drawing",
-      "Picture",
-      "Detail",
-      "Elevation",
-      "InteriorElevation",
-      "Worksheet",
-      "Hotlink",
-      "CurtainWall",
-      "CurtainWallSegment",
-      "CurtainWallFrame",
-      "CurtainWallPanel",
-      "CurtainWallJunction",
-      "CurtainWallAccessory",
-      "Shell",
-      "Skylight",
-      "Morph",
-      "ChangeMarker",
-      "Stair",
-      "Riser",
-      "Tread",
-      "StairStructure",
-      "Railing",
-      "RailingToprail",
-      "RailingHandrail",
-      "RailingRail",
-      "RailingPost",
-      "RailingInnerPost",
-      "RailingBaluster",
-      "RailingPanel",
-      "RailingSegment",
-      "RailingNode",
-      "RailingBalusterSet",
-      "RailingPattern",
-      "RailingToprailEnd",
-      "RailingHandrailEnd",
-      "RailingRailEnd",
-      "RailingToprailConnection",
-      "RailingHandrailConnection",
-      "RailingRailConnection",
-      "RailingEndFinish",
-      "BeamSegment",
-      "ColumnSegment",
-      "Opening",
-      "Unknown"
-    ]
-  },
-  "ElementFilter": {
-    "type": "string",
-    "description": "A filter type for an element.",
-    "enum": [
-      "IsEditable",
-      "IsVisibleByLayer",
-      "IsVisibleByRenovation",
-      "IsVisibleByStructureDisplay",
-      "IsVisibleIn3D",
-      "OnActualFloor",
-      "OnActualLayout",
-      "InMyWorkspace",
-      "IsIndependent",
-      "InCroppedView",
-      "HasAccessRight",
-      "IsOverriddenByRenovation"
-    ]
-  },
-  "WindowType": {
-    "type": "string",
-    "description": "The type of a window.",
-    "enum": [
-      "FloorPlan",
-      "Section",
-      "Details",
-      "3DModel",
-      "Layout",
-      "Drawing",
-      "CustomText",
-      "CustomDraw",
-      "MasterLayout",
-      "Elevation",
-      "InteriorElevation",
-      "Worksheet",
-      "Report",
-      "3DDocument",
-      "External3D",
-      "Movie3D",
-      "MovieRendering",
-      "Rendering",
-      "ModelCompare",
-      "Interactive Schedule",
-      "Unknown"
-    ]
-  },
-  "IssueId": {
-    "type": "object",
-    "description": "The identifier of an issue.",
-    "properties": {
-      "guid": {
-        "$ref": "#/Guid"
-      }
+    "PropertyIdArrayItem": {
+        "type": "object",
+        "properties": {
+            "propertyId": {
+                "$ref": "#/PropertyId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "propertyId"
+        ]
     },
-    "additionalProperties": false,
-    "required": [
-      "guid"
-    ]
-  },
-  "IssueIdArrayItem": {
-    "type": "object",
-    "properties": {
-      "issueId": {
-        "$ref": "#/IssueId"
-      }
+    "PropertyIds": {
+        "type": "array",
+        "description": "A list of property identifiers.",
+        "items": {
+            "$ref": "#/PropertyIdArrayItem"
+        }
     },
-    "additionalProperties": false,
-    "required": [
-      "issueId"
-    ]
-  },
-  "Issues": {
-    "type": "array",
-    "description": "A list of Issues.",
-    "items": {
-      "$ref": "#/IssueIdArrayItem"
-    }
-  },
-  "IssueElementType": {
-    "type": "string",
-    "description": "The attachment type of an element component of an issue.",
-    "enum": [
-      "Creation",
-      "Highlight",
-      "Deletion",
-      "Modification"
-    ]
-  },
-  "IssueCommentStatus": {
-    "type": "string",
-    "description": "The status of an issue comment.",
-    "enum": [
-      "Error",
-      "Warning",
-      "Info",
-      "Unknown"
-    ]
-  },
-  "PropertyId": {
-    "type": "object",
-    "description": "The identifier of a property.",
-    "properties": {
-      "guid": {
-        "$ref": "#/Guid"
-      }
+    "PropertyDetails": {
+        "type": "object",
+        "description": "The details of the property.",
+        "properties": {
+            "propertyId": {
+                "$ref": "#/PropertyId"
+            },
+            "propertyType": {
+                "type": "string",
+                "enum": [
+                    "StaticBuiltIn",
+                    "DynamicBuiltIn",
+                    "Custom"
+                ]
+            },
+            "propertyGroupName": {
+                "type": "string"
+            },
+            "propertyName": {
+                "type": "string"
+            },
+            "propertyCollectionType": {
+                "type": "string",
+                "enum": [
+                    "Undefined",
+                    "Single",
+                    "List",
+                    "SingleChoiceEnumeration",
+                    "MultipleChoiceEnumeration"
+                ]
+            },
+            "propertyValueType": {
+                "type": "string",
+                "enum": [
+                    "Undefined",
+                    "Integer",
+                    "Real",
+                    "String",
+                    "Boolean",
+                    "Guid"
+                ]
+            },
+            "propertyMeasureType": {
+                "type": "string",
+                "enum": [
+                    "Undefined",
+                    "Default",
+                    "Length",
+                    "Area",
+                    "Volume",
+                    "Angle"
+                ]
+            },
+            "propertyIsEditable": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "propertyId",
+            "propertyType",
+            "propertyGroupName",
+            "propertyName",
+            "propertyCollectionType",
+            "propertyValueType",
+            "propertyMeasureType",
+            "propertyIsEditable"
+        ]
     },
-    "additionalProperties": false,
-    "required": [
-      "guid"
-    ]
-  },
-  "PropertyGroupId": {
-    "type": "object",
-    "description": "The identifier of a property group.",
-    "properties": {
-      "guid": {
-        "$ref": "#/Guid"
-      }
+    "PropertyValue": {
+        "type": "object",
+        "description": "The display string value of a property.",
+        "properties": {
+            "value": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": true,
+        "required": [
+            "value"
+        ]
     },
-    "additionalProperties": false,
-    "required": [
-      "guid"
-    ]
-  },
-  "PropertyIdArrayItem": {
-    "type": "object",
-    "properties": {
-      "propertyId": {
-        "$ref": "#/PropertyId"
-      }
+    "PropertyValueOrErrorItem": {
+        "type": "object",
+        "description": "A property value or an error",
+        "oneOf": [
+            {
+                "title": "propertyValue",
+                "properties": {
+                    "propertyValue": {
+                        "$ref": "#/PropertyValue"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [ "propertyValue" ]
+            },
+            {
+                "title": "error",
+                "$ref": "#/ErrorItem"
+            }
+        ]
     },
-    "additionalProperties": false,
-    "required": [
-      "propertyId"
-    ]
-  },
-  "PropertyIds": {
-    "type": "array",
-    "description": "A list of property identifiers.",
-    "items": {
-      "$ref": "#/PropertyIdArrayItem"
-    }
-  },
-  "PropertyDetails": {
-    "type": "object",
-    "description": "The details of the property.",
-    "properties": {
-      "propertyId": {
-        "$ref": "#/PropertyId"
-      },
-      "propertyType": {
+    "PropertyValues": {
+        "type": "array",
+        "description": "A list of property values.",
+        "items": {
+            "$ref": "#/PropertyValueOrErrorItem"
+        }
+    },
+    "PropertyValuesOrError": {
+        "type": "object",
+        "description": "A list of property values or an error.",
+        "oneOf": [
+            {
+                "title": "propertyValues",
+                "properties": {
+                    "propertyValues": {
+                        "$ref": "#/PropertyValues"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [ "propertyValues" ]
+            },
+            {
+                "title": "error",
+                "$ref": "#/ErrorItem"
+            }
+        ]
+    },
+    "PropertyValuesOrErrorArray": {
+        "type": "array",
+        "description": "A list of property value lists.",
+        "items": {
+            "$ref": "#/PropertyValuesOrError"
+        }
+    },
+    "PropertyIdOrError": {
+        "type": "object",
+        "description": "A propertyId or an error.",
+        "oneOf": [
+            {
+                "properties": {
+                    "propertyId": {
+                        "$ref": "#/PropertyId"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [ "propertyId" ]
+            },
+            {
+                "$ref": "#/ErrorItem"
+            }
+        ]
+    },
+    "PropertyIdOrErrorArray": {
+        "type": "array",
+        "description": "A list of property identifiers.",
+        "items": {
+            "$ref": "#/PropertyIdOrError"
+        }
+    },
+    "ElementPropertyValue": {
+        "type": "object",
+        "description": "A property value with the identifiers of the property and its owner element.",
+        "properties": {
+            "elementId": {
+                "$ref": "#/ElementId"
+            },
+            "propertyId": {
+                "$ref": "#/PropertyId"
+            },
+            "propertyValue": {
+                "$ref": "#/PropertyValue"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "elementId",
+            "propertyId",
+            "propertyValue"
+        ]
+    },
+    "ElementPropertyValues": {
+        "type": "array",
+        "description": "A list of element property values.",
+        "items": {
+            "$ref": "#/ElementPropertyValue"
+        }
+    },
+    "PropertyType": {
         "type": "string",
         "enum": [
-          "StaticBuiltIn",
-          "DynamicBuiltIn",
-          "Custom"
+            "number",
+            "integer",
+            "string",
+            "boolean",
+            "length",
+            "area",
+            "volume",
+            "angle",
+            "numberList",
+            "integerList",
+            "stringList",
+            "booleanList",
+            "lengthList",
+            "areaList",
+            "volumeList",
+            "angleList",
+            "singleEnum",
+            "multiEnum"
         ]
-      },
-      "propertyGroupName": {
-        "type": "string"
-      },
-      "propertyName": {
-        "type": "string"
-      },
-      "propertyCollectionType": {
-        "type": "string",
-        "enum": [
-          "Undefined",
-          "Single",
-          "List",
-          "SingleChoiceEnumeration",
-          "MultipleChoiceEnumeration"
+    },
+    "DisplayValueEnumId": {
+        "type": "object",
+        "description": "An enumeration value identifier using the displayed value.",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "displayValue" ]
+            },
+            "displayValue": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "type",
+            "displayValue"
         ]
-      },
-      "propertyValueType": {
-        "type": "string",
-        "enum": [
-          "Undefined",
-          "Integer",
-          "Real",
-          "String",
-          "Boolean",
-          "Guid"
+    },
+    "NonLocalizedValueEnumId": {
+        "type": "object",
+        "description": "An enumeration value identifier using the nonlocalized value.",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "nonLocalizedValue" ]
+            },
+            "nonLocalizedValue": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "type",
+            "nonLocalizedValue"
         ]
-      },
-      "propertyMeasureType": {
-        "type": "string",
-        "enum": [
-          "Undefined",
-          "Default",
-          "Length",
-          "Area",
-          "Volume",
-          "Angle"
+    },
+    "EnumValueId": {
+        "type": "object",
+        "description": "The identifier of a property enumeration value.",
+        "oneOf": [
+            {
+                "$ref": "#/DisplayValueEnumId"
+            },
+            {
+                "$ref": "#/NonLocalizedValueEnumId"
+            }
         ]
-      },
-      "propertyIsEditable": {
-        "type": "boolean"
-      }
     },
-    "additionalProperties": false,
-    "required": [
-      "propertyId",
-      "propertyType",
-      "propertyGroupName",
-      "propertyName",
-      "propertyCollectionType",
-      "propertyValueType",
-      "propertyMeasureType",
-      "propertyIsEditable"
-    ]
-  },
-  "PropertyValue": {
-    "type": "object",
-    "description": "The display string value of a property.",
-    "properties": {
-      "value": {
-        "type": "string"
-      }
+    "EnumValueIds": {
+        "type": "array",
+        "description": "A list of enumeration identifiers.",
+        "items": {
+            "type": "object",
+            "properties": {
+                "enumValueId": {
+                    "$ref": "#/EnumValueId"
+                }
+            },
+            "additionalProperties": false,
+            "required": [ "enumValueId" ]
+        }
     },
-    "additionalProperties": true,
-    "required": [
-      "value"
-    ]
-  },
-  "PropertyValueOrErrorItem": {
-    "type": "object",
-    "description": "A property value or an error",
-    "oneOf": [
-      {
-        "title": "propertyValue",
+    "NormalOrUserUndefinedPropertyValue": {
+        "type": "object",
+        "description": "A normal or a userUndefined property value.",
+        "oneOf": [
+            {
+                "$ref": "#/NormalNumberPropertyValue"
+            },
+            {
+                "$ref": "#/NormalIntegerPropertyValue"
+            },
+            {
+                "$ref": "#/NormalStringPropertyValue"
+            },
+            {
+                "$ref": "#/NormalBooleanPropertyValue"
+            },
+            {
+                "$ref": "#/NormalLengthPropertyValue"
+            },
+            {
+                "$ref": "#/NormalAreaPropertyValue"
+            },
+            {
+                "$ref": "#/NormalVolumePropertyValue"
+            },
+            {
+                "$ref": "#/NormalAnglePropertyValue"
+            },
+            {
+                "$ref": "#/NormalNumberListPropertyValue"
+            },
+            {
+                "$ref": "#/NormalIntegerListPropertyValue"
+            },
+            {
+                "$ref": "#/NormalStringListPropertyValue"
+            },
+            {
+                "$ref": "#/NormalBooleanListPropertyValue"
+            },
+            {
+                "$ref": "#/NormalLengthListPropertyValue"
+            },
+            {
+                "$ref": "#/NormalAreaListPropertyValue"
+            },
+            {
+                "$ref": "#/NormalVolumeListPropertyValue"
+            },
+            {
+                "$ref": "#/NormalAngleListPropertyValue"
+            },
+            {
+                "$ref": "#/NormalSingleEnumPropertyValue"
+            },
+            {
+                "$ref": "#/NormalMultiEnumPropertyValue"
+            },
+            {
+                "$ref": "#/UserUndefinedPropertyValue"
+            }
+        ]
+    },
+    "PropertyValueDetails": {
+        "type": "object",
+        "description": "A normal, userUndefined, notAvailable or notEvaluated property value.",
+        "oneOf": [
+            {
+                "$ref": "#/NormalOrUserUndefinedPropertyValue"
+            },
+            {
+                "$ref": "#/NotAvailablePropertyValue"
+            }
+        ]
+    },
+    "UserUndefinedPropertyValue": {
+        "type": "object",
+        "description": "A userUndefined value means that there is no actual number/string/etc. value, but the user deliberately set an Undefined value: this is a valid value, too.",
         "properties": {
-          "propertyValue": {
-            "$ref": "#/PropertyValue"
-          }
+            "type": {
+                "$ref": "#/PropertyType"
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "userUndefined" ]
+            }
         },
         "additionalProperties": false,
-        "required": [ "propertyValue" ]
-      },
-      {
-        "title": "error",
-        "$ref": "#/ErrorItem"
-      }
-    ]
-  },
-  "PropertyValues": {
-    "type": "array",
-    "description": "A list of property values.",
-    "items": {
-      "$ref": "#/PropertyValueOrErrorItem"
-    }
-  },
-  "PropertyValuesOrError": {
-    "type": "object",
-    "description": "A list of property values or an error.",
-    "oneOf": [
-      {
-        "title": "propertyValues",
+        "required": [ "type", "status" ]
+    },
+    "NotAvailablePropertyValue": {
+        "type": "object",
+        "description": "A notAvailable value means that the property is not available for the property owner (and therefore it has no property value for it).",
         "properties": {
-          "propertyValues": {
-            "$ref": "#/PropertyValues"
-          }
+            "type": {
+                "$ref": "#/PropertyType"
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "notAvailable" ]
+            }
         },
         "additionalProperties": false,
-        "required": [ "propertyValues" ]
-      },
-      {
-        "title": "error",
-        "$ref": "#/ErrorItem"
-      }
-    ]
-  },
-  "PropertyValuesOrErrorArray": {
-    "type": "array",
-    "description": "A list of property value lists.",
-    "items": {
-      "$ref": "#/PropertyValuesOrError"
-    }
-  },
-  "PropertyIdOrError": {
-    "type": "object",
-    "description": "A propertyId or an error.",
-    "oneOf": [
-      {
+        "required": [
+            "type",
+            "status"
+        ]
+    },
+    "NormalNumberPropertyValue": {
+        "type": "object",
+        "description": "A number property value containing a valid numeric value.",
         "properties": {
-          "propertyId": {
-            "$ref": "#/PropertyId"
-          }
+            "type": {
+                "type": "string",
+                "enum": [ "number" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "number"
+            }
         },
         "additionalProperties": false,
-        "required": [ "propertyId" ]
-      },
-      {
-        "$ref": "#/ErrorItem"
-      }
-    ]
-  },
-  "PropertyIdOrErrorArray": {
-    "type": "array",
-    "description": "A list of property identifiers.",
-    "items": {
-      "$ref": "#/PropertyIdOrError"
-    }
-  },
-  "ElementPropertyValue": {
-    "type": "object",
-    "description": "A property value with the identifiers of the property and its owner element.",
-    "properties": {
-      "elementId": {
-        "$ref": "#/ElementId"
-      },
-      "propertyId": {
-        "$ref": "#/PropertyId"
-      },
-      "propertyValue": {
-        "$ref": "#/PropertyValue"
-      }
+        "required": [ "type", "status", "value" ]
     },
-    "additionalProperties": false,
-    "required": [
-      "elementId",
-      "propertyId",
-      "propertyValue"
-    ]
-  },
-  "ElementPropertyValues": {
-    "type": "array",
-    "description": "A list of element property values.",
-    "items": {
-      "$ref": "#/ElementPropertyValue"
-    }
-  },
-  "PropertyType": {
-    "type": "string",
-    "enum": [
-      "number",
-      "integer",
-      "string",
-      "boolean",
-      "length",
-      "area",
-      "volume",
-      "angle",
-      "numberList",
-      "integerList",
-      "stringList",
-      "booleanList",
-      "lengthList",
-      "areaList",
-      "volumeList",
-      "angleList",
-      "singleEnum",
-      "multiEnum"
-    ]
-  },
-  "DisplayValueEnumId": {
-    "type": "object",
-    "description": "An enumeration value identifier using the displayed value.",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "displayValue" ]
-      },
-      "displayValue": {
-        "type": "string"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "type",
-      "displayValue"
-    ]
-  },
-  "NonLocalizedValueEnumId": {
-    "type": "object",
-    "description": "An enumeration value identifier using the nonlocalized value.",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "nonLocalizedValue" ]
-      },
-      "nonLocalizedValue": {
-        "type": "string"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "type",
-      "nonLocalizedValue"
-    ]
-  },
-  "EnumValueId": {
-    "type": "object",
-    "description": "The identifier of a property enumeration value.",
-    "oneOf": [
-      {
-        "$ref": "#/DisplayValueEnumId"
-      },
-      {
-        "$ref": "#/NonLocalizedValueEnumId"
-      }
-    ]
-  },
-  "EnumValueIds": {
-    "type": "array",
-    "description": "A list of enumeration identifiers.",
-    "items": {
-      "type": "object",
-      "properties": {
-        "enumValueId": {
-          "$ref": "#/EnumValueId"
-        }
-      },
-      "additionalProperties": false,
-      "required": [ "enumValueId" ]
-    }
-  },
-  "NormalOrUserUndefinedPropertyValue": {
-    "type": "object",
-    "description": "A normal or a userUndefined property value.",
-    "oneOf": [
-      {
-        "$ref": "#/NormalNumberPropertyValue"
-      },
-      {
-        "$ref": "#/NormalIntegerPropertyValue"
-      },
-      {
-        "$ref": "#/NormalStringPropertyValue"
-      },
-      {
-        "$ref": "#/NormalBooleanPropertyValue"
-      },
-      {
-        "$ref": "#/NormalLengthPropertyValue"
-      },
-      {
-        "$ref": "#/NormalAreaPropertyValue"
-      },
-      {
-        "$ref": "#/NormalVolumePropertyValue"
-      },
-      {
-        "$ref": "#/NormalAnglePropertyValue"
-      },
-      {
-        "$ref": "#/NormalNumberListPropertyValue"
-      },
-      {
-        "$ref": "#/NormalIntegerListPropertyValue"
-      },
-      {
-        "$ref": "#/NormalStringListPropertyValue"
-      },
-      {
-        "$ref": "#/NormalBooleanListPropertyValue"
-      },
-      {
-        "$ref": "#/NormalLengthListPropertyValue"
-      },
-      {
-        "$ref": "#/NormalAreaListPropertyValue"
-      },
-      {
-        "$ref": "#/NormalVolumeListPropertyValue"
-      },
-      {
-        "$ref": "#/NormalAngleListPropertyValue"
-      },
-      {
-        "$ref": "#/NormalSingleEnumPropertyValue"
-      },
-      {
-        "$ref": "#/NormalMultiEnumPropertyValue"
-      },
-      {
-        "$ref": "#/UserUndefinedPropertyValue"
-      }
-    ]
-  },
-  "PropertyValueDetails": {
-    "type": "object",
-    "description": "A normal, userUndefined, notAvailable or notEvaluated property value.",
-    "oneOf": [
-      {
-        "$ref": "#/NormalOrUserUndefinedPropertyValue"
-      },
-      {
-        "$ref": "#/NotAvailablePropertyValue"
-      }
-    ]
-  },
-  "UserUndefinedPropertyValue": {
-    "type": "object",
-    "description": "A userUndefined value means that there is no actual number/string/etc. value, but the user deliberately set an Undefined value: this is a valid value, too.",
-    "properties": {
-      "type": {
-        "$ref": "#/PropertyType"
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "userUndefined" ]
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status" ]
-  },
-  "NotAvailablePropertyValue": {
-    "type": "object",
-    "description": "A notAvailable value means that the property is not available for the property owner (and therefore it has no property value for it).",
-    "properties": {
-      "type": {
-        "$ref": "#/PropertyType"
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "notAvailable" ]
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "type",
-      "status"
-    ]
-  },
-  "NormalNumberPropertyValue": {
-    "type": "object",
-    "description": "A number property value containing a valid numeric value.",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "number" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "number"
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalIntegerPropertyValue": {
-    "type": "object",
-    "description": "An integer property value containing a valid integer number.",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "integer" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "integer"
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalStringPropertyValue": {
-    "type": "object",
-    "description": "A string property value containing a valid string.",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "string" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "string"
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalBooleanPropertyValue": {
-    "type": "object",
-    "description": "A boolean property value containing a valid boolean value.",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "boolean" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "boolean"
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalLengthPropertyValue": {
-    "type": "object",
-    "description": "A length property value containing a real length value. The value is measured in SI (meters).",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "length" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "number"
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalAreaPropertyValue": {
-    "type": "object",
-    "description": "An area property value containing a real area. The value is measured in SI (square meters).",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "area" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "number"
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalVolumePropertyValue": {
-    "type": "object",
-    "description": "A volume property value containing a real volume. The value is measured in SI (cubic meters).",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "volume" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "number"
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalAnglePropertyValue": {
-    "type": "object",
-    "description": "An angle property value containing a real angle. The value is measured in SI (radians).",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "angle" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "number"
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalNumberListPropertyValue": {
-    "type": "object",
-    "description": "A number list property value containing numbers in an array.",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "numberList" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "array",
-        "items": {
-          "type": "number"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalIntegerListPropertyValue": {
-    "type": "object",
-    "description": "An integer list property value containing integers in an array.",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "integerList" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "array",
-        "items": {
-          "type": "integer"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalStringListPropertyValue": {
-    "type": "object",
-    "description": "A string list property value containing strings in an array.",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "stringList" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalBooleanListPropertyValue": {
-    "type": "object",
-    "description": "A boolean list property value containing boolean values in an array.",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "booleanList" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "array",
-        "items": {
-          "type": "boolean"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalLengthListPropertyValue": {
-    "type": "object",
-    "description": "A length list property value containing length values in an array. The values are measured in SI (meters).",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "lengthList" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "array",
-        "items": {
-          "type": "number"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalAreaListPropertyValue": {
-    "type": "object",
-    "description": "An area list property value containing areas in an array. The values are measured in SI (square meters).",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "areaList" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "array",
-        "items": {
-          "type": "number"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalVolumeListPropertyValue": {
-    "type": "object",
-    "description": "A volume list property value containing volumes in an array. The values are measured in SI (cubic meters).",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "volumeList" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "array",
-        "items": {
-          "type": "number"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalAngleListPropertyValue": {
-    "type": "object",
-    "description": "An angle list property value containing angles in an array. The values are measured in SI (radians).",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "angleList" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "type": "array",
-        "items": {
-          "type": "number"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalSingleEnumPropertyValue": {
-    "type": "object",
-    "description": "A single enumeration property value containing the ID of the selected enum value.",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "singleEnum" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "$ref": "#/EnumValueId"
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "NormalMultiEnumPropertyValue": {
-    "type": "object",
-    "description": "A multiple choice enumeration property value containing the IDs of the selected enum values in an array.",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [ "multiEnum" ]
-      },
-      "status": {
-        "type": "string",
-        "enum": [ "normal" ]
-      },
-      "value": {
-        "$ref": "#/EnumValueIds"
-      }
-    },
-    "additionalProperties": false,
-    "required": [ "type", "status", "value" ]
-  },
-  "BasicDefaultValue": {
-    "type": "object",
-    "description": "Default value of the property in case of a basic property value (ie. not an expression).",
-    "properties": {
-      "basicDefaultValue": {
-        "$ref": "#/PropertyValueDetails"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "basicDefaultValue"
-    ]
-  },
-  "ExpressionDefaultValue": {
-    "type": "object",
-    "description": "Default value of the property in case of an expression based property value.",
-    "properties": {
-      "expressions": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "expressions"
-    ]
-  },
-  "PropertyDefaultValue": {
-    "type": "object",
-    "oneOf": [
-      {
-        "$ref": "#/BasicDefaultValue"
-      },
-      {
-        "$ref": "#/ExpressionDefaultValue"
-      }
-    ]
-  },
-  "ClassificationSystemId": {
-    "type": "object",
-    "description": "The identifier of a classification system.",
-    "properties": {
-      "guid": {
-        "$ref": "#/Guid"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "guid"
-    ]
-  },
-  "ClassificationSystemIdArrayItem": {
-    "type": "object",
-    "properties": {
-      "classificationSystemId": {
-        "$ref": "#/ClassificationSystemId"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "classificationSystemId"
-    ]
-  },
-  "ClassificationSystemIds": {
-    "type": "array",
-    "description": "A list of classification system identifiers.",
-    "items": {
-      "$ref": "#/ClassificationSystemIdArrayItem"
-    }
-  },
-  "ClassificationItemId": {
-    "type": "object",
-    "description": "The identifier of a classification item.",
-    "properties": {
-      "guid": {
-        "$ref": "#/Guid"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "guid"
-    ]
-  },
-  "ClassificationItemIdArrayItem": {
-    "type": "object",
-    "properties": {
-      "classificationItemId": {
-        "$ref": "#/ClassificationItemId"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "classificationItemId"
-    ]
-  },
-  "ClassificationId": {
-    "type": "object",
-    "description": "The element classification identifier.",
-    "properties": {
-      "classificationSystemId": {
-        "$ref": "#/ClassificationSystemId"
-      },
-      "classificationItemId": {
-        "$ref": "#/ClassificationItemId",
-        "description": "The element's classification in the given system. If no value is specified here, the element is Unclassified in this system."
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "classificationSystemId"
-    ]
-  },
-  "ClassificationIdOrError": {
-    "type": "object",
-    "description": "A classification identifier or an error.",
-    "oneOf": [
-      {
-        "title": "classificationId",
+    "NormalIntegerPropertyValue": {
+        "type": "object",
+        "description": "An integer property value containing a valid integer number.",
         "properties": {
-          "classificationId": {
-            "$ref": "#/ClassificationId"
-          }
+            "type": {
+                "type": "string",
+                "enum": [ "integer" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "integer"
+            }
         },
         "additionalProperties": false,
-        "required": [ "classificationId" ]
-      },
-      {
-        "title": "error",
-        "$ref": "#/ErrorItem"
-      }
-    ]
-  },
-  "ClassificationIdsOrErrors": {
-    "type": "array",
-    "description": "A list of element classification identifiers or errors.",
-    "items": {
-      "$ref": "#/ClassificationIdOrError"
-    }
-  },
-  "ElementClassificationOrError": {
-    "type": "object",
-    "description": "Element classification identifiers or errors.",
-    "oneOf": [
-      {
-        "title": "classificationIds",
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalStringPropertyValue": {
+        "type": "object",
+        "description": "A string property value containing a valid string.",
         "properties": {
-          "classificationIds": {
-            "$ref": "#/ClassificationIdsOrErrors"
-          }
+            "type": {
+                "type": "string",
+                "enum": [ "string" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "string"
+            }
         },
         "additionalProperties": false,
-        "required": [ "classificationIds" ]
-      },
-      {
-        "title": "error",
-        "$ref": "#/ErrorItem"
-      }
-    ]
-  },
-  "ElementClassificationsOrErrors": {
-    "type": "array",
-    "description": "A list of element classification identifiers or errors.",
-    "items": {
-      "$ref": "#/ElementClassificationOrError"
-    }
-  },
-  "ElementClassification": {
-    "type": "object",
-    "description": "The classification of an element.",
-    "properties": {
-      "elementId": {
-        "$ref": "#/ElementId"
-      },
-      "classificationId": {
-        "$ref": "#/ClassificationId"
-      }
+        "required": [ "type", "status", "value" ]
     },
-    "additionalProperties": false,
-    "required": [
-      "elementId",
-      "classificationId"
-    ]
-  },
-  "ElementClassifications": {
-    "type": "array",
-    "description": "A list of element classification identifiers.",
-    "items": {
-      "$ref": "#/ElementClassification"
-    }
-  },
-  "BoundingBox3D": {
-    "type": "object",
-    "description": "A 3D bounding box of an element.",
-    "properties": {
-      "xMin": {
-        "type": "number",
-        "description": "The minimum X value of the bounding box."
-      },
-      "yMin": {
-        "type": "number",
-        "description": "The minimum Y value of the bounding box."
-      },
-      "zMin": {
-        "type": "number",
-        "description": "The minimum Z value of the bounding box."
-      },
-      "xMax": {
-        "type": "number",
-        "description": "The maximum X value of the bounding box."
-      },
-      "yMax": {
-        "type": "number",
-        "description": "The maximum Y value of the bounding box."
-      },
-      "zMax": {
-        "type": "number",
-        "description": "The maximum Z value of the bounding box."
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "xMin",
-      "yMin",
-      "zMin",
-      "xMax",
-      "yMax",
-      "zMax"
-    ]
-  },
-  "BoundingBox3DOrError": {
-    "type": "object",
-    "description": "A 3D bounding box or an error.",
-    "oneOf": [
-      {
-        "title": "boundingBox3D",
+    "NormalBooleanPropertyValue": {
+        "type": "object",
+        "description": "A boolean property value containing a valid boolean value.",
         "properties": {
-          "boundingBox3D": {
-            "$ref": "#/BoundingBox3D"
-          }
+            "type": {
+                "type": "string",
+                "enum": [ "boolean" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "boolean"
+            }
         },
         "additionalProperties": false,
-        "required": [ "boundingBox3D" ]
-      },
-      {
-        "title": "error",
-        "$ref": "#/ErrorItem"
-      }
-    ]
-  },
-  "BoundingBoxes3D": {
-    "type": "array",
-    "description": "A list of 3D bounding boxes.",
-    "items": {
-      "$ref": "#/BoundingBox3DOrError"
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalLengthPropertyValue": {
+        "type": "object",
+        "description": "A length property value containing a real length value. The value is measured in SI (meters).",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "length" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "number"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalAreaPropertyValue": {
+        "type": "object",
+        "description": "An area property value containing a real area. The value is measured in SI (square meters).",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "area" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "number"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalVolumePropertyValue": {
+        "type": "object",
+        "description": "A volume property value containing a real volume. The value is measured in SI (cubic meters).",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "volume" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "number"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalAnglePropertyValue": {
+        "type": "object",
+        "description": "An angle property value containing a real angle. The value is measured in SI (radians).",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "angle" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "number"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalNumberListPropertyValue": {
+        "type": "object",
+        "description": "A number list property value containing numbers in an array.",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "numberList" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "array",
+                "items": {
+                    "type": "number"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalIntegerListPropertyValue": {
+        "type": "object",
+        "description": "An integer list property value containing integers in an array.",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "integerList" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "array",
+                "items": {
+                    "type": "integer"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalStringListPropertyValue": {
+        "type": "object",
+        "description": "A string list property value containing strings in an array.",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "stringList" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalBooleanListPropertyValue": {
+        "type": "object",
+        "description": "A boolean list property value containing boolean values in an array.",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "booleanList" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "array",
+                "items": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalLengthListPropertyValue": {
+        "type": "object",
+        "description": "A length list property value containing length values in an array. The values are measured in SI (meters).",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "lengthList" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "array",
+                "items": {
+                    "type": "number"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalAreaListPropertyValue": {
+        "type": "object",
+        "description": "An area list property value containing areas in an array. The values are measured in SI (square meters).",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "areaList" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "array",
+                "items": {
+                    "type": "number"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalVolumeListPropertyValue": {
+        "type": "object",
+        "description": "A volume list property value containing volumes in an array. The values are measured in SI (cubic meters).",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "volumeList" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "array",
+                "items": {
+                    "type": "number"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalAngleListPropertyValue": {
+        "type": "object",
+        "description": "An angle list property value containing angles in an array. The values are measured in SI (radians).",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "angleList" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "type": "array",
+                "items": {
+                    "type": "number"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalSingleEnumPropertyValue": {
+        "type": "object",
+        "description": "A single enumeration property value containing the ID of the selected enum value.",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "singleEnum" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "$ref": "#/EnumValueId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "NormalMultiEnumPropertyValue": {
+        "type": "object",
+        "description": "A multiple choice enumeration property value containing the IDs of the selected enum values in an array.",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [ "multiEnum" ]
+            },
+            "status": {
+                "type": "string",
+                "enum": [ "normal" ]
+            },
+            "value": {
+                "$ref": "#/EnumValueIds"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "type", "status", "value" ]
+    },
+    "BasicDefaultValue": {
+        "type": "object",
+        "description": "Default value of the property in case of a basic property value (ie. not an expression).",
+        "properties": {
+            "basicDefaultValue": {
+                "$ref": "#/PropertyValueDetails"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "basicDefaultValue"
+        ]
+    },
+    "ExpressionDefaultValue": {
+        "type": "object",
+        "description": "Default value of the property in case of an expression based property value.",
+        "properties": {
+            "expressions": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "expressions"
+        ]
+    },
+    "PropertyDefaultValue": {
+        "type": "object",
+        "oneOf": [
+            {
+                "$ref": "#/BasicDefaultValue"
+            },
+            {
+                "$ref": "#/ExpressionDefaultValue"
+            }
+        ]
+    },
+    "ClassificationSystemId": {
+        "type": "object",
+        "description": "The identifier of a classification system.",
+        "properties": {
+            "guid": {
+                "$ref": "#/Guid"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "guid"
+        ]
+    },
+    "ClassificationSystemIdArrayItem": {
+        "type": "object",
+        "properties": {
+            "classificationSystemId": {
+                "$ref": "#/ClassificationSystemId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "classificationSystemId"
+        ]
+    },
+    "ClassificationSystemIds": {
+        "type": "array",
+        "description": "A list of classification system identifiers.",
+        "items": {
+            "$ref": "#/ClassificationSystemIdArrayItem"
+        }
+    },
+    "ClassificationItemId": {
+        "type": "object",
+        "description": "The identifier of a classification item.",
+        "properties": {
+            "guid": {
+                "$ref": "#/Guid"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "guid"
+        ]
+    },
+    "ClassificationItemIdArrayItem": {
+        "type": "object",
+        "properties": {
+            "classificationItemId": {
+                "$ref": "#/ClassificationItemId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "classificationItemId"
+        ]
+    },
+    "ClassificationId": {
+        "type": "object",
+        "description": "The element classification identifier.",
+        "properties": {
+            "classificationSystemId": {
+                "$ref": "#/ClassificationSystemId"
+            },
+            "classificationItemId": {
+                "$ref": "#/ClassificationItemId",
+                "description": "The element's classification in the given system. If no value is specified here, the element is Unclassified in this system."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "classificationSystemId"
+        ]
+    },
+    "ClassificationIdOrError": {
+        "type": "object",
+        "description": "A classification identifier or an error.",
+        "oneOf": [
+            {
+                "title": "classificationId",
+                "properties": {
+                    "classificationId": {
+                        "$ref": "#/ClassificationId"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [ "classificationId" ]
+            },
+            {
+                "title": "error",
+                "$ref": "#/ErrorItem"
+            }
+        ]
+    },
+    "ClassificationIdsOrErrors": {
+        "type": "array",
+        "description": "A list of element classification identifiers or errors.",
+        "items": {
+            "$ref": "#/ClassificationIdOrError"
+        }
+    },
+    "ElementClassificationOrError": {
+        "type": "object",
+        "description": "Element classification identifiers or errors.",
+        "oneOf": [
+            {
+                "title": "classificationIds",
+                "properties": {
+                    "classificationIds": {
+                        "$ref": "#/ClassificationIdsOrErrors"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [ "classificationIds" ]
+            },
+            {
+                "title": "error",
+                "$ref": "#/ErrorItem"
+            }
+        ]
+    },
+    "ElementClassificationsOrErrors": {
+        "type": "array",
+        "description": "A list of element classification identifiers or errors.",
+        "items": {
+            "$ref": "#/ElementClassificationOrError"
+        }
+    },
+    "ElementClassification": {
+        "type": "object",
+        "description": "The classification of an element.",
+        "properties": {
+            "elementId": {
+                "$ref": "#/ElementId"
+            },
+            "classificationId": {
+                "$ref": "#/ClassificationId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "elementId",
+            "classificationId"
+        ]
+    },
+    "ElementClassifications": {
+        "type": "array",
+        "description": "A list of element classification identifiers.",
+        "items": {
+            "$ref": "#/ElementClassification"
+        }
+    },
+    "BoundingBox3D": {
+        "type": "object",
+        "description": "A 3D bounding box of an element.",
+        "properties": {
+            "xMin": {
+                "type": "number",
+                "description": "The minimum X value of the bounding box."
+            },
+            "yMin": {
+                "type": "number",
+                "description": "The minimum Y value of the bounding box."
+            },
+            "zMin": {
+                "type": "number",
+                "description": "The minimum Z value of the bounding box."
+            },
+            "xMax": {
+                "type": "number",
+                "description": "The maximum X value of the bounding box."
+            },
+            "yMax": {
+                "type": "number",
+                "description": "The maximum Y value of the bounding box."
+            },
+            "zMax": {
+                "type": "number",
+                "description": "The maximum Z value of the bounding box."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "xMin",
+            "yMin",
+            "zMin",
+            "xMax",
+            "yMax",
+            "zMax"
+        ]
+    },
+    "BoundingBox3DOrError": {
+        "type": "object",
+        "description": "A 3D bounding box or an error.",
+        "oneOf": [
+            {
+                "title": "boundingBox3D",
+                "properties": {
+                    "boundingBox3D": {
+                        "$ref": "#/BoundingBox3D"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [ "boundingBox3D" ]
+            },
+            {
+                "title": "error",
+                "$ref": "#/ErrorItem"
+            }
+        ]
+    },
+    "BoundingBoxes3D": {
+        "type": "array",
+        "description": "A list of 3D bounding boxes.",
+        "items": {
+            "$ref": "#/BoundingBox3DOrError"
+        }
+    },
+    "LibPartUnId": {
+        "type": "object",
+        "properties": {
+            "guid": {
+                "$ref": "#/Guid"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "guid"
+        ]
+    },
+    "LibPartDetails": {
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "parentUnID": {
+                "$ref": "#/LibPartUnId"
+            },
+            "ownUnID": {
+                "$ref": "#/LibPartUnId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name",
+            "parentUnID",
+            "ownUnID"
+        ]
+    },
+    "NavigatorItemIds": {
+        "type": "array",
+        "description": "A list of navigator item identifiers.",
+        "items": {
+            "$ref": "#/NavigatorItemIdArrayItem"
+        }
+    },
+    "NavigatorItemIdArrayItem": {
+        "type": "object",
+        "properties": {
+            "navigatorItemId": {
+                "$ref": "#/NavigatorItemId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "navigatorItemId"
+        ]
+    },
+    "NavigatorItemId": {
+        "type": "object",
+        "description": "The identifier of a navigator item.",
+        "properties": {
+            "guid": {
+                "$ref": "#/Guid"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "guid"
+        ]
+    },
+    "Databases": {
+        "type": "array",
+        "description": "A list of Archicad databases.",
+        "items": {
+            "$ref": "#/DatabaseIdArrayItem"
+        }
+    },
+    "DatabaseIdArrayItem": {
+        "type": "object",
+        "properties": {
+            "databaseId": {
+                "$ref": "#/DatabaseId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "databaseId"
+        ]
+    },
+    "DatabaseId": {
+        "type": "object",
+        "description": "The identifier of a database",
+        "properties": {
+            "guid": {
+                "$ref": "#/Guid"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "guid"
+        ]
     }
-  },
-  "LibPartUnId": {
-    "type": "object",
-    "properties": {
-      "guid": {
-        "$ref": "#/Guid"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "guid"
-    ]
-  },
-  "LibPartDetails": {
-    "properties": {
-      "name": {
-        "type": "string"
-      },
-      "parentUnID": {
-        "$ref": "#/LibPartUnId"
-      },
-      "ownUnID": {
-        "$ref": "#/LibPartUnId"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "name",
-      "parentUnID",
-      "ownUnID"
-    ]
-  },
-  "NavigatorItemIds": {
-    "type": "array",
-    "description": "A list of navigator item identifiers.",
-    "items": {
-      "$ref": "#/NavigatorItemIdArrayItem"
-    }
-  },
-  "NavigatorItemIdArrayItem": {
-    "type": "object",
-    "properties": {
-      "navigatorItemId": {
-        "$ref": "#/NavigatorItemId"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "navigatorItemId"
-    ]
-  },
-  "NavigatorItemId": {
-    "type": "object",
-    "description": "The identifier of a navigator item.",
-    "properties": {
-      "guid": {
-        "$ref": "#/Guid"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "guid"
-    ]
-  },
-  "Databases": {
-    "type": "array",
-    "description": "A list of Archicad databases.",
-    "items": {
-      "$ref": "#/DatabaseIdArrayItem"
-    }
-  },
-  "DatabaseIdArrayItem": {
-    "type": "object",
-    "properties": {
-      "databaseId": {
-        "$ref": "#/DatabaseId"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "databaseId"
-    ]
-  },
-  "DatabaseId": {
-    "type": "object",
-    "description": "The identifier of a database",
-    "properties": {
-      "guid": {
-        "$ref": "#/Guid"
-      }
-    },
-    "additionalProperties": false,
-    "required": [
-      "guid"
-    ]
-  }
 }

--- a/archicad-addon/Sources/RFIX/Schemas/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Schemas/CommonSchemaDefinitions.json
@@ -1,1572 +1,1636 @@
 {
-    "Elements": {
-        "type": "array",
-        "description": "A list of elements.",
-        "items": {
-            "$ref": "#/ElementIdArrayItem"
-        }
-    },
-    "ElementIdArrayItem": {
-        "type": "object",
-        "properties": {
-            "elementId": {
-                "$ref": "#/ElementId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "elementId"
-        ]
-    },
-    "ElementId": {
-        "type": "object",
-        "description": "The identifier of an element.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "AttributeType": {
-        "type": "string",
-        "description": "The type of an attribute.",
-        "enum": [
-            "Layer",
-            "Line",
-            "Fill",
-            "Composite",
-            "Surface",
-            "LayerCombination",
-            "ZoneCategory",
-            "Profile",
-            "PenTable",
-            "MEPSystem",
-            "OperationProfile",
-            "BuildingMaterial"
-        ]
-    },
-    "AttributeIds": {
-        "type": "array",
-        "description": "A list of attributes.",
-        "items": {
-            "$ref": "#/AttributeIdArrayItem"
-        }
-    },
-    "AttributeIdArrayItem": {
-        "type": "object",
-        "properties": {
-            "attributeId": {
-                "$ref": "#/AttributeId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "attributeId"
-        ]
-    },
-    "AttributeId": {
-        "type": "object",
-        "description": "The identifier of an attribute.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "Guid": {
-        "type": "string",
-        "description": "A Globally Unique Identifier (or Universally Unique Identifier) in its string representation as defined in RFC 4122.",
-        "format": "uuid",
-        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-    },
-    "Hotlinks": {
-        "type": "array",
-        "description": "A list of hotlink nodes.",
-        "items": {
-            "$ref": "#/Hotlink"
-        }
-    },
-    "Hotlink": {
-        "type": "object",
-        "description": "The details of a hotlink node.",
-        "properties": {
-            "location": {
-                "type": "string",
-                "description": "The path of the hotlink file."
-            },
-            "children": {
-                "$ref": "#/Hotlinks",
-                "description": "The children of the hotlink node if it has any."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "location"
-        ]
-    },
-    "GDLParameterList": {
-        "type": "object",
-        "description": "The list of GDL parameters.",
-        "properties": {
-            "parameters": {
-                "type": "array",
-                "description": "The list of GDL parameters.",
-                "items": {
-                    "$ref": "#/GDLParameterDetails"
-                }
-            }
-        },
-        "required": [
-            "parameters"
-        ]
-    },
-    "GDLParameterDetails": {
-        "type": "object",
-        "description": "Details of a GDL parameter.",
-        "properties": {
-            "name": {
-                "type": "string",
-                "description": "The name of the parameter."
-            },
-            "index": {
-                "type": "string",
-                "description": "The index of the parameter."
-            },
-            "type": {
-                "type": "string",
-                "description": "The type of the parameter."
-            },
-            "dimension1": {
-                "type": "number",
-                "description": "The 1st dimension of array (in case of array value)."
-            },
-            "dimension2": {
-                "type": "number",
-                "description": "The 2nd dimension of array (in case of array value)."
-            },
-            "value": {
-                "description": "The value of the parameter."
-            }
-        },
-        "additionalProperties": true,
-        "required": [
-            "index",
-            "type",
-            "value"
-        ]
-    },
-    "2DCoordinate": {
-        "type": "object",
-        "description": "2D coordinate.",
-        "properties": {
-            "x": {
-                "type": "number",
-                "description": "X value of the coordinate."
-            },
-            "y": {
-                "type": "number",
-                "description": "Y value of the coordinate."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "x",
-            "y"
-        ]
-    },
-    "3DCoordinate": {
-        "type": "object",
-        "description": "3D coordinate.",
-        "properties": {
-            "x": {
-                "type": "number",
-                "description": "X value of the coordinate."
-            },
-            "y": {
-                "type": "number",
-                "description": "Y value of the coordinate."
-            },
-            "z": {
-                "type": "number",
-                "description": "Z value of the coordinate."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "x",
-            "y",
-            "z"
-        ]
-    },
-    "3DDimensions": {
-        "type": "object",
-        "description": "Dimensions in 3D.",
-        "properties": {
-            "x": {
-                "type": "number",
-                "description": "X dimension."
-            },
-            "y": {
-                "type": "number",
-                "description": "Y dimension."
-            },
-            "z": {
-                "type": "number",
-                "description": "Z dimension."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "x",
-            "y",
-            "z"
-        ]
-    },
-    "Error": {
-        "type": "object",
-        "description": "The details of an error.",
-        "properties": {
-            "code": {
-                "type": "integer",
-                "description": "The code of the error."
-            },
-            "message": {
-                "type": "string",
-                "description": "The error message."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "code",
-            "message"
-        ]
-    },
-    "ErrorItem": {
-        "type": "object",
-        "properties": {
-            "error": {
-                "$ref": "#/Error"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "error" ]
-    },
-    "SuccessfulExecutionResult": {
-        "type": "object",
-        "description": "The result of a successful execution.",
-        "properties": {
-            "success": {
-                "type": "boolean",
-                "enum": [ true ]
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "success"
-        ]
-    },
-    "FailedExecutionResult": {
-        "type": "object",
-        "description": "The result of a failed execution.",
-        "properties": {
-            "success": {
-                "type": "boolean",
-                "enum": [ false ]
-            },
-            "error": {
-                "$ref": "#/Error",
-                "description": "The details of an execution failure."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "success",
-            "error"
-        ]
-    },
-    "ExecutionResult": {
-        "type": "object",
-        "description": "The result of the execution.",
-        "oneOf": [
-            {
-                "$ref": "#/SuccessfulExecutionResult"
-            },
-            {
-                "$ref": "#/FailedExecutionResult"
-            }
-        ]
-    },
-    "ExecutionResults": {
-        "type": "array",
-        "description": "A list of execution results.",
-        "items": {
-            "$ref": "#/ExecutionResult"
-        }
-    },
-    "ElementType": {
-        "type": "string",
-        "description": "The type of an element.",
-        "enum": [
-            "Wall",
-            "Column",
-            "Beam",
-            "Window",
-            "Door",
-            "Object",
-            "Lamp",
-            "Slab",
-            "Roof",
-            "Mesh",
-            "Dimension",
-            "RadialDimension",
-            "LevelDimension",
-            "AngleDimension",
-            "Text",
-            "Label",
-            "Zone",
-            "Hatch",
-            "Line",
-            "PolyLine",
-            "Arc",
-            "Circle",
-            "Spline",
-            "Hotspot",
-            "CutPlane",
-            "Camera",
-            "CamSet",
-            "Group",
-            "SectElem",
-            "Drawing",
-            "Picture",
-            "Detail",
-            "Elevation",
-            "InteriorElevation",
-            "Worksheet",
-            "Hotlink",
-            "CurtainWall",
-            "CurtainWallSegment",
-            "CurtainWallFrame",
-            "CurtainWallPanel",
-            "CurtainWallJunction",
-            "CurtainWallAccessory",
-            "Shell",
-            "Skylight",
-            "Morph",
-            "ChangeMarker",
-            "Stair",
-            "Riser",
-            "Tread",
-            "StairStructure",
-            "Railing",
-            "RailingToprail",
-            "RailingHandrail",
-            "RailingRail",
-            "RailingPost",
-            "RailingInnerPost",
-            "RailingBaluster",
-            "RailingPanel",
-            "RailingSegment",
-            "RailingNode",
-            "RailingBalusterSet",
-            "RailingPattern",
-            "RailingToprailEnd",
-            "RailingHandrailEnd",
-            "RailingRailEnd",
-            "RailingToprailConnection",
-            "RailingHandrailConnection",
-            "RailingRailConnection",
-            "RailingEndFinish",
-            "BeamSegment",
-            "ColumnSegment",
-            "Opening",
-            "Unknown"
-        ]
-    },
-    "ElementFilter": {
-        "type": "string",
-        "description": "A filter type for an element.",
-        "enum": [
-            "IsEditable",
-            "IsVisibleByLayer",
-            "IsVisibleByRenovation",
-            "IsVisibleByStructureDisplay",
-            "IsVisibleIn3D",
-            "OnActualFloor",
-            "OnActualLayout",
-            "InMyWorkspace",
-            "IsIndependent",
-            "InCroppedView",
-            "HasAccessRight",
-            "IsOverriddenByRenovation"
-        ]
-    },
-    "WindowType": {
-        "type": "string",
-        "description": "The type of a window.",
-        "enum": [
-            "FloorPlan",
-            "Section",
-            "Details",
-            "3DModel",
-            "Layout",
-            "Drawing",
-            "CustomText",
-            "CustomDraw",
-            "MasterLayout",
-            "Elevation",
-            "InteriorElevation",
-            "Worksheet",
-            "Report",
-            "3DDocument",
-            "External3D",
-            "Movie3D",
-            "MovieRendering",
-            "Rendering",
-            "ModelCompare",
-            "Interactive Schedule",
-            "Unknown"
-        ]
-    },
-    "IssueId": {
-        "type": "object",
-        "description": "The identifier of an issue.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "IssueIdArrayItem": {
-        "type": "object",
-        "properties": {
-            "issueId": {
-                "$ref": "#/IssueId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "issueId"
-        ]
-    },
-    "Issues": {
-        "type": "array",
-        "description": "A list of Issues.",
-        "items": {
-            "$ref": "#/IssueIdArrayItem"
-        }
-    },
-    "IssueElementType": {
-        "type": "string",
-        "description": "The attachment type of an element component of an issue.",
-        "enum": [
-            "Creation",
-            "Highlight",
-            "Deletion",
-            "Modification"
-        ]
-    },
-    "IssueCommentStatus": {
-        "type": "string",
-        "description": "The status of an issue comment.",
-        "enum": [
-            "Error",
-            "Warning",
-            "Info",
-            "Unknown"
-        ]
-    },
-    "PropertyId": {
-        "type": "object",
-        "description": "The identifier of a property.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "PropertyGroupId": {
-        "type": "object",
-        "description": "The identifier of a property group.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "PropertyIdArrayItem": {
-        "type": "object",
-        "properties": {
-            "propertyId": {
-                "$ref": "#/PropertyId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "propertyId"
-        ]
-    },
-    "PropertyIds": {
-        "type": "array",
-        "description": "A list of property identifiers.",
-        "items": {
-            "$ref": "#/PropertyIdArrayItem"
-        }
-    },
-    "PropertyDetails": {
-        "type": "object",
-        "description": "The details of the property.",
-        "properties": {
-            "propertyId": {
-                "$ref": "#/PropertyId"
-            },
-            "propertyType": {
-                "type": "string",
-                "enum": [
-                    "StaticBuiltIn",
-                    "DynamicBuiltIn",
-                    "Custom"
-                ]
-            },
-            "propertyGroupName": {
-                "type": "string"
-            },
-            "propertyName": {
-                "type": "string"
-            },
-            "propertyCollectionType": {
-                "type": "string",
-                "enum": [
-                    "Undefined",
-                    "Single",
-                    "List",
-                    "SingleChoiceEnumeration",
-                    "MultipleChoiceEnumeration"
-                ]
-            },
-            "propertyValueType": {
-                "type": "string",
-                "enum": [
-                    "Undefined",
-                    "Integer",
-                    "Real",
-                    "String",
-                    "Boolean",
-                    "Guid"
-                ]
-            },
-            "propertyMeasureType": {
-                "type": "string",
-                "enum": [
-                    "Undefined",
-                    "Default",
-                    "Length",
-                    "Area",
-                    "Volume",
-                    "Angle"
-                ]
-            },
-            "propertyIsEditable": {
-                "type": "boolean"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "propertyId",
-            "propertyType",
-            "propertyGroupName",
-            "propertyName",
-            "propertyCollectionType",
-            "propertyValueType",
-            "propertyMeasureType",
-            "propertyIsEditable"
-        ]
-    },
-    "PropertyValue": {
-        "type": "object",
-        "description": "The display string value of a property.",
-        "properties": {
-            "value": {
-                "type": "string"
-            }
-        },
-        "additionalProperties": true,
-        "required": [
-            "value"
-        ]
-    },
-    "PropertyValueOrErrorItem": {
-        "type": "object",
-        "description": "A property value or an error",
-        "oneOf": [
-            {
-                "title": "propertyValue",
-                "properties": {
-                    "propertyValue": {
-                        "$ref": "#/PropertyValue"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "propertyValue" ]
-            },
-            {
-                "title": "error",
-                "$ref": "#/ErrorItem"
-            }
-        ]
-    },
-    "PropertyValues": {
-        "type": "array",
-        "description": "A list of property values.",
-        "items": {
-            "$ref": "#/PropertyValueOrErrorItem"
-        }
-    },
-    "PropertyValuesOrError": {
-        "type": "object",
-        "description": "A list of property values or an error.",
-        "oneOf": [
-            {
-                "title": "propertyValues",
-                "properties": {
-                    "propertyValues": {
-                        "$ref": "#/PropertyValues"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "propertyValues" ]
-            },
-            {
-                "title": "error",
-                "$ref": "#/ErrorItem"
-            }
-        ]
-    },
-    "PropertyValuesOrErrorArray": {
-        "type": "array",
-        "description": "A list of property value lists.",
-        "items": {
-            "$ref": "#/PropertyValuesOrError"
-        }
-    },
-    "PropertyIdOrError": {
-        "type": "object",
-        "description": "A propertyId or an error.",
-        "oneOf": [
-            {
-                "properties": {
-                    "propertyId": {
-                        "$ref": "#/PropertyId"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "propertyId" ]
-            },
-            {
-                "$ref": "#/ErrorItem"
-            }
-        ]
-    },
-    "PropertyIdOrErrorArray": {
-        "type": "array",
-        "description": "A list of property identifiers.",
-        "items": {
-            "$ref": "#/PropertyIdOrError"
-        }
-    },
-    "ElementPropertyValue": {
-        "type": "object",
-        "description": "A property value with the identifiers of the property and its owner element.",
-        "properties": {
-            "elementId": {
-                "$ref": "#/ElementId"
-            },
-            "propertyId": {
-                "$ref": "#/PropertyId"
-            },
-            "propertyValue": {
-                "$ref": "#/PropertyValue"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "elementId",
-            "propertyId",
-            "propertyValue"
-        ]
-    },
-    "ElementPropertyValues": {
-        "type": "array",
-        "description": "A list of element property values.",
-        "items": {
-            "$ref": "#/ElementPropertyValue"
-        }
-    },
-    "PropertyType": {
-        "type": "string",
-        "enum": [
-            "number",
-            "integer",
-            "string",
-            "boolean",
-            "length",
-            "area",
-            "volume",
-            "angle",
-            "numberList",
-            "integerList",
-            "stringList",
-            "booleanList",
-            "lengthList",
-            "areaList",
-            "volumeList",
-            "angleList",
-            "singleEnum",
-            "multiEnum"
-        ]
-    },
-    "DisplayValueEnumId": {
-        "type": "object",
-        "description": "An enumeration value identifier using the displayed value.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "displayValue" ]
-            },
-            "displayValue": {
-                "type": "string"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "type",
-            "displayValue"
-        ]
-    },
-    "NonLocalizedValueEnumId": {
-        "type": "object",
-        "description": "An enumeration value identifier using the nonlocalized value.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "nonLocalizedValue" ]
-            },
-            "nonLocalizedValue": {
-                "type": "string"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "type",
-            "nonLocalizedValue"
-        ]
-    },
-    "EnumValueId": {
-        "type": "object",
-        "description": "The identifier of a property enumeration value.",
-        "oneOf": [
-            {
-                "$ref": "#/DisplayValueEnumId"
-            },
-            {
-                "$ref": "#/NonLocalizedValueEnumId"
-            }
-        ]
-    },
-    "EnumValueIds": {
-        "type": "array",
-        "description": "A list of enumeration identifiers.",
-        "items": {
-            "type": "object",
-            "properties": {
-                "enumValueId": {
-                    "$ref": "#/EnumValueId"
-                }
-            },
-            "additionalProperties": false,
-            "required": [ "enumValueId" ]
-        }
-    },
-    "NormalOrUserUndefinedPropertyValue": {
-        "type": "object",
-        "description": "A normal or a userUndefined property value.",
-        "oneOf": [
-            {
-                "$ref": "#/NormalNumberPropertyValue"
-            },
-            {
-                "$ref": "#/NormalIntegerPropertyValue"
-            },
-            {
-                "$ref": "#/NormalStringPropertyValue"
-            },
-            {
-                "$ref": "#/NormalBooleanPropertyValue"
-            },
-            {
-                "$ref": "#/NormalLengthPropertyValue"
-            },
-            {
-                "$ref": "#/NormalAreaPropertyValue"
-            },
-            {
-                "$ref": "#/NormalVolumePropertyValue"
-            },
-            {
-                "$ref": "#/NormalAnglePropertyValue"
-            },
-            {
-                "$ref": "#/NormalNumberListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalIntegerListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalStringListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalBooleanListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalLengthListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalAreaListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalVolumeListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalAngleListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalSingleEnumPropertyValue"
-            },
-            {
-                "$ref": "#/NormalMultiEnumPropertyValue"
-            },
-            {
-                "$ref": "#/UserUndefinedPropertyValue"
-            }
-        ]
-    },
-    "PropertyValueDetails": {
-        "type": "object",
-        "description": "A normal, userUndefined, notAvailable or notEvaluated property value.",
-        "oneOf": [
-            {
-                "$ref": "#/NormalOrUserUndefinedPropertyValue"
-            },
-            {
-                "$ref": "#/NotAvailablePropertyValue"
-            }
-        ]
-    },
-    "UserUndefinedPropertyValue": {
-        "type": "object",
-        "description": "A userUndefined value means that there is no actual number/string/etc. value, but the user deliberately set an Undefined value: this is a valid value, too.",
-        "properties": {
-            "type": {
-                "$ref": "#/PropertyType"
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "userUndefined" ]
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status" ]
-    },
-    "NotAvailablePropertyValue": {
-        "type": "object",
-        "description": "A notAvailable value means that the property is not available for the property owner (and therefore it has no property value for it).",
-        "properties": {
-            "type": {
-                "$ref": "#/PropertyType"
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "notAvailable" ]
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "type",
-            "status"
-        ]
-    },
-    "NormalNumberPropertyValue": {
-        "type": "object",
-        "description": "A number property value containing a valid numeric value.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "number" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "number"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalIntegerPropertyValue": {
-        "type": "object",
-        "description": "An integer property value containing a valid integer number.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "integer" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "integer"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalStringPropertyValue": {
-        "type": "object",
-        "description": "A string property value containing a valid string.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "string" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "string"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalBooleanPropertyValue": {
-        "type": "object",
-        "description": "A boolean property value containing a valid boolean value.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "boolean" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "boolean"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalLengthPropertyValue": {
-        "type": "object",
-        "description": "A length property value containing a real length value. The value is measured in SI (meters).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "length" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "number"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalAreaPropertyValue": {
-        "type": "object",
-        "description": "An area property value containing a real area. The value is measured in SI (square meters).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "area" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "number"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalVolumePropertyValue": {
-        "type": "object",
-        "description": "A volume property value containing a real volume. The value is measured in SI (cubic meters).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "volume" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "number"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalAnglePropertyValue": {
-        "type": "object",
-        "description": "An angle property value containing a real angle. The value is measured in SI (radians).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "angle" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "number"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalNumberListPropertyValue": {
-        "type": "object",
-        "description": "A number list property value containing numbers in an array.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "numberList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "number"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalIntegerListPropertyValue": {
-        "type": "object",
-        "description": "An integer list property value containing integers in an array.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "integerList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "integer"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalStringListPropertyValue": {
-        "type": "object",
-        "description": "A string list property value containing strings in an array.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "stringList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalBooleanListPropertyValue": {
-        "type": "object",
-        "description": "A boolean list property value containing boolean values in an array.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "booleanList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalLengthListPropertyValue": {
-        "type": "object",
-        "description": "A length list property value containing length values in an array. The values are measured in SI (meters).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "lengthList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "number"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalAreaListPropertyValue": {
-        "type": "object",
-        "description": "An area list property value containing areas in an array. The values are measured in SI (square meters).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "areaList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "number"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalVolumeListPropertyValue": {
-        "type": "object",
-        "description": "A volume list property value containing volumes in an array. The values are measured in SI (cubic meters).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "volumeList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "number"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalAngleListPropertyValue": {
-        "type": "object",
-        "description": "An angle list property value containing angles in an array. The values are measured in SI (radians).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "angleList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "number"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalSingleEnumPropertyValue": {
-        "type": "object",
-        "description": "A single enumeration property value containing the ID of the selected enum value.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "singleEnum" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "$ref": "#/EnumValueId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalMultiEnumPropertyValue": {
-        "type": "object",
-        "description": "A multiple choice enumeration property value containing the IDs of the selected enum values in an array.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "multiEnum" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "$ref": "#/EnumValueIds"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "BasicDefaultValue": {
-        "type": "object",
-        "description": "Default value of the property in case of a basic property value (ie. not an expression).",
-        "properties": {
-            "basicDefaultValue": {
-                "$ref": "#/PropertyValueDetails"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "basicDefaultValue"
-        ]
-    },
-    "ExpressionDefaultValue": {
-        "type": "object",
-        "description": "Default value of the property in case of an expression based property value.",
-        "properties": {
-            "expressions": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "expressions"
-        ]
-    },
-    "PropertyDefaultValue": {
-        "type": "object",
-        "oneOf": [
-            {
-                "$ref": "#/BasicDefaultValue"
-            },
-            {
-                "$ref": "#/ExpressionDefaultValue"
-            }
-        ]
-    },
-    "ClassificationSystemId": {
-        "type": "object",
-        "description": "The identifier of a classification system.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "ClassificationSystemIdArrayItem": {
-        "type": "object",
-        "properties": {
-            "classificationSystemId": {
-                "$ref": "#/ClassificationSystemId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "classificationSystemId"
-        ]
-    },
-    "ClassificationSystemIds": {
-        "type": "array",
-        "description": "A list of classification system identifiers.",
-        "items": {
-            "$ref": "#/ClassificationSystemIdArrayItem"
-        }
-    },
-    "ClassificationItemId": {
-        "type": "object",
-        "description": "The identifier of a classification item.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "ClassificationItemIdArrayItem": {
-        "type": "object",
-        "properties": {
-            "classificationItemId": {
-                "$ref": "#/ClassificationItemId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "classificationItemId"
-        ]
-    },
-    "ClassificationId": {
-        "type": "object",
-        "description": "The element classification identifier.",
-        "properties": {
-            "classificationSystemId": {
-                "$ref": "#/ClassificationSystemId"
-            },
-            "classificationItemId": {
-                "$ref": "#/ClassificationItemId",
-                "description": "The element's classification in the given system. If no value is specified here, the element is Unclassified in this system."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "classificationSystemId"
-        ]
-    },
-    "ClassificationIdOrError": {
-        "type": "object",
-        "description": "A classification identifier or an error.",
-        "oneOf": [
-            {
-                "title": "classificationId",
-                "properties": {
-                    "classificationId": {
-                        "$ref": "#/ClassificationId"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "classificationId" ]
-            },
-            {
-                "title": "error",
-                "$ref": "#/ErrorItem"
-            }
-        ]
-    },
-    "ClassificationIdsOrErrors": {
-        "type": "array",
-        "description": "A list of element classification identifiers or errors.",
-        "items": {
-            "$ref": "#/ClassificationIdOrError"
-        }
-    },
-    "ElementClassificationOrError": {
-        "type": "object",
-        "description": "Element classification identifiers or errors.",
-        "oneOf": [
-            {
-                "title": "classificationIds",
-                "properties": {
-                    "classificationIds": {
-                        "$ref": "#/ClassificationIdsOrErrors"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "classificationIds" ]
-            },
-            {
-                "title": "error",
-                "$ref": "#/ErrorItem"
-            }
-        ]
-    },
-    "ElementClassificationsOrErrors": {
-        "type": "array",
-        "description": "A list of element classification identifiers or errors.",
-        "items": {
-            "$ref": "#/ElementClassificationOrError"
-        }
-    },
-    "ElementClassification": {
-        "type": "object",
-        "description": "The classification of an element.",
-        "properties": {
-            "elementId": {
-                "$ref": "#/ElementId"
-            },
-            "classificationId": {
-                "$ref": "#/ClassificationId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "elementId",
-            "classificationId"
-        ]
-    },
-    "ElementClassifications": {
-        "type": "array",
-        "description": "A list of element classification identifiers.",
-        "items": {
-            "$ref": "#/ElementClassification"
-        }
-    },
-    "BoundingBox3D": {
-        "type": "object",
-        "description": "A 3D bounding box of an element.",
-        "properties": {
-            "xMin": {
-                "type": "number",
-                "description": "The minimum X value of the bounding box."
-            },
-            "yMin": {
-                "type": "number",
-                "description": "The minimum Y value of the bounding box."
-            },
-            "zMin": {
-                "type": "number",
-                "description": "The minimum Z value of the bounding box."
-            },
-            "xMax": {
-                "type": "number",
-                "description": "The maximum X value of the bounding box."
-            },
-            "yMax": {
-                "type": "number",
-                "description": "The maximum Y value of the bounding box."
-            },
-            "zMax": {
-                "type": "number",
-                "description": "The maximum Z value of the bounding box."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "xMin",
-            "yMin",
-            "zMin",
-            "xMax",
-            "yMax",
-            "zMax"
-        ]
-    },
-    "BoundingBox3DOrError": {
-        "type": "object",
-        "description": "A 3D bounding box or an error.",
-        "oneOf": [
-            {
-                "title": "boundingBox3D",
-                "properties": {
-                    "boundingBox3D": {
-                        "$ref": "#/BoundingBox3D"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "boundingBox3D" ]
-            },
-            {
-                "title": "error",
-                "$ref": "#/ErrorItem"
-            }
-        ]
-    },
-    "BoundingBoxes3D": {
-        "type": "array",
-        "description": "A list of 3D bounding boxes.",
-        "items": {
-            "$ref": "#/BoundingBox3DOrError"
-        }
-    },
-    "LibPartUnId": {
-        "type": "object",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "LibPartDetails": {
-        "properties": {
-            "name": {
-                "type": "string"
-            },
-            "parentUnID": {
-                "$ref": "#/LibPartUnId"
-            },
-            "ownUnID": {
-                "$ref": "#/LibPartUnId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "name",
-            "parentUnID",
-            "ownUnID"
-        ]
+  "Elements": {
+    "type": "array",
+    "description": "A list of elements.",
+    "items": {
+      "$ref": "#/ElementIdArrayItem"
     }
+  },
+  "ElementIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "elementId": {
+        "$ref": "#/ElementId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "elementId"
+    ]
+  },
+  "ElementId": {
+    "type": "object",
+    "description": "The identifier of an element.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "AttributeType": {
+    "type": "string",
+    "description": "The type of an attribute.",
+    "enum": [
+      "Layer",
+      "Line",
+      "Fill",
+      "Composite",
+      "Surface",
+      "LayerCombination",
+      "ZoneCategory",
+      "Profile",
+      "PenTable",
+      "MEPSystem",
+      "OperationProfile",
+      "BuildingMaterial"
+    ]
+  },
+  "AttributeIds": {
+    "type": "array",
+    "description": "A list of attributes.",
+    "items": {
+      "$ref": "#/AttributeIdArrayItem"
+    }
+  },
+  "AttributeIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "attributeId": {
+        "$ref": "#/AttributeId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "attributeId"
+    ]
+  },
+  "AttributeId": {
+    "type": "object",
+    "description": "The identifier of an attribute.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "Guid": {
+    "type": "string",
+    "description": "A Globally Unique Identifier (or Universally Unique Identifier) in its string representation as defined in RFC 4122.",
+    "format": "uuid",
+    "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+  },
+  "Hotlinks": {
+    "type": "array",
+    "description": "A list of hotlink nodes.",
+    "items": {
+      "$ref": "#/Hotlink"
+    }
+  },
+  "Hotlink": {
+    "type": "object",
+    "description": "The details of a hotlink node.",
+    "properties": {
+      "location": {
+        "type": "string",
+        "description": "The path of the hotlink file."
+      },
+      "children": {
+        "$ref": "#/Hotlinks",
+        "description": "The children of the hotlink node if it has any."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "location"
+    ]
+  },
+  "GDLParameterList": {
+    "type": "object",
+    "description": "The list of GDL parameters.",
+    "properties": {
+      "parameters": {
+        "type": "array",
+        "description": "The list of GDL parameters.",
+        "items": {
+          "$ref": "#/GDLParameterDetails"
+        }
+      }
+    },
+    "required": [
+      "parameters"
+    ]
+  },
+  "GDLParameterDetails": {
+    "type": "object",
+    "description": "Details of a GDL parameter.",
+    "properties": {
+      "name": {
+        "type": "string",
+        "description": "The name of the parameter."
+      },
+      "index": {
+        "type": "string",
+        "description": "The index of the parameter."
+      },
+      "type": {
+        "type": "string",
+        "description": "The type of the parameter."
+      },
+      "dimension1": {
+        "type": "number",
+        "description": "The 1st dimension of array (in case of array value)."
+      },
+      "dimension2": {
+        "type": "number",
+        "description": "The 2nd dimension of array (in case of array value)."
+      },
+      "value": {
+        "description": "The value of the parameter."
+      }
+    },
+    "additionalProperties": true,
+    "required": [
+      "index",
+      "type",
+      "value"
+    ]
+  },
+  "2DCoordinate": {
+    "type": "object",
+    "description": "2D coordinate.",
+    "properties": {
+      "x": {
+        "type": "number",
+        "description": "X value of the coordinate."
+      },
+      "y": {
+        "type": "number",
+        "description": "Y value of the coordinate."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "x",
+      "y"
+    ]
+  },
+  "3DCoordinate": {
+    "type": "object",
+    "description": "3D coordinate.",
+    "properties": {
+      "x": {
+        "type": "number",
+        "description": "X value of the coordinate."
+      },
+      "y": {
+        "type": "number",
+        "description": "Y value of the coordinate."
+      },
+      "z": {
+        "type": "number",
+        "description": "Z value of the coordinate."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "x",
+      "y",
+      "z"
+    ]
+  },
+  "3DDimensions": {
+    "type": "object",
+    "description": "Dimensions in 3D.",
+    "properties": {
+      "x": {
+        "type": "number",
+        "description": "X dimension."
+      },
+      "y": {
+        "type": "number",
+        "description": "Y dimension."
+      },
+      "z": {
+        "type": "number",
+        "description": "Z dimension."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "x",
+      "y",
+      "z"
+    ]
+  },
+  "Error": {
+    "type": "object",
+    "description": "The details of an error.",
+    "properties": {
+      "code": {
+        "type": "integer",
+        "description": "The code of the error."
+      },
+      "message": {
+        "type": "string",
+        "description": "The error message."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "code",
+      "message"
+    ]
+  },
+  "ErrorItem": {
+    "type": "object",
+    "properties": {
+      "error": {
+        "$ref": "#/Error"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "error" ]
+  },
+  "SuccessfulExecutionResult": {
+    "type": "object",
+    "description": "The result of a successful execution.",
+    "properties": {
+      "success": {
+        "type": "boolean",
+        "enum": [ true ]
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "success"
+    ]
+  },
+  "FailedExecutionResult": {
+    "type": "object",
+    "description": "The result of a failed execution.",
+    "properties": {
+      "success": {
+        "type": "boolean",
+        "enum": [ false ]
+      },
+      "error": {
+        "$ref": "#/Error",
+        "description": "The details of an execution failure."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "success",
+      "error"
+    ]
+  },
+  "ExecutionResult": {
+    "type": "object",
+    "description": "The result of the execution.",
+    "oneOf": [
+      {
+        "$ref": "#/SuccessfulExecutionResult"
+      },
+      {
+        "$ref": "#/FailedExecutionResult"
+      }
+    ]
+  },
+  "ExecutionResults": {
+    "type": "array",
+    "description": "A list of execution results.",
+    "items": {
+      "$ref": "#/ExecutionResult"
+    }
+  },
+  "ElementType": {
+    "type": "string",
+    "description": "The type of an element.",
+    "enum": [
+      "Wall",
+      "Column",
+      "Beam",
+      "Window",
+      "Door",
+      "Object",
+      "Lamp",
+      "Slab",
+      "Roof",
+      "Mesh",
+      "Dimension",
+      "RadialDimension",
+      "LevelDimension",
+      "AngleDimension",
+      "Text",
+      "Label",
+      "Zone",
+      "Hatch",
+      "Line",
+      "PolyLine",
+      "Arc",
+      "Circle",
+      "Spline",
+      "Hotspot",
+      "CutPlane",
+      "Camera",
+      "CamSet",
+      "Group",
+      "SectElem",
+      "Drawing",
+      "Picture",
+      "Detail",
+      "Elevation",
+      "InteriorElevation",
+      "Worksheet",
+      "Hotlink",
+      "CurtainWall",
+      "CurtainWallSegment",
+      "CurtainWallFrame",
+      "CurtainWallPanel",
+      "CurtainWallJunction",
+      "CurtainWallAccessory",
+      "Shell",
+      "Skylight",
+      "Morph",
+      "ChangeMarker",
+      "Stair",
+      "Riser",
+      "Tread",
+      "StairStructure",
+      "Railing",
+      "RailingToprail",
+      "RailingHandrail",
+      "RailingRail",
+      "RailingPost",
+      "RailingInnerPost",
+      "RailingBaluster",
+      "RailingPanel",
+      "RailingSegment",
+      "RailingNode",
+      "RailingBalusterSet",
+      "RailingPattern",
+      "RailingToprailEnd",
+      "RailingHandrailEnd",
+      "RailingRailEnd",
+      "RailingToprailConnection",
+      "RailingHandrailConnection",
+      "RailingRailConnection",
+      "RailingEndFinish",
+      "BeamSegment",
+      "ColumnSegment",
+      "Opening",
+      "Unknown"
+    ]
+  },
+  "ElementFilter": {
+    "type": "string",
+    "description": "A filter type for an element.",
+    "enum": [
+      "IsEditable",
+      "IsVisibleByLayer",
+      "IsVisibleByRenovation",
+      "IsVisibleByStructureDisplay",
+      "IsVisibleIn3D",
+      "OnActualFloor",
+      "OnActualLayout",
+      "InMyWorkspace",
+      "IsIndependent",
+      "InCroppedView",
+      "HasAccessRight",
+      "IsOverriddenByRenovation"
+    ]
+  },
+  "WindowType": {
+    "type": "string",
+    "description": "The type of a window.",
+    "enum": [
+      "FloorPlan",
+      "Section",
+      "Details",
+      "3DModel",
+      "Layout",
+      "Drawing",
+      "CustomText",
+      "CustomDraw",
+      "MasterLayout",
+      "Elevation",
+      "InteriorElevation",
+      "Worksheet",
+      "Report",
+      "3DDocument",
+      "External3D",
+      "Movie3D",
+      "MovieRendering",
+      "Rendering",
+      "ModelCompare",
+      "Interactive Schedule",
+      "Unknown"
+    ]
+  },
+  "IssueId": {
+    "type": "object",
+    "description": "The identifier of an issue.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "IssueIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "issueId": {
+        "$ref": "#/IssueId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "issueId"
+    ]
+  },
+  "Issues": {
+    "type": "array",
+    "description": "A list of Issues.",
+    "items": {
+      "$ref": "#/IssueIdArrayItem"
+    }
+  },
+  "IssueElementType": {
+    "type": "string",
+    "description": "The attachment type of an element component of an issue.",
+    "enum": [
+      "Creation",
+      "Highlight",
+      "Deletion",
+      "Modification"
+    ]
+  },
+  "IssueCommentStatus": {
+    "type": "string",
+    "description": "The status of an issue comment.",
+    "enum": [
+      "Error",
+      "Warning",
+      "Info",
+      "Unknown"
+    ]
+  },
+  "PropertyId": {
+    "type": "object",
+    "description": "The identifier of a property.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "PropertyGroupId": {
+    "type": "object",
+    "description": "The identifier of a property group.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "PropertyIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "propertyId": {
+        "$ref": "#/PropertyId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "propertyId"
+    ]
+  },
+  "PropertyIds": {
+    "type": "array",
+    "description": "A list of property identifiers.",
+    "items": {
+      "$ref": "#/PropertyIdArrayItem"
+    }
+  },
+  "PropertyDetails": {
+    "type": "object",
+    "description": "The details of the property.",
+    "properties": {
+      "propertyId": {
+        "$ref": "#/PropertyId"
+      },
+      "propertyType": {
+        "type": "string",
+        "enum": [
+          "StaticBuiltIn",
+          "DynamicBuiltIn",
+          "Custom"
+        ]
+      },
+      "propertyGroupName": {
+        "type": "string"
+      },
+      "propertyName": {
+        "type": "string"
+      },
+      "propertyCollectionType": {
+        "type": "string",
+        "enum": [
+          "Undefined",
+          "Single",
+          "List",
+          "SingleChoiceEnumeration",
+          "MultipleChoiceEnumeration"
+        ]
+      },
+      "propertyValueType": {
+        "type": "string",
+        "enum": [
+          "Undefined",
+          "Integer",
+          "Real",
+          "String",
+          "Boolean",
+          "Guid"
+        ]
+      },
+      "propertyMeasureType": {
+        "type": "string",
+        "enum": [
+          "Undefined",
+          "Default",
+          "Length",
+          "Area",
+          "Volume",
+          "Angle"
+        ]
+      },
+      "propertyIsEditable": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "propertyId",
+      "propertyType",
+      "propertyGroupName",
+      "propertyName",
+      "propertyCollectionType",
+      "propertyValueType",
+      "propertyMeasureType",
+      "propertyIsEditable"
+    ]
+  },
+  "PropertyValue": {
+    "type": "object",
+    "description": "The display string value of a property.",
+    "properties": {
+      "value": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": true,
+    "required": [
+      "value"
+    ]
+  },
+  "PropertyValueOrErrorItem": {
+    "type": "object",
+    "description": "A property value or an error",
+    "oneOf": [
+      {
+        "title": "propertyValue",
+        "properties": {
+          "propertyValue": {
+            "$ref": "#/PropertyValue"
+          }
+        },
+        "additionalProperties": false,
+        "required": [ "propertyValue" ]
+      },
+      {
+        "title": "error",
+        "$ref": "#/ErrorItem"
+      }
+    ]
+  },
+  "PropertyValues": {
+    "type": "array",
+    "description": "A list of property values.",
+    "items": {
+      "$ref": "#/PropertyValueOrErrorItem"
+    }
+  },
+  "PropertyValuesOrError": {
+    "type": "object",
+    "description": "A list of property values or an error.",
+    "oneOf": [
+      {
+        "title": "propertyValues",
+        "properties": {
+          "propertyValues": {
+            "$ref": "#/PropertyValues"
+          }
+        },
+        "additionalProperties": false,
+        "required": [ "propertyValues" ]
+      },
+      {
+        "title": "error",
+        "$ref": "#/ErrorItem"
+      }
+    ]
+  },
+  "PropertyValuesOrErrorArray": {
+    "type": "array",
+    "description": "A list of property value lists.",
+    "items": {
+      "$ref": "#/PropertyValuesOrError"
+    }
+  },
+  "PropertyIdOrError": {
+    "type": "object",
+    "description": "A propertyId or an error.",
+    "oneOf": [
+      {
+        "properties": {
+          "propertyId": {
+            "$ref": "#/PropertyId"
+          }
+        },
+        "additionalProperties": false,
+        "required": [ "propertyId" ]
+      },
+      {
+        "$ref": "#/ErrorItem"
+      }
+    ]
+  },
+  "PropertyIdOrErrorArray": {
+    "type": "array",
+    "description": "A list of property identifiers.",
+    "items": {
+      "$ref": "#/PropertyIdOrError"
+    }
+  },
+  "ElementPropertyValue": {
+    "type": "object",
+    "description": "A property value with the identifiers of the property and its owner element.",
+    "properties": {
+      "elementId": {
+        "$ref": "#/ElementId"
+      },
+      "propertyId": {
+        "$ref": "#/PropertyId"
+      },
+      "propertyValue": {
+        "$ref": "#/PropertyValue"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "elementId",
+      "propertyId",
+      "propertyValue"
+    ]
+  },
+  "ElementPropertyValues": {
+    "type": "array",
+    "description": "A list of element property values.",
+    "items": {
+      "$ref": "#/ElementPropertyValue"
+    }
+  },
+  "PropertyType": {
+    "type": "string",
+    "enum": [
+      "number",
+      "integer",
+      "string",
+      "boolean",
+      "length",
+      "area",
+      "volume",
+      "angle",
+      "numberList",
+      "integerList",
+      "stringList",
+      "booleanList",
+      "lengthList",
+      "areaList",
+      "volumeList",
+      "angleList",
+      "singleEnum",
+      "multiEnum"
+    ]
+  },
+  "DisplayValueEnumId": {
+    "type": "object",
+    "description": "An enumeration value identifier using the displayed value.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "displayValue" ]
+      },
+      "displayValue": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "type",
+      "displayValue"
+    ]
+  },
+  "NonLocalizedValueEnumId": {
+    "type": "object",
+    "description": "An enumeration value identifier using the nonlocalized value.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "nonLocalizedValue" ]
+      },
+      "nonLocalizedValue": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "type",
+      "nonLocalizedValue"
+    ]
+  },
+  "EnumValueId": {
+    "type": "object",
+    "description": "The identifier of a property enumeration value.",
+    "oneOf": [
+      {
+        "$ref": "#/DisplayValueEnumId"
+      },
+      {
+        "$ref": "#/NonLocalizedValueEnumId"
+      }
+    ]
+  },
+  "EnumValueIds": {
+    "type": "array",
+    "description": "A list of enumeration identifiers.",
+    "items": {
+      "type": "object",
+      "properties": {
+        "enumValueId": {
+          "$ref": "#/EnumValueId"
+        }
+      },
+      "additionalProperties": false,
+      "required": [ "enumValueId" ]
+    }
+  },
+  "NormalOrUserUndefinedPropertyValue": {
+    "type": "object",
+    "description": "A normal or a userUndefined property value.",
+    "oneOf": [
+      {
+        "$ref": "#/NormalNumberPropertyValue"
+      },
+      {
+        "$ref": "#/NormalIntegerPropertyValue"
+      },
+      {
+        "$ref": "#/NormalStringPropertyValue"
+      },
+      {
+        "$ref": "#/NormalBooleanPropertyValue"
+      },
+      {
+        "$ref": "#/NormalLengthPropertyValue"
+      },
+      {
+        "$ref": "#/NormalAreaPropertyValue"
+      },
+      {
+        "$ref": "#/NormalVolumePropertyValue"
+      },
+      {
+        "$ref": "#/NormalAnglePropertyValue"
+      },
+      {
+        "$ref": "#/NormalNumberListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalIntegerListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalStringListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalBooleanListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalLengthListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalAreaListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalVolumeListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalAngleListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalSingleEnumPropertyValue"
+      },
+      {
+        "$ref": "#/NormalMultiEnumPropertyValue"
+      },
+      {
+        "$ref": "#/UserUndefinedPropertyValue"
+      }
+    ]
+  },
+  "PropertyValueDetails": {
+    "type": "object",
+    "description": "A normal, userUndefined, notAvailable or notEvaluated property value.",
+    "oneOf": [
+      {
+        "$ref": "#/NormalOrUserUndefinedPropertyValue"
+      },
+      {
+        "$ref": "#/NotAvailablePropertyValue"
+      }
+    ]
+  },
+  "UserUndefinedPropertyValue": {
+    "type": "object",
+    "description": "A userUndefined value means that there is no actual number/string/etc. value, but the user deliberately set an Undefined value: this is a valid value, too.",
+    "properties": {
+      "type": {
+        "$ref": "#/PropertyType"
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "userUndefined" ]
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status" ]
+  },
+  "NotAvailablePropertyValue": {
+    "type": "object",
+    "description": "A notAvailable value means that the property is not available for the property owner (and therefore it has no property value for it).",
+    "properties": {
+      "type": {
+        "$ref": "#/PropertyType"
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "notAvailable" ]
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "type",
+      "status"
+    ]
+  },
+  "NormalNumberPropertyValue": {
+    "type": "object",
+    "description": "A number property value containing a valid numeric value.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "number" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "number"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalIntegerPropertyValue": {
+    "type": "object",
+    "description": "An integer property value containing a valid integer number.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "integer" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "integer"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalStringPropertyValue": {
+    "type": "object",
+    "description": "A string property value containing a valid string.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "string" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalBooleanPropertyValue": {
+    "type": "object",
+    "description": "A boolean property value containing a valid boolean value.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "boolean" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalLengthPropertyValue": {
+    "type": "object",
+    "description": "A length property value containing a real length value. The value is measured in SI (meters).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "length" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "number"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalAreaPropertyValue": {
+    "type": "object",
+    "description": "An area property value containing a real area. The value is measured in SI (square meters).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "area" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "number"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalVolumePropertyValue": {
+    "type": "object",
+    "description": "A volume property value containing a real volume. The value is measured in SI (cubic meters).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "volume" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "number"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalAnglePropertyValue": {
+    "type": "object",
+    "description": "An angle property value containing a real angle. The value is measured in SI (radians).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "angle" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "number"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalNumberListPropertyValue": {
+    "type": "object",
+    "description": "A number list property value containing numbers in an array.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "numberList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalIntegerListPropertyValue": {
+    "type": "object",
+    "description": "An integer list property value containing integers in an array.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "integerList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "integer"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalStringListPropertyValue": {
+    "type": "object",
+    "description": "A string list property value containing strings in an array.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "stringList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalBooleanListPropertyValue": {
+    "type": "object",
+    "description": "A boolean list property value containing boolean values in an array.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "booleanList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "boolean"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalLengthListPropertyValue": {
+    "type": "object",
+    "description": "A length list property value containing length values in an array. The values are measured in SI (meters).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "lengthList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalAreaListPropertyValue": {
+    "type": "object",
+    "description": "An area list property value containing areas in an array. The values are measured in SI (square meters).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "areaList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalVolumeListPropertyValue": {
+    "type": "object",
+    "description": "A volume list property value containing volumes in an array. The values are measured in SI (cubic meters).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "volumeList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalAngleListPropertyValue": {
+    "type": "object",
+    "description": "An angle list property value containing angles in an array. The values are measured in SI (radians).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "angleList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalSingleEnumPropertyValue": {
+    "type": "object",
+    "description": "A single enumeration property value containing the ID of the selected enum value.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "singleEnum" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "$ref": "#/EnumValueId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalMultiEnumPropertyValue": {
+    "type": "object",
+    "description": "A multiple choice enumeration property value containing the IDs of the selected enum values in an array.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "multiEnum" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "$ref": "#/EnumValueIds"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "BasicDefaultValue": {
+    "type": "object",
+    "description": "Default value of the property in case of a basic property value (ie. not an expression).",
+    "properties": {
+      "basicDefaultValue": {
+        "$ref": "#/PropertyValueDetails"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "basicDefaultValue"
+    ]
+  },
+  "ExpressionDefaultValue": {
+    "type": "object",
+    "description": "Default value of the property in case of an expression based property value.",
+    "properties": {
+      "expressions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "expressions"
+    ]
+  },
+  "PropertyDefaultValue": {
+    "type": "object",
+    "oneOf": [
+      {
+        "$ref": "#/BasicDefaultValue"
+      },
+      {
+        "$ref": "#/ExpressionDefaultValue"
+      }
+    ]
+  },
+  "ClassificationSystemId": {
+    "type": "object",
+    "description": "The identifier of a classification system.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "ClassificationSystemIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "classificationSystemId": {
+        "$ref": "#/ClassificationSystemId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "classificationSystemId"
+    ]
+  },
+  "ClassificationSystemIds": {
+    "type": "array",
+    "description": "A list of classification system identifiers.",
+    "items": {
+      "$ref": "#/ClassificationSystemIdArrayItem"
+    }
+  },
+  "ClassificationItemId": {
+    "type": "object",
+    "description": "The identifier of a classification item.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "ClassificationItemIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "classificationItemId": {
+        "$ref": "#/ClassificationItemId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "classificationItemId"
+    ]
+  },
+  "ClassificationId": {
+    "type": "object",
+    "description": "The element classification identifier.",
+    "properties": {
+      "classificationSystemId": {
+        "$ref": "#/ClassificationSystemId"
+      },
+      "classificationItemId": {
+        "$ref": "#/ClassificationItemId",
+        "description": "The element's classification in the given system. If no value is specified here, the element is Unclassified in this system."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "classificationSystemId"
+    ]
+  },
+  "ClassificationIdOrError": {
+    "type": "object",
+    "description": "A classification identifier or an error.",
+    "oneOf": [
+      {
+        "title": "classificationId",
+        "properties": {
+          "classificationId": {
+            "$ref": "#/ClassificationId"
+          }
+        },
+        "additionalProperties": false,
+        "required": [ "classificationId" ]
+      },
+      {
+        "title": "error",
+        "$ref": "#/ErrorItem"
+      }
+    ]
+  },
+  "ClassificationIdsOrErrors": {
+    "type": "array",
+    "description": "A list of element classification identifiers or errors.",
+    "items": {
+      "$ref": "#/ClassificationIdOrError"
+    }
+  },
+  "ElementClassificationOrError": {
+    "type": "object",
+    "description": "Element classification identifiers or errors.",
+    "oneOf": [
+      {
+        "title": "classificationIds",
+        "properties": {
+          "classificationIds": {
+            "$ref": "#/ClassificationIdsOrErrors"
+          }
+        },
+        "additionalProperties": false,
+        "required": [ "classificationIds" ]
+      },
+      {
+        "title": "error",
+        "$ref": "#/ErrorItem"
+      }
+    ]
+  },
+  "ElementClassificationsOrErrors": {
+    "type": "array",
+    "description": "A list of element classification identifiers or errors.",
+    "items": {
+      "$ref": "#/ElementClassificationOrError"
+    }
+  },
+  "ElementClassification": {
+    "type": "object",
+    "description": "The classification of an element.",
+    "properties": {
+      "elementId": {
+        "$ref": "#/ElementId"
+      },
+      "classificationId": {
+        "$ref": "#/ClassificationId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "elementId",
+      "classificationId"
+    ]
+  },
+  "ElementClassifications": {
+    "type": "array",
+    "description": "A list of element classification identifiers.",
+    "items": {
+      "$ref": "#/ElementClassification"
+    }
+  },
+  "BoundingBox3D": {
+    "type": "object",
+    "description": "A 3D bounding box of an element.",
+    "properties": {
+      "xMin": {
+        "type": "number",
+        "description": "The minimum X value of the bounding box."
+      },
+      "yMin": {
+        "type": "number",
+        "description": "The minimum Y value of the bounding box."
+      },
+      "zMin": {
+        "type": "number",
+        "description": "The minimum Z value of the bounding box."
+      },
+      "xMax": {
+        "type": "number",
+        "description": "The maximum X value of the bounding box."
+      },
+      "yMax": {
+        "type": "number",
+        "description": "The maximum Y value of the bounding box."
+      },
+      "zMax": {
+        "type": "number",
+        "description": "The maximum Z value of the bounding box."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "xMin",
+      "yMin",
+      "zMin",
+      "xMax",
+      "yMax",
+      "zMax"
+    ]
+  },
+  "BoundingBox3DOrError": {
+    "type": "object",
+    "description": "A 3D bounding box or an error.",
+    "oneOf": [
+      {
+        "title": "boundingBox3D",
+        "properties": {
+          "boundingBox3D": {
+            "$ref": "#/BoundingBox3D"
+          }
+        },
+        "additionalProperties": false,
+        "required": [ "boundingBox3D" ]
+      },
+      {
+        "title": "error",
+        "$ref": "#/ErrorItem"
+      }
+    ]
+  },
+  "BoundingBoxes3D": {
+    "type": "array",
+    "description": "A list of 3D bounding boxes.",
+    "items": {
+      "$ref": "#/BoundingBox3DOrError"
+    }
+  },
+  "LibPartUnId": {
+    "type": "object",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "LibPartDetails": {
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "parentUnID": {
+        "$ref": "#/LibPartUnId"
+      },
+      "ownUnID": {
+        "$ref": "#/LibPartUnId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "name",
+      "parentUnID",
+      "ownUnID"
+    ]
+  },
+  "NavigatorItemIds": {
+    "type": "array",
+    "description": "A list of navigator item identifiers.",
+    "items": {
+      "$ref": "#/NavigatorItemIdArrayItem"
+    }
+  },
+  "NavigatorItemIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "navigatorItemId": {
+        "$ref": "#/NavigatorItemId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "navigatorItemId"
+    ]
+  },
+  "NavigatorItemId": {
+    "type": "object",
+    "description": "The identifier of a navigator item.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "Databases": {
+    "type": "array",
+    "description": "A list of Archicad databases.",
+    "items": {
+      "$ref": "#/DatabaseIdArrayItem"
+    }
+  },
+  "DatabaseIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "databaseId": {
+        "$ref": "#/DatabaseId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "databaseId"
+    ]
+  },
+  "DatabaseId": {
+    "type": "object",
+    "description": "The identifier of a database",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  }
 }

--- a/archicad-addon/Test/ExpectedOutputs/update_drawings.py.output
+++ b/archicad-addon/Test/ExpectedOutputs/update_drawings.py.output
@@ -1,0 +1,147 @@
+Command: GetDatabaseIdFromNavigatorItemId
+Parameters:
+{
+    "navigatorItemIds": [
+        {
+            "navigatorItemId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "navigatorItemId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "navigatorItemId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "navigatorItemId": {
+                "guid": "<GUID>"
+            }
+        }
+    ]
+}
+Response:
+{
+    "databases": [
+        {
+            "databaseId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "databaseId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "databaseId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "databaseId": {
+                "guid": "<GUID>"
+            }
+        }
+    ]
+}
+Command: GetElementsByType
+Parameters:
+{
+    "elementType": "Drawing",
+    "databases": [
+        {
+            "databaseId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "databaseId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "databaseId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "databaseId": {
+                "guid": "<GUID>"
+            }
+        }
+    ]
+}
+Response:
+{
+    "elements": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        }
+    ],
+    "executionResultForDatabases": [
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        },
+        {
+            "success": true
+        }
+    ]
+}
+Command: UpdateDrawings
+Parameters:
+{
+    "elements": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        }
+    ]
+}
+Response:
+{
+    "success": true
+}

--- a/archicad-addon/Test/TestProject.pla
+++ b/archicad-addon/Test/TestProject.pla
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9d2ea21ad3ed7b47837524fba8fa6e6693db614c6cd6df3fcac3e4328276a73a
-size 106806720
+oid sha256:029fa42b233c46d9e10bd006a3e7ad569d54bc0889ee2965b053e29a880d5ecc
+size 106442976

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -308,6 +308,9 @@ var gCommands = [{
                     "$ref": "#/ElementFilter"
                 },
                 "minItems": 1
+            },
+            "databases": {
+                 "$ref": "#/Databases"
             }
         },
         "additionalProperties": false,
@@ -320,11 +323,15 @@ var gCommands = [{
         "properties": {
             "elements": {
                 "$ref": "#/Elements"
+            },
+            "executionResultForDatabases": {
+                "$ref": "#/ExecutionResults"
             }
         },
         "additionalProperties": false,
         "required": [
-            "elements"
+            "elements",
+            "executionResultForDatabases"
         ]
     }
             },{
@@ -340,6 +347,9 @@ var gCommands = [{
                     "$ref": "#/ElementFilter"
                 },
                 "minItems": 1
+            },
+            "databases": {
+                 "$ref": "#/Databases"
             }
         },
         "additionalProperties": false,
@@ -350,11 +360,15 @@ var gCommands = [{
         "properties": {
             "elements": {
                 "$ref": "#/Elements"
+            },
+            "executionResultForDatabases": {
+                "$ref": "#/ExecutionResults"
             }
         },
         "additionalProperties": false,
         "required": [
-            "elements"
+            "elements",
+            "executionResultForDatabases"
         ]
     }
             },{
@@ -2238,13 +2252,17 @@ var gCommands = [{
                 "version": "0.1.0",
                 "description": "Performs a send operation on the currently opened Teamwork project.",
                 "inputScheme": null,
-                "outputScheme": null
+                "outputScheme": {
+        "$ref": "#/ExecutionResult"
+    }
             },{
                 "name": "TeamworkReceive",
                 "version": "0.1.0",
                 "description": "Performs a receive operation on the currently opened Teamwork project.",
                 "inputScheme": null,
-                "outputScheme": null
+                "outputScheme": {
+        "$ref": "#/ExecutionResult"
+    }
             },{
                 "name": "ReserveElements",
                 "version": "1.1.4",
@@ -2370,6 +2388,34 @@ var gCommands = [{
                 "outputScheme": {
         "$ref": "#/ExecutionResult"
     }
+            },{
+                "name": "GetDatabaseIdFromNavigatorItemId",
+                "version": "1.1.4",
+                "description": "Gets the ID of the database associated with the supplied navigator item id",
+                "inputScheme": {
+    "type": "object",
+    "properties": {
+        "navigatorItemIds": {
+            "$ref": "#/NavigatorItemIds"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "navigatorItemIds"
+    ]
+},
+                "outputScheme": {
+    "type": "object",
+    "properties": {
+        "databases": {
+            "$ref": "#/Databases"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "databases"
+    ]
+}
             }]
         },{
             "name": "Issue Management Commands",

--- a/docs/archicad-addon/common_schema_definitions.js
+++ b/docs/archicad-addon/common_schema_definitions.js
@@ -1,1572 +1,1636 @@
 var gSchemaDefinitions = {
-    "Elements": {
-        "type": "array",
-        "description": "A list of elements.",
-        "items": {
-            "$ref": "#/ElementIdArrayItem"
-        }
-    },
-    "ElementIdArrayItem": {
-        "type": "object",
-        "properties": {
-            "elementId": {
-                "$ref": "#/ElementId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "elementId"
-        ]
-    },
-    "ElementId": {
-        "type": "object",
-        "description": "The identifier of an element.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "AttributeType": {
-        "type": "string",
-        "description": "The type of an attribute.",
-        "enum": [
-            "Layer",
-            "Line",
-            "Fill",
-            "Composite",
-            "Surface",
-            "LayerCombination",
-            "ZoneCategory",
-            "Profile",
-            "PenTable",
-            "MEPSystem",
-            "OperationProfile",
-            "BuildingMaterial"
-        ]
-    },
-    "AttributeIds": {
-        "type": "array",
-        "description": "A list of attributes.",
-        "items": {
-            "$ref": "#/AttributeIdArrayItem"
-        }
-    },
-    "AttributeIdArrayItem": {
-        "type": "object",
-        "properties": {
-            "attributeId": {
-                "$ref": "#/AttributeId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "attributeId"
-        ]
-    },
-    "AttributeId": {
-        "type": "object",
-        "description": "The identifier of an attribute.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "Guid": {
-        "type": "string",
-        "description": "A Globally Unique Identifier (or Universally Unique Identifier) in its string representation as defined in RFC 4122.",
-        "format": "uuid",
-        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-    },
-    "Hotlinks": {
-        "type": "array",
-        "description": "A list of hotlink nodes.",
-        "items": {
-            "$ref": "#/Hotlink"
-        }
-    },
-    "Hotlink": {
-        "type": "object",
-        "description": "The details of a hotlink node.",
-        "properties": {
-            "location": {
-                "type": "string",
-                "description": "The path of the hotlink file."
-            },
-            "children": {
-                "$ref": "#/Hotlinks",
-                "description": "The children of the hotlink node if it has any."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "location"
-        ]
-    },
-    "GDLParameterList": {
-        "type": "object",
-        "description": "The list of GDL parameters.",
-        "properties": {
-            "parameters": {
-                "type": "array",
-                "description": "The list of GDL parameters.",
-                "items": {
-                    "$ref": "#/GDLParameterDetails"
-                }
-            }
-        },
-        "required": [
-            "parameters"
-        ]
-    },
-    "GDLParameterDetails": {
-        "type": "object",
-        "description": "Details of a GDL parameter.",
-        "properties": {
-            "name": {
-                "type": "string",
-                "description": "The name of the parameter."
-            },
-            "index": {
-                "type": "string",
-                "description": "The index of the parameter."
-            },
-            "type": {
-                "type": "string",
-                "description": "The type of the parameter."
-            },
-            "dimension1": {
-                "type": "number",
-                "description": "The 1st dimension of array (in case of array value)."
-            },
-            "dimension2": {
-                "type": "number",
-                "description": "The 2nd dimension of array (in case of array value)."
-            },
-            "value": {
-                "description": "The value of the parameter."
-            }
-        },
-        "additionalProperties": true,
-        "required": [
-            "index",
-            "type",
-            "value"
-        ]
-    },
-    "2DCoordinate": {
-        "type": "object",
-        "description": "2D coordinate.",
-        "properties": {
-            "x": {
-                "type": "number",
-                "description": "X value of the coordinate."
-            },
-            "y": {
-                "type": "number",
-                "description": "Y value of the coordinate."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "x",
-            "y"
-        ]
-    },
-    "3DCoordinate": {
-        "type": "object",
-        "description": "3D coordinate.",
-        "properties": {
-            "x": {
-                "type": "number",
-                "description": "X value of the coordinate."
-            },
-            "y": {
-                "type": "number",
-                "description": "Y value of the coordinate."
-            },
-            "z": {
-                "type": "number",
-                "description": "Z value of the coordinate."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "x",
-            "y",
-            "z"
-        ]
-    },
-    "3DDimensions": {
-        "type": "object",
-        "description": "Dimensions in 3D.",
-        "properties": {
-            "x": {
-                "type": "number",
-                "description": "X dimension."
-            },
-            "y": {
-                "type": "number",
-                "description": "Y dimension."
-            },
-            "z": {
-                "type": "number",
-                "description": "Z dimension."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "x",
-            "y",
-            "z"
-        ]
-    },
-    "Error": {
-        "type": "object",
-        "description": "The details of an error.",
-        "properties": {
-            "code": {
-                "type": "integer",
-                "description": "The code of the error."
-            },
-            "message": {
-                "type": "string",
-                "description": "The error message."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "code",
-            "message"
-        ]
-    },
-    "ErrorItem": {
-        "type": "object",
-        "properties": {
-            "error": {
-                "$ref": "#/Error"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "error" ]
-    },
-    "SuccessfulExecutionResult": {
-        "type": "object",
-        "description": "The result of a successful execution.",
-        "properties": {
-            "success": {
-                "type": "boolean",
-                "enum": [ true ]
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "success"
-        ]
-    },
-    "FailedExecutionResult": {
-        "type": "object",
-        "description": "The result of a failed execution.",
-        "properties": {
-            "success": {
-                "type": "boolean",
-                "enum": [ false ]
-            },
-            "error": {
-                "$ref": "#/Error",
-                "description": "The details of an execution failure."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "success",
-            "error"
-        ]
-    },
-    "ExecutionResult": {
-        "type": "object",
-        "description": "The result of the execution.",
-        "oneOf": [
-            {
-                "$ref": "#/SuccessfulExecutionResult"
-            },
-            {
-                "$ref": "#/FailedExecutionResult"
-            }
-        ]
-    },
-    "ExecutionResults": {
-        "type": "array",
-        "description": "A list of execution results.",
-        "items": {
-            "$ref": "#/ExecutionResult"
-        }
-    },
-    "ElementType": {
-        "type": "string",
-        "description": "The type of an element.",
-        "enum": [
-            "Wall",
-            "Column",
-            "Beam",
-            "Window",
-            "Door",
-            "Object",
-            "Lamp",
-            "Slab",
-            "Roof",
-            "Mesh",
-            "Dimension",
-            "RadialDimension",
-            "LevelDimension",
-            "AngleDimension",
-            "Text",
-            "Label",
-            "Zone",
-            "Hatch",
-            "Line",
-            "PolyLine",
-            "Arc",
-            "Circle",
-            "Spline",
-            "Hotspot",
-            "CutPlane",
-            "Camera",
-            "CamSet",
-            "Group",
-            "SectElem",
-            "Drawing",
-            "Picture",
-            "Detail",
-            "Elevation",
-            "InteriorElevation",
-            "Worksheet",
-            "Hotlink",
-            "CurtainWall",
-            "CurtainWallSegment",
-            "CurtainWallFrame",
-            "CurtainWallPanel",
-            "CurtainWallJunction",
-            "CurtainWallAccessory",
-            "Shell",
-            "Skylight",
-            "Morph",
-            "ChangeMarker",
-            "Stair",
-            "Riser",
-            "Tread",
-            "StairStructure",
-            "Railing",
-            "RailingToprail",
-            "RailingHandrail",
-            "RailingRail",
-            "RailingPost",
-            "RailingInnerPost",
-            "RailingBaluster",
-            "RailingPanel",
-            "RailingSegment",
-            "RailingNode",
-            "RailingBalusterSet",
-            "RailingPattern",
-            "RailingToprailEnd",
-            "RailingHandrailEnd",
-            "RailingRailEnd",
-            "RailingToprailConnection",
-            "RailingHandrailConnection",
-            "RailingRailConnection",
-            "RailingEndFinish",
-            "BeamSegment",
-            "ColumnSegment",
-            "Opening",
-            "Unknown"
-        ]
-    },
-    "ElementFilter": {
-        "type": "string",
-        "description": "A filter type for an element.",
-        "enum": [
-            "IsEditable",
-            "IsVisibleByLayer",
-            "IsVisibleByRenovation",
-            "IsVisibleByStructureDisplay",
-            "IsVisibleIn3D",
-            "OnActualFloor",
-            "OnActualLayout",
-            "InMyWorkspace",
-            "IsIndependent",
-            "InCroppedView",
-            "HasAccessRight",
-            "IsOverriddenByRenovation"
-        ]
-    },
-    "WindowType": {
-        "type": "string",
-        "description": "The type of a window.",
-        "enum": [
-            "FloorPlan",
-            "Section",
-            "Details",
-            "3DModel",
-            "Layout",
-            "Drawing",
-            "CustomText",
-            "CustomDraw",
-            "MasterLayout",
-            "Elevation",
-            "InteriorElevation",
-            "Worksheet",
-            "Report",
-            "3DDocument",
-            "External3D",
-            "Movie3D",
-            "MovieRendering",
-            "Rendering",
-            "ModelCompare",
-            "Interactive Schedule",
-            "Unknown"
-        ]
-    },
-    "IssueId": {
-        "type": "object",
-        "description": "The identifier of an issue.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "IssueIdArrayItem": {
-        "type": "object",
-        "properties": {
-            "issueId": {
-                "$ref": "#/IssueId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "issueId"
-        ]
-    },
-    "Issues": {
-        "type": "array",
-        "description": "A list of Issues.",
-        "items": {
-            "$ref": "#/IssueIdArrayItem"
-        }
-    },
-    "IssueElementType": {
-        "type": "string",
-        "description": "The attachment type of an element component of an issue.",
-        "enum": [
-            "Creation",
-            "Highlight",
-            "Deletion",
-            "Modification"
-        ]
-    },
-    "IssueCommentStatus": {
-        "type": "string",
-        "description": "The status of an issue comment.",
-        "enum": [
-            "Error",
-            "Warning",
-            "Info",
-            "Unknown"
-        ]
-    },
-    "PropertyId": {
-        "type": "object",
-        "description": "The identifier of a property.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "PropertyGroupId": {
-        "type": "object",
-        "description": "The identifier of a property group.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "PropertyIdArrayItem": {
-        "type": "object",
-        "properties": {
-            "propertyId": {
-                "$ref": "#/PropertyId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "propertyId"
-        ]
-    },
-    "PropertyIds": {
-        "type": "array",
-        "description": "A list of property identifiers.",
-        "items": {
-            "$ref": "#/PropertyIdArrayItem"
-        }
-    },
-    "PropertyDetails": {
-        "type": "object",
-        "description": "The details of the property.",
-        "properties": {
-            "propertyId": {
-                "$ref": "#/PropertyId"
-            },
-            "propertyType": {
-                "type": "string",
-                "enum": [
-                    "StaticBuiltIn",
-                    "DynamicBuiltIn",
-                    "Custom"
-                ]
-            },
-            "propertyGroupName": {
-                "type": "string"
-            },
-            "propertyName": {
-                "type": "string"
-            },
-            "propertyCollectionType": {
-                "type": "string",
-                "enum": [
-                    "Undefined",
-                    "Single",
-                    "List",
-                    "SingleChoiceEnumeration",
-                    "MultipleChoiceEnumeration"
-                ]
-            },
-            "propertyValueType": {
-                "type": "string",
-                "enum": [
-                    "Undefined",
-                    "Integer",
-                    "Real",
-                    "String",
-                    "Boolean",
-                    "Guid"
-                ]
-            },
-            "propertyMeasureType": {
-                "type": "string",
-                "enum": [
-                    "Undefined",
-                    "Default",
-                    "Length",
-                    "Area",
-                    "Volume",
-                    "Angle"
-                ]
-            },
-            "propertyIsEditable": {
-                "type": "boolean"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "propertyId",
-            "propertyType",
-            "propertyGroupName",
-            "propertyName",
-            "propertyCollectionType",
-            "propertyValueType",
-            "propertyMeasureType",
-            "propertyIsEditable"
-        ]
-    },
-    "PropertyValue": {
-        "type": "object",
-        "description": "The display string value of a property.",
-        "properties": {
-            "value": {
-                "type": "string"
-            }
-        },
-        "additionalProperties": true,
-        "required": [
-            "value"
-        ]
-    },
-    "PropertyValueOrErrorItem": {
-        "type": "object",
-        "description": "A property value or an error",
-        "oneOf": [
-            {
-                "title": "propertyValue",
-                "properties": {
-                    "propertyValue": {
-                        "$ref": "#/PropertyValue"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "propertyValue" ]
-            },
-            {
-                "title": "error",
-                "$ref": "#/ErrorItem"
-            }
-        ]
-    },
-    "PropertyValues": {
-        "type": "array",
-        "description": "A list of property values.",
-        "items": {
-            "$ref": "#/PropertyValueOrErrorItem"
-        }
-    },
-    "PropertyValuesOrError": {
-        "type": "object",
-        "description": "A list of property values or an error.",
-        "oneOf": [
-            {
-                "title": "propertyValues",
-                "properties": {
-                    "propertyValues": {
-                        "$ref": "#/PropertyValues"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "propertyValues" ]
-            },
-            {
-                "title": "error",
-                "$ref": "#/ErrorItem"
-            }
-        ]
-    },
-    "PropertyValuesOrErrorArray": {
-        "type": "array",
-        "description": "A list of property value lists.",
-        "items": {
-            "$ref": "#/PropertyValuesOrError"
-        }
-    },
-    "PropertyIdOrError": {
-        "type": "object",
-        "description": "A propertyId or an error.",
-        "oneOf": [
-            {
-                "properties": {
-                    "propertyId": {
-                        "$ref": "#/PropertyId"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "propertyId" ]
-            },
-            {
-                "$ref": "#/ErrorItem"
-            }
-        ]
-    },
-    "PropertyIdOrErrorArray": {
-        "type": "array",
-        "description": "A list of property identifiers.",
-        "items": {
-            "$ref": "#/PropertyIdOrError"
-        }
-    },
-    "ElementPropertyValue": {
-        "type": "object",
-        "description": "A property value with the identifiers of the property and its owner element.",
-        "properties": {
-            "elementId": {
-                "$ref": "#/ElementId"
-            },
-            "propertyId": {
-                "$ref": "#/PropertyId"
-            },
-            "propertyValue": {
-                "$ref": "#/PropertyValue"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "elementId",
-            "propertyId",
-            "propertyValue"
-        ]
-    },
-    "ElementPropertyValues": {
-        "type": "array",
-        "description": "A list of element property values.",
-        "items": {
-            "$ref": "#/ElementPropertyValue"
-        }
-    },
-    "PropertyType": {
-        "type": "string",
-        "enum": [
-            "number",
-            "integer",
-            "string",
-            "boolean",
-            "length",
-            "area",
-            "volume",
-            "angle",
-            "numberList",
-            "integerList",
-            "stringList",
-            "booleanList",
-            "lengthList",
-            "areaList",
-            "volumeList",
-            "angleList",
-            "singleEnum",
-            "multiEnum"
-        ]
-    },
-    "DisplayValueEnumId": {
-        "type": "object",
-        "description": "An enumeration value identifier using the displayed value.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "displayValue" ]
-            },
-            "displayValue": {
-                "type": "string"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "type",
-            "displayValue"
-        ]
-    },
-    "NonLocalizedValueEnumId": {
-        "type": "object",
-        "description": "An enumeration value identifier using the nonlocalized value.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "nonLocalizedValue" ]
-            },
-            "nonLocalizedValue": {
-                "type": "string"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "type",
-            "nonLocalizedValue"
-        ]
-    },
-    "EnumValueId": {
-        "type": "object",
-        "description": "The identifier of a property enumeration value.",
-        "oneOf": [
-            {
-                "$ref": "#/DisplayValueEnumId"
-            },
-            {
-                "$ref": "#/NonLocalizedValueEnumId"
-            }
-        ]
-    },
-    "EnumValueIds": {
-        "type": "array",
-        "description": "A list of enumeration identifiers.",
-        "items": {
-            "type": "object",
-            "properties": {
-                "enumValueId": {
-                    "$ref": "#/EnumValueId"
-                }
-            },
-            "additionalProperties": false,
-            "required": [ "enumValueId" ]
-        }
-    },
-    "NormalOrUserUndefinedPropertyValue": {
-        "type": "object",
-        "description": "A normal or a userUndefined property value.",
-        "oneOf": [
-            {
-                "$ref": "#/NormalNumberPropertyValue"
-            },
-            {
-                "$ref": "#/NormalIntegerPropertyValue"
-            },
-            {
-                "$ref": "#/NormalStringPropertyValue"
-            },
-            {
-                "$ref": "#/NormalBooleanPropertyValue"
-            },
-            {
-                "$ref": "#/NormalLengthPropertyValue"
-            },
-            {
-                "$ref": "#/NormalAreaPropertyValue"
-            },
-            {
-                "$ref": "#/NormalVolumePropertyValue"
-            },
-            {
-                "$ref": "#/NormalAnglePropertyValue"
-            },
-            {
-                "$ref": "#/NormalNumberListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalIntegerListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalStringListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalBooleanListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalLengthListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalAreaListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalVolumeListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalAngleListPropertyValue"
-            },
-            {
-                "$ref": "#/NormalSingleEnumPropertyValue"
-            },
-            {
-                "$ref": "#/NormalMultiEnumPropertyValue"
-            },
-            {
-                "$ref": "#/UserUndefinedPropertyValue"
-            }
-        ]
-    },
-    "PropertyValueDetails": {
-        "type": "object",
-        "description": "A normal, userUndefined, notAvailable or notEvaluated property value.",
-        "oneOf": [
-            {
-                "$ref": "#/NormalOrUserUndefinedPropertyValue"
-            },
-            {
-                "$ref": "#/NotAvailablePropertyValue"
-            }
-        ]
-    },
-    "UserUndefinedPropertyValue": {
-        "type": "object",
-        "description": "A userUndefined value means that there is no actual number/string/etc. value, but the user deliberately set an Undefined value: this is a valid value, too.",
-        "properties": {
-            "type": {
-                "$ref": "#/PropertyType"
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "userUndefined" ]
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status" ]
-    },
-    "NotAvailablePropertyValue": {
-        "type": "object",
-        "description": "A notAvailable value means that the property is not available for the property owner (and therefore it has no property value for it).",
-        "properties": {
-            "type": {
-                "$ref": "#/PropertyType"
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "notAvailable" ]
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "type",
-            "status"
-        ]
-    },
-    "NormalNumberPropertyValue": {
-        "type": "object",
-        "description": "A number property value containing a valid numeric value.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "number" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "number"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalIntegerPropertyValue": {
-        "type": "object",
-        "description": "An integer property value containing a valid integer number.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "integer" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "integer"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalStringPropertyValue": {
-        "type": "object",
-        "description": "A string property value containing a valid string.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "string" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "string"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalBooleanPropertyValue": {
-        "type": "object",
-        "description": "A boolean property value containing a valid boolean value.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "boolean" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "boolean"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalLengthPropertyValue": {
-        "type": "object",
-        "description": "A length property value containing a real length value. The value is measured in SI (meters).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "length" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "number"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalAreaPropertyValue": {
-        "type": "object",
-        "description": "An area property value containing a real area. The value is measured in SI (square meters).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "area" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "number"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalVolumePropertyValue": {
-        "type": "object",
-        "description": "A volume property value containing a real volume. The value is measured in SI (cubic meters).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "volume" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "number"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalAnglePropertyValue": {
-        "type": "object",
-        "description": "An angle property value containing a real angle. The value is measured in SI (radians).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "angle" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "number"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalNumberListPropertyValue": {
-        "type": "object",
-        "description": "A number list property value containing numbers in an array.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "numberList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "number"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalIntegerListPropertyValue": {
-        "type": "object",
-        "description": "An integer list property value containing integers in an array.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "integerList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "integer"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalStringListPropertyValue": {
-        "type": "object",
-        "description": "A string list property value containing strings in an array.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "stringList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalBooleanListPropertyValue": {
-        "type": "object",
-        "description": "A boolean list property value containing boolean values in an array.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "booleanList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalLengthListPropertyValue": {
-        "type": "object",
-        "description": "A length list property value containing length values in an array. The values are measured in SI (meters).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "lengthList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "number"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalAreaListPropertyValue": {
-        "type": "object",
-        "description": "An area list property value containing areas in an array. The values are measured in SI (square meters).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "areaList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "number"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalVolumeListPropertyValue": {
-        "type": "object",
-        "description": "A volume list property value containing volumes in an array. The values are measured in SI (cubic meters).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "volumeList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "number"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalAngleListPropertyValue": {
-        "type": "object",
-        "description": "An angle list property value containing angles in an array. The values are measured in SI (radians).",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "angleList" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "type": "array",
-                "items": {
-                    "type": "number"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalSingleEnumPropertyValue": {
-        "type": "object",
-        "description": "A single enumeration property value containing the ID of the selected enum value.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "singleEnum" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "$ref": "#/EnumValueId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "NormalMultiEnumPropertyValue": {
-        "type": "object",
-        "description": "A multiple choice enumeration property value containing the IDs of the selected enum values in an array.",
-        "properties": {
-            "type": {
-                "type": "string",
-                "enum": [ "multiEnum" ]
-            },
-            "status": {
-                "type": "string",
-                "enum": [ "normal" ]
-            },
-            "value": {
-                "$ref": "#/EnumValueIds"
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "type", "status", "value" ]
-    },
-    "BasicDefaultValue": {
-        "type": "object",
-        "description": "Default value of the property in case of a basic property value (ie. not an expression).",
-        "properties": {
-            "basicDefaultValue": {
-                "$ref": "#/PropertyValueDetails"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "basicDefaultValue"
-        ]
-    },
-    "ExpressionDefaultValue": {
-        "type": "object",
-        "description": "Default value of the property in case of an expression based property value.",
-        "properties": {
-            "expressions": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "expressions"
-        ]
-    },
-    "PropertyDefaultValue": {
-        "type": "object",
-        "oneOf": [
-            {
-                "$ref": "#/BasicDefaultValue"
-            },
-            {
-                "$ref": "#/ExpressionDefaultValue"
-            }
-        ]
-    },
-    "ClassificationSystemId": {
-        "type": "object",
-        "description": "The identifier of a classification system.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "ClassificationSystemIdArrayItem": {
-        "type": "object",
-        "properties": {
-            "classificationSystemId": {
-                "$ref": "#/ClassificationSystemId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "classificationSystemId"
-        ]
-    },
-    "ClassificationSystemIds": {
-        "type": "array",
-        "description": "A list of classification system identifiers.",
-        "items": {
-            "$ref": "#/ClassificationSystemIdArrayItem"
-        }
-    },
-    "ClassificationItemId": {
-        "type": "object",
-        "description": "The identifier of a classification item.",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "ClassificationItemIdArrayItem": {
-        "type": "object",
-        "properties": {
-            "classificationItemId": {
-                "$ref": "#/ClassificationItemId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "classificationItemId"
-        ]
-    },
-    "ClassificationId": {
-        "type": "object",
-        "description": "The element classification identifier.",
-        "properties": {
-            "classificationSystemId": {
-                "$ref": "#/ClassificationSystemId"
-            },
-            "classificationItemId": {
-                "$ref": "#/ClassificationItemId",
-                "description": "The element's classification in the given system. If no value is specified here, the element is Unclassified in this system."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "classificationSystemId"
-        ]
-    },
-    "ClassificationIdOrError": {
-        "type": "object",
-        "description": "A classification identifier or an error.",
-        "oneOf": [
-            {
-                "title": "classificationId",
-                "properties": {
-                    "classificationId": {
-                        "$ref": "#/ClassificationId"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "classificationId" ]
-            },
-            {
-                "title": "error",
-                "$ref": "#/ErrorItem"
-            }
-        ]
-    },
-    "ClassificationIdsOrErrors": {
-        "type": "array",
-        "description": "A list of element classification identifiers or errors.",
-        "items": {
-            "$ref": "#/ClassificationIdOrError"
-        }
-    },
-    "ElementClassificationOrError": {
-        "type": "object",
-        "description": "Element classification identifiers or errors.",
-        "oneOf": [
-            {
-                "title": "classificationIds",
-                "properties": {
-                    "classificationIds": {
-                        "$ref": "#/ClassificationIdsOrErrors"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "classificationIds" ]
-            },
-            {
-                "title": "error",
-                "$ref": "#/ErrorItem"
-            }
-        ]
-    },
-    "ElementClassificationsOrErrors": {
-        "type": "array",
-        "description": "A list of element classification identifiers or errors.",
-        "items": {
-            "$ref": "#/ElementClassificationOrError"
-        }
-    },
-    "ElementClassification": {
-        "type": "object",
-        "description": "The classification of an element.",
-        "properties": {
-            "elementId": {
-                "$ref": "#/ElementId"
-            },
-            "classificationId": {
-                "$ref": "#/ClassificationId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "elementId",
-            "classificationId"
-        ]
-    },
-    "ElementClassifications": {
-        "type": "array",
-        "description": "A list of element classification identifiers.",
-        "items": {
-            "$ref": "#/ElementClassification"
-        }
-    },
-    "BoundingBox3D": {
-        "type": "object",
-        "description": "A 3D bounding box of an element.",
-        "properties": {
-            "xMin": {
-                "type": "number",
-                "description": "The minimum X value of the bounding box."
-            },
-            "yMin": {
-                "type": "number",
-                "description": "The minimum Y value of the bounding box."
-            },
-            "zMin": {
-                "type": "number",
-                "description": "The minimum Z value of the bounding box."
-            },
-            "xMax": {
-                "type": "number",
-                "description": "The maximum X value of the bounding box."
-            },
-            "yMax": {
-                "type": "number",
-                "description": "The maximum Y value of the bounding box."
-            },
-            "zMax": {
-                "type": "number",
-                "description": "The maximum Z value of the bounding box."
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "xMin",
-            "yMin",
-            "zMin",
-            "xMax",
-            "yMax",
-            "zMax"
-        ]
-    },
-    "BoundingBox3DOrError": {
-        "type": "object",
-        "description": "A 3D bounding box or an error.",
-        "oneOf": [
-            {
-                "title": "boundingBox3D",
-                "properties": {
-                    "boundingBox3D": {
-                        "$ref": "#/BoundingBox3D"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "boundingBox3D" ]
-            },
-            {
-                "title": "error",
-                "$ref": "#/ErrorItem"
-            }
-        ]
-    },
-    "BoundingBoxes3D": {
-        "type": "array",
-        "description": "A list of 3D bounding boxes.",
-        "items": {
-            "$ref": "#/BoundingBox3DOrError"
-        }
-    },
-    "LibPartUnId": {
-        "type": "object",
-        "properties": {
-            "guid": {
-                "$ref": "#/Guid"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "guid"
-        ]
-    },
-    "LibPartDetails": {
-        "properties": {
-            "name": {
-                "type": "string"
-            },
-            "parentUnID": {
-                "$ref": "#/LibPartUnId"
-            },
-            "ownUnID": {
-                "$ref": "#/LibPartUnId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "name",
-            "parentUnID",
-            "ownUnID"
-        ]
+  "Elements": {
+    "type": "array",
+    "description": "A list of elements.",
+    "items": {
+      "$ref": "#/ElementIdArrayItem"
     }
+  },
+  "ElementIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "elementId": {
+        "$ref": "#/ElementId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "elementId"
+    ]
+  },
+  "ElementId": {
+    "type": "object",
+    "description": "The identifier of an element.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "AttributeType": {
+    "type": "string",
+    "description": "The type of an attribute.",
+    "enum": [
+      "Layer",
+      "Line",
+      "Fill",
+      "Composite",
+      "Surface",
+      "LayerCombination",
+      "ZoneCategory",
+      "Profile",
+      "PenTable",
+      "MEPSystem",
+      "OperationProfile",
+      "BuildingMaterial"
+    ]
+  },
+  "AttributeIds": {
+    "type": "array",
+    "description": "A list of attributes.",
+    "items": {
+      "$ref": "#/AttributeIdArrayItem"
+    }
+  },
+  "AttributeIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "attributeId": {
+        "$ref": "#/AttributeId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "attributeId"
+    ]
+  },
+  "AttributeId": {
+    "type": "object",
+    "description": "The identifier of an attribute.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "Guid": {
+    "type": "string",
+    "description": "A Globally Unique Identifier (or Universally Unique Identifier) in its string representation as defined in RFC 4122.",
+    "format": "uuid",
+    "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+  },
+  "Hotlinks": {
+    "type": "array",
+    "description": "A list of hotlink nodes.",
+    "items": {
+      "$ref": "#/Hotlink"
+    }
+  },
+  "Hotlink": {
+    "type": "object",
+    "description": "The details of a hotlink node.",
+    "properties": {
+      "location": {
+        "type": "string",
+        "description": "The path of the hotlink file."
+      },
+      "children": {
+        "$ref": "#/Hotlinks",
+        "description": "The children of the hotlink node if it has any."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "location"
+    ]
+  },
+  "GDLParameterList": {
+    "type": "object",
+    "description": "The list of GDL parameters.",
+    "properties": {
+      "parameters": {
+        "type": "array",
+        "description": "The list of GDL parameters.",
+        "items": {
+          "$ref": "#/GDLParameterDetails"
+        }
+      }
+    },
+    "required": [
+      "parameters"
+    ]
+  },
+  "GDLParameterDetails": {
+    "type": "object",
+    "description": "Details of a GDL parameter.",
+    "properties": {
+      "name": {
+        "type": "string",
+        "description": "The name of the parameter."
+      },
+      "index": {
+        "type": "string",
+        "description": "The index of the parameter."
+      },
+      "type": {
+        "type": "string",
+        "description": "The type of the parameter."
+      },
+      "dimension1": {
+        "type": "number",
+        "description": "The 1st dimension of array (in case of array value)."
+      },
+      "dimension2": {
+        "type": "number",
+        "description": "The 2nd dimension of array (in case of array value)."
+      },
+      "value": {
+        "description": "The value of the parameter."
+      }
+    },
+    "additionalProperties": true,
+    "required": [
+      "index",
+      "type",
+      "value"
+    ]
+  },
+  "2DCoordinate": {
+    "type": "object",
+    "description": "2D coordinate.",
+    "properties": {
+      "x": {
+        "type": "number",
+        "description": "X value of the coordinate."
+      },
+      "y": {
+        "type": "number",
+        "description": "Y value of the coordinate."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "x",
+      "y"
+    ]
+  },
+  "3DCoordinate": {
+    "type": "object",
+    "description": "3D coordinate.",
+    "properties": {
+      "x": {
+        "type": "number",
+        "description": "X value of the coordinate."
+      },
+      "y": {
+        "type": "number",
+        "description": "Y value of the coordinate."
+      },
+      "z": {
+        "type": "number",
+        "description": "Z value of the coordinate."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "x",
+      "y",
+      "z"
+    ]
+  },
+  "3DDimensions": {
+    "type": "object",
+    "description": "Dimensions in 3D.",
+    "properties": {
+      "x": {
+        "type": "number",
+        "description": "X dimension."
+      },
+      "y": {
+        "type": "number",
+        "description": "Y dimension."
+      },
+      "z": {
+        "type": "number",
+        "description": "Z dimension."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "x",
+      "y",
+      "z"
+    ]
+  },
+  "Error": {
+    "type": "object",
+    "description": "The details of an error.",
+    "properties": {
+      "code": {
+        "type": "integer",
+        "description": "The code of the error."
+      },
+      "message": {
+        "type": "string",
+        "description": "The error message."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "code",
+      "message"
+    ]
+  },
+  "ErrorItem": {
+    "type": "object",
+    "properties": {
+      "error": {
+        "$ref": "#/Error"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "error" ]
+  },
+  "SuccessfulExecutionResult": {
+    "type": "object",
+    "description": "The result of a successful execution.",
+    "properties": {
+      "success": {
+        "type": "boolean",
+        "enum": [ true ]
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "success"
+    ]
+  },
+  "FailedExecutionResult": {
+    "type": "object",
+    "description": "The result of a failed execution.",
+    "properties": {
+      "success": {
+        "type": "boolean",
+        "enum": [ false ]
+      },
+      "error": {
+        "$ref": "#/Error",
+        "description": "The details of an execution failure."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "success",
+      "error"
+    ]
+  },
+  "ExecutionResult": {
+    "type": "object",
+    "description": "The result of the execution.",
+    "oneOf": [
+      {
+        "$ref": "#/SuccessfulExecutionResult"
+      },
+      {
+        "$ref": "#/FailedExecutionResult"
+      }
+    ]
+  },
+  "ExecutionResults": {
+    "type": "array",
+    "description": "A list of execution results.",
+    "items": {
+      "$ref": "#/ExecutionResult"
+    }
+  },
+  "ElementType": {
+    "type": "string",
+    "description": "The type of an element.",
+    "enum": [
+      "Wall",
+      "Column",
+      "Beam",
+      "Window",
+      "Door",
+      "Object",
+      "Lamp",
+      "Slab",
+      "Roof",
+      "Mesh",
+      "Dimension",
+      "RadialDimension",
+      "LevelDimension",
+      "AngleDimension",
+      "Text",
+      "Label",
+      "Zone",
+      "Hatch",
+      "Line",
+      "PolyLine",
+      "Arc",
+      "Circle",
+      "Spline",
+      "Hotspot",
+      "CutPlane",
+      "Camera",
+      "CamSet",
+      "Group",
+      "SectElem",
+      "Drawing",
+      "Picture",
+      "Detail",
+      "Elevation",
+      "InteriorElevation",
+      "Worksheet",
+      "Hotlink",
+      "CurtainWall",
+      "CurtainWallSegment",
+      "CurtainWallFrame",
+      "CurtainWallPanel",
+      "CurtainWallJunction",
+      "CurtainWallAccessory",
+      "Shell",
+      "Skylight",
+      "Morph",
+      "ChangeMarker",
+      "Stair",
+      "Riser",
+      "Tread",
+      "StairStructure",
+      "Railing",
+      "RailingToprail",
+      "RailingHandrail",
+      "RailingRail",
+      "RailingPost",
+      "RailingInnerPost",
+      "RailingBaluster",
+      "RailingPanel",
+      "RailingSegment",
+      "RailingNode",
+      "RailingBalusterSet",
+      "RailingPattern",
+      "RailingToprailEnd",
+      "RailingHandrailEnd",
+      "RailingRailEnd",
+      "RailingToprailConnection",
+      "RailingHandrailConnection",
+      "RailingRailConnection",
+      "RailingEndFinish",
+      "BeamSegment",
+      "ColumnSegment",
+      "Opening",
+      "Unknown"
+    ]
+  },
+  "ElementFilter": {
+    "type": "string",
+    "description": "A filter type for an element.",
+    "enum": [
+      "IsEditable",
+      "IsVisibleByLayer",
+      "IsVisibleByRenovation",
+      "IsVisibleByStructureDisplay",
+      "IsVisibleIn3D",
+      "OnActualFloor",
+      "OnActualLayout",
+      "InMyWorkspace",
+      "IsIndependent",
+      "InCroppedView",
+      "HasAccessRight",
+      "IsOverriddenByRenovation"
+    ]
+  },
+  "WindowType": {
+    "type": "string",
+    "description": "The type of a window.",
+    "enum": [
+      "FloorPlan",
+      "Section",
+      "Details",
+      "3DModel",
+      "Layout",
+      "Drawing",
+      "CustomText",
+      "CustomDraw",
+      "MasterLayout",
+      "Elevation",
+      "InteriorElevation",
+      "Worksheet",
+      "Report",
+      "3DDocument",
+      "External3D",
+      "Movie3D",
+      "MovieRendering",
+      "Rendering",
+      "ModelCompare",
+      "Interactive Schedule",
+      "Unknown"
+    ]
+  },
+  "IssueId": {
+    "type": "object",
+    "description": "The identifier of an issue.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "IssueIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "issueId": {
+        "$ref": "#/IssueId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "issueId"
+    ]
+  },
+  "Issues": {
+    "type": "array",
+    "description": "A list of Issues.",
+    "items": {
+      "$ref": "#/IssueIdArrayItem"
+    }
+  },
+  "IssueElementType": {
+    "type": "string",
+    "description": "The attachment type of an element component of an issue.",
+    "enum": [
+      "Creation",
+      "Highlight",
+      "Deletion",
+      "Modification"
+    ]
+  },
+  "IssueCommentStatus": {
+    "type": "string",
+    "description": "The status of an issue comment.",
+    "enum": [
+      "Error",
+      "Warning",
+      "Info",
+      "Unknown"
+    ]
+  },
+  "PropertyId": {
+    "type": "object",
+    "description": "The identifier of a property.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "PropertyGroupId": {
+    "type": "object",
+    "description": "The identifier of a property group.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "PropertyIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "propertyId": {
+        "$ref": "#/PropertyId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "propertyId"
+    ]
+  },
+  "PropertyIds": {
+    "type": "array",
+    "description": "A list of property identifiers.",
+    "items": {
+      "$ref": "#/PropertyIdArrayItem"
+    }
+  },
+  "PropertyDetails": {
+    "type": "object",
+    "description": "The details of the property.",
+    "properties": {
+      "propertyId": {
+        "$ref": "#/PropertyId"
+      },
+      "propertyType": {
+        "type": "string",
+        "enum": [
+          "StaticBuiltIn",
+          "DynamicBuiltIn",
+          "Custom"
+        ]
+      },
+      "propertyGroupName": {
+        "type": "string"
+      },
+      "propertyName": {
+        "type": "string"
+      },
+      "propertyCollectionType": {
+        "type": "string",
+        "enum": [
+          "Undefined",
+          "Single",
+          "List",
+          "SingleChoiceEnumeration",
+          "MultipleChoiceEnumeration"
+        ]
+      },
+      "propertyValueType": {
+        "type": "string",
+        "enum": [
+          "Undefined",
+          "Integer",
+          "Real",
+          "String",
+          "Boolean",
+          "Guid"
+        ]
+      },
+      "propertyMeasureType": {
+        "type": "string",
+        "enum": [
+          "Undefined",
+          "Default",
+          "Length",
+          "Area",
+          "Volume",
+          "Angle"
+        ]
+      },
+      "propertyIsEditable": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "propertyId",
+      "propertyType",
+      "propertyGroupName",
+      "propertyName",
+      "propertyCollectionType",
+      "propertyValueType",
+      "propertyMeasureType",
+      "propertyIsEditable"
+    ]
+  },
+  "PropertyValue": {
+    "type": "object",
+    "description": "The display string value of a property.",
+    "properties": {
+      "value": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": true,
+    "required": [
+      "value"
+    ]
+  },
+  "PropertyValueOrErrorItem": {
+    "type": "object",
+    "description": "A property value or an error",
+    "oneOf": [
+      {
+        "title": "propertyValue",
+        "properties": {
+          "propertyValue": {
+            "$ref": "#/PropertyValue"
+          }
+        },
+        "additionalProperties": false,
+        "required": [ "propertyValue" ]
+      },
+      {
+        "title": "error",
+        "$ref": "#/ErrorItem"
+      }
+    ]
+  },
+  "PropertyValues": {
+    "type": "array",
+    "description": "A list of property values.",
+    "items": {
+      "$ref": "#/PropertyValueOrErrorItem"
+    }
+  },
+  "PropertyValuesOrError": {
+    "type": "object",
+    "description": "A list of property values or an error.",
+    "oneOf": [
+      {
+        "title": "propertyValues",
+        "properties": {
+          "propertyValues": {
+            "$ref": "#/PropertyValues"
+          }
+        },
+        "additionalProperties": false,
+        "required": [ "propertyValues" ]
+      },
+      {
+        "title": "error",
+        "$ref": "#/ErrorItem"
+      }
+    ]
+  },
+  "PropertyValuesOrErrorArray": {
+    "type": "array",
+    "description": "A list of property value lists.",
+    "items": {
+      "$ref": "#/PropertyValuesOrError"
+    }
+  },
+  "PropertyIdOrError": {
+    "type": "object",
+    "description": "A propertyId or an error.",
+    "oneOf": [
+      {
+        "properties": {
+          "propertyId": {
+            "$ref": "#/PropertyId"
+          }
+        },
+        "additionalProperties": false,
+        "required": [ "propertyId" ]
+      },
+      {
+        "$ref": "#/ErrorItem"
+      }
+    ]
+  },
+  "PropertyIdOrErrorArray": {
+    "type": "array",
+    "description": "A list of property identifiers.",
+    "items": {
+      "$ref": "#/PropertyIdOrError"
+    }
+  },
+  "ElementPropertyValue": {
+    "type": "object",
+    "description": "A property value with the identifiers of the property and its owner element.",
+    "properties": {
+      "elementId": {
+        "$ref": "#/ElementId"
+      },
+      "propertyId": {
+        "$ref": "#/PropertyId"
+      },
+      "propertyValue": {
+        "$ref": "#/PropertyValue"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "elementId",
+      "propertyId",
+      "propertyValue"
+    ]
+  },
+  "ElementPropertyValues": {
+    "type": "array",
+    "description": "A list of element property values.",
+    "items": {
+      "$ref": "#/ElementPropertyValue"
+    }
+  },
+  "PropertyType": {
+    "type": "string",
+    "enum": [
+      "number",
+      "integer",
+      "string",
+      "boolean",
+      "length",
+      "area",
+      "volume",
+      "angle",
+      "numberList",
+      "integerList",
+      "stringList",
+      "booleanList",
+      "lengthList",
+      "areaList",
+      "volumeList",
+      "angleList",
+      "singleEnum",
+      "multiEnum"
+    ]
+  },
+  "DisplayValueEnumId": {
+    "type": "object",
+    "description": "An enumeration value identifier using the displayed value.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "displayValue" ]
+      },
+      "displayValue": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "type",
+      "displayValue"
+    ]
+  },
+  "NonLocalizedValueEnumId": {
+    "type": "object",
+    "description": "An enumeration value identifier using the nonlocalized value.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "nonLocalizedValue" ]
+      },
+      "nonLocalizedValue": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "type",
+      "nonLocalizedValue"
+    ]
+  },
+  "EnumValueId": {
+    "type": "object",
+    "description": "The identifier of a property enumeration value.",
+    "oneOf": [
+      {
+        "$ref": "#/DisplayValueEnumId"
+      },
+      {
+        "$ref": "#/NonLocalizedValueEnumId"
+      }
+    ]
+  },
+  "EnumValueIds": {
+    "type": "array",
+    "description": "A list of enumeration identifiers.",
+    "items": {
+      "type": "object",
+      "properties": {
+        "enumValueId": {
+          "$ref": "#/EnumValueId"
+        }
+      },
+      "additionalProperties": false,
+      "required": [ "enumValueId" ]
+    }
+  },
+  "NormalOrUserUndefinedPropertyValue": {
+    "type": "object",
+    "description": "A normal or a userUndefined property value.",
+    "oneOf": [
+      {
+        "$ref": "#/NormalNumberPropertyValue"
+      },
+      {
+        "$ref": "#/NormalIntegerPropertyValue"
+      },
+      {
+        "$ref": "#/NormalStringPropertyValue"
+      },
+      {
+        "$ref": "#/NormalBooleanPropertyValue"
+      },
+      {
+        "$ref": "#/NormalLengthPropertyValue"
+      },
+      {
+        "$ref": "#/NormalAreaPropertyValue"
+      },
+      {
+        "$ref": "#/NormalVolumePropertyValue"
+      },
+      {
+        "$ref": "#/NormalAnglePropertyValue"
+      },
+      {
+        "$ref": "#/NormalNumberListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalIntegerListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalStringListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalBooleanListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalLengthListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalAreaListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalVolumeListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalAngleListPropertyValue"
+      },
+      {
+        "$ref": "#/NormalSingleEnumPropertyValue"
+      },
+      {
+        "$ref": "#/NormalMultiEnumPropertyValue"
+      },
+      {
+        "$ref": "#/UserUndefinedPropertyValue"
+      }
+    ]
+  },
+  "PropertyValueDetails": {
+    "type": "object",
+    "description": "A normal, userUndefined, notAvailable or notEvaluated property value.",
+    "oneOf": [
+      {
+        "$ref": "#/NormalOrUserUndefinedPropertyValue"
+      },
+      {
+        "$ref": "#/NotAvailablePropertyValue"
+      }
+    ]
+  },
+  "UserUndefinedPropertyValue": {
+    "type": "object",
+    "description": "A userUndefined value means that there is no actual number/string/etc. value, but the user deliberately set an Undefined value: this is a valid value, too.",
+    "properties": {
+      "type": {
+        "$ref": "#/PropertyType"
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "userUndefined" ]
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status" ]
+  },
+  "NotAvailablePropertyValue": {
+    "type": "object",
+    "description": "A notAvailable value means that the property is not available for the property owner (and therefore it has no property value for it).",
+    "properties": {
+      "type": {
+        "$ref": "#/PropertyType"
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "notAvailable" ]
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "type",
+      "status"
+    ]
+  },
+  "NormalNumberPropertyValue": {
+    "type": "object",
+    "description": "A number property value containing a valid numeric value.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "number" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "number"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalIntegerPropertyValue": {
+    "type": "object",
+    "description": "An integer property value containing a valid integer number.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "integer" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "integer"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalStringPropertyValue": {
+    "type": "object",
+    "description": "A string property value containing a valid string.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "string" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalBooleanPropertyValue": {
+    "type": "object",
+    "description": "A boolean property value containing a valid boolean value.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "boolean" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalLengthPropertyValue": {
+    "type": "object",
+    "description": "A length property value containing a real length value. The value is measured in SI (meters).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "length" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "number"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalAreaPropertyValue": {
+    "type": "object",
+    "description": "An area property value containing a real area. The value is measured in SI (square meters).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "area" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "number"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalVolumePropertyValue": {
+    "type": "object",
+    "description": "A volume property value containing a real volume. The value is measured in SI (cubic meters).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "volume" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "number"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalAnglePropertyValue": {
+    "type": "object",
+    "description": "An angle property value containing a real angle. The value is measured in SI (radians).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "angle" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "number"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalNumberListPropertyValue": {
+    "type": "object",
+    "description": "A number list property value containing numbers in an array.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "numberList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalIntegerListPropertyValue": {
+    "type": "object",
+    "description": "An integer list property value containing integers in an array.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "integerList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "integer"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalStringListPropertyValue": {
+    "type": "object",
+    "description": "A string list property value containing strings in an array.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "stringList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalBooleanListPropertyValue": {
+    "type": "object",
+    "description": "A boolean list property value containing boolean values in an array.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "booleanList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "boolean"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalLengthListPropertyValue": {
+    "type": "object",
+    "description": "A length list property value containing length values in an array. The values are measured in SI (meters).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "lengthList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalAreaListPropertyValue": {
+    "type": "object",
+    "description": "An area list property value containing areas in an array. The values are measured in SI (square meters).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "areaList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalVolumeListPropertyValue": {
+    "type": "object",
+    "description": "A volume list property value containing volumes in an array. The values are measured in SI (cubic meters).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "volumeList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalAngleListPropertyValue": {
+    "type": "object",
+    "description": "An angle list property value containing angles in an array. The values are measured in SI (radians).",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "angleList" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalSingleEnumPropertyValue": {
+    "type": "object",
+    "description": "A single enumeration property value containing the ID of the selected enum value.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "singleEnum" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "$ref": "#/EnumValueId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "NormalMultiEnumPropertyValue": {
+    "type": "object",
+    "description": "A multiple choice enumeration property value containing the IDs of the selected enum values in an array.",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": [ "multiEnum" ]
+      },
+      "status": {
+        "type": "string",
+        "enum": [ "normal" ]
+      },
+      "value": {
+        "$ref": "#/EnumValueIds"
+      }
+    },
+    "additionalProperties": false,
+    "required": [ "type", "status", "value" ]
+  },
+  "BasicDefaultValue": {
+    "type": "object",
+    "description": "Default value of the property in case of a basic property value (ie. not an expression).",
+    "properties": {
+      "basicDefaultValue": {
+        "$ref": "#/PropertyValueDetails"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "basicDefaultValue"
+    ]
+  },
+  "ExpressionDefaultValue": {
+    "type": "object",
+    "description": "Default value of the property in case of an expression based property value.",
+    "properties": {
+      "expressions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "expressions"
+    ]
+  },
+  "PropertyDefaultValue": {
+    "type": "object",
+    "oneOf": [
+      {
+        "$ref": "#/BasicDefaultValue"
+      },
+      {
+        "$ref": "#/ExpressionDefaultValue"
+      }
+    ]
+  },
+  "ClassificationSystemId": {
+    "type": "object",
+    "description": "The identifier of a classification system.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "ClassificationSystemIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "classificationSystemId": {
+        "$ref": "#/ClassificationSystemId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "classificationSystemId"
+    ]
+  },
+  "ClassificationSystemIds": {
+    "type": "array",
+    "description": "A list of classification system identifiers.",
+    "items": {
+      "$ref": "#/ClassificationSystemIdArrayItem"
+    }
+  },
+  "ClassificationItemId": {
+    "type": "object",
+    "description": "The identifier of a classification item.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "ClassificationItemIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "classificationItemId": {
+        "$ref": "#/ClassificationItemId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "classificationItemId"
+    ]
+  },
+  "ClassificationId": {
+    "type": "object",
+    "description": "The element classification identifier.",
+    "properties": {
+      "classificationSystemId": {
+        "$ref": "#/ClassificationSystemId"
+      },
+      "classificationItemId": {
+        "$ref": "#/ClassificationItemId",
+        "description": "The element's classification in the given system. If no value is specified here, the element is Unclassified in this system."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "classificationSystemId"
+    ]
+  },
+  "ClassificationIdOrError": {
+    "type": "object",
+    "description": "A classification identifier or an error.",
+    "oneOf": [
+      {
+        "title": "classificationId",
+        "properties": {
+          "classificationId": {
+            "$ref": "#/ClassificationId"
+          }
+        },
+        "additionalProperties": false,
+        "required": [ "classificationId" ]
+      },
+      {
+        "title": "error",
+        "$ref": "#/ErrorItem"
+      }
+    ]
+  },
+  "ClassificationIdsOrErrors": {
+    "type": "array",
+    "description": "A list of element classification identifiers or errors.",
+    "items": {
+      "$ref": "#/ClassificationIdOrError"
+    }
+  },
+  "ElementClassificationOrError": {
+    "type": "object",
+    "description": "Element classification identifiers or errors.",
+    "oneOf": [
+      {
+        "title": "classificationIds",
+        "properties": {
+          "classificationIds": {
+            "$ref": "#/ClassificationIdsOrErrors"
+          }
+        },
+        "additionalProperties": false,
+        "required": [ "classificationIds" ]
+      },
+      {
+        "title": "error",
+        "$ref": "#/ErrorItem"
+      }
+    ]
+  },
+  "ElementClassificationsOrErrors": {
+    "type": "array",
+    "description": "A list of element classification identifiers or errors.",
+    "items": {
+      "$ref": "#/ElementClassificationOrError"
+    }
+  },
+  "ElementClassification": {
+    "type": "object",
+    "description": "The classification of an element.",
+    "properties": {
+      "elementId": {
+        "$ref": "#/ElementId"
+      },
+      "classificationId": {
+        "$ref": "#/ClassificationId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "elementId",
+      "classificationId"
+    ]
+  },
+  "ElementClassifications": {
+    "type": "array",
+    "description": "A list of element classification identifiers.",
+    "items": {
+      "$ref": "#/ElementClassification"
+    }
+  },
+  "BoundingBox3D": {
+    "type": "object",
+    "description": "A 3D bounding box of an element.",
+    "properties": {
+      "xMin": {
+        "type": "number",
+        "description": "The minimum X value of the bounding box."
+      },
+      "yMin": {
+        "type": "number",
+        "description": "The minimum Y value of the bounding box."
+      },
+      "zMin": {
+        "type": "number",
+        "description": "The minimum Z value of the bounding box."
+      },
+      "xMax": {
+        "type": "number",
+        "description": "The maximum X value of the bounding box."
+      },
+      "yMax": {
+        "type": "number",
+        "description": "The maximum Y value of the bounding box."
+      },
+      "zMax": {
+        "type": "number",
+        "description": "The maximum Z value of the bounding box."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "xMin",
+      "yMin",
+      "zMin",
+      "xMax",
+      "yMax",
+      "zMax"
+    ]
+  },
+  "BoundingBox3DOrError": {
+    "type": "object",
+    "description": "A 3D bounding box or an error.",
+    "oneOf": [
+      {
+        "title": "boundingBox3D",
+        "properties": {
+          "boundingBox3D": {
+            "$ref": "#/BoundingBox3D"
+          }
+        },
+        "additionalProperties": false,
+        "required": [ "boundingBox3D" ]
+      },
+      {
+        "title": "error",
+        "$ref": "#/ErrorItem"
+      }
+    ]
+  },
+  "BoundingBoxes3D": {
+    "type": "array",
+    "description": "A list of 3D bounding boxes.",
+    "items": {
+      "$ref": "#/BoundingBox3DOrError"
+    }
+  },
+  "LibPartUnId": {
+    "type": "object",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "LibPartDetails": {
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "parentUnID": {
+        "$ref": "#/LibPartUnId"
+      },
+      "ownUnID": {
+        "$ref": "#/LibPartUnId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "name",
+      "parentUnID",
+      "ownUnID"
+    ]
+  },
+  "NavigatorItemIds": {
+    "type": "array",
+    "description": "A list of navigator item identifiers.",
+    "items": {
+      "$ref": "#/NavigatorItemIdArrayItem"
+    }
+  },
+  "NavigatorItemIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "navigatorItemId": {
+        "$ref": "#/NavigatorItemId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "navigatorItemId"
+    ]
+  },
+  "NavigatorItemId": {
+    "type": "object",
+    "description": "The identifier of a navigator item.",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  },
+  "Databases": {
+    "type": "array",
+    "description": "A list of Archicad databases.",
+    "items": {
+      "$ref": "#/DatabaseIdArrayItem"
+    }
+  },
+  "DatabaseIdArrayItem": {
+    "type": "object",
+    "properties": {
+      "databaseId": {
+        "$ref": "#/DatabaseId"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "databaseId"
+    ]
+  },
+  "DatabaseId": {
+    "type": "object",
+    "description": "The identifier of a database",
+    "properties": {
+      "guid": {
+        "$ref": "#/Guid"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "guid"
+    ]
+  }
 };


### PR DESCRIPTION
Added optional input parameter "databases" to GetElementsByType and GetAllElements 
Commands created update_drawings example

I think I need a bit of help.

1. I added the command, and tested it with the debugger from Visual studio using AC_27.
2. Wen it was working, I deleted the build folder, and started all_build.bat
3. it does not compile for AC25 and AC26. Probably there are some changes in te API since that. But where can I find those changes? 
4. The build completed without error for AC27 and 28.
5. But after loading the newly build addon it seams like an old version is stuck. Even if I load the new .apx, an old version is loaded into ArchiCAD. (I think the last official release?) 

I have nearly spent the last 3 hours trying to fix this, but no luck.

Cmake traceback:
Checking File Globs
  ElementCommands.cpp
C:\Users\szamosi.mate\source\repos\TSPC-Computational-Design\tapir-archicad-automation\archicad-addon\Sources\ElementCo
mmands.cpp(69,21): error C3861: 'ACAPI_Database_GetCurrentDatabase': identifier not found [C:\Users\szamosi.mate\source
\repos\TSPC-Computational-Design\tapir-archicad-automation\archicad-addon\Build\AC25\AddOn.vcxproj]
C:\Users\szamosi.mate\source\repos\TSPC-Computational-Design\tapir-archicad-automation\archicad-addon\Sources\ElementCo
mmands.cpp(165): message : see reference to function template instantiation 'GS::GSErrCode ExecuteActionForEachDatabase
<const GS::ObjectState::AddList::<lambda_32b9fc251d970714c480da3e2b067695>>(const GS::Array<API_Guid> &,ListProxyType &
,const std::function<void (void)> &)' being compiled [C:\Users\szamosi.mate\source\repos\TSPC-Computational-Design\tapi
r-archicad-automation\archicad-addon\Build\AC25\AddOn.vcxproj]
          with
          [
              ListProxyType=const GS::ObjectState::AddList::<lambda_32b9fc251d970714c480da3e2b067695>
          ]
C:\Users\szamosi.mate\source\repos\TSPC-Computational-Design\tapir-archicad-automation\archicad-addon\Sources\ElementCo
mmands.cpp(76,15): error C3861: 'ACAPI_Window_GetDatabaseInfo': identifier not found [C:\Users\szamosi.mate\source\repo
s\TSPC-Computational-Design\tapir-archicad-automation\archicad-addon\Build\AC25\AddOn.vcxproj]
C:\Users\szamosi.mate\source\repos\TSPC-Computational-Design\tapir-archicad-automation\archicad-addon\Sources\ElementCo
mmands.cpp(81,15): error C3861: 'ACAPI_Database_ChangeCurrentDatabase': identifier not found [C:\Users\szamosi.mate\sou
rce\repos\TSPC-Computational-Design\tapir-archicad-automation\archicad-addon\Build\AC25\AddOn.vcxproj]
C:\Users\szamosi.mate\source\repos\TSPC-Computational-Design\tapir-archicad-automation\archicad-addon\Sources\ElementCo
mmands.cpp(89,11): error C3861: 'ACAPI_Database_ChangeCurrentDatabase': identifier not found [C:\Users\szamosi.mate\sou
rce\repos\TSPC-Computational-Design\tapir-archicad-automation\archicad-addon\Build\AC25\AddOn.vcxproj]
  ElementCreationCommands.cpp
  NavigatorCommands.cpp
C:\Users\szamosi.mate\source\repos\TSPC-Computational-Design\tapir-archicad-automation\archicad-addon\Sources\Navigator
Commands.cpp(193,25): error C3861: 'ACAPI_Navigator_GetNavigatorItem': identifier not found [C:\Users\szamosi.mate\sour
ce\repos\TSPC-Computational-Design\tapir-archicad-automation\archicad-addon\Build\AC25\AddOn.vcxproj]
  ProjectCommands.cpp
  TeamworkCommands.cpp
  Generating Code...
