### PR TITLE
Prevent Lock (.lck) files from checking in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ local/
 grasshopper-plugin/src/components/
 grasshopper-plugin/src/test.py
 .vscode
+.lck


### PR DESCRIPTION
Update `.gitignore` to exclude lock files from being tracked in the repository (as already happened).