### PR TITLE
config.json handling and load scripts from multiple repositories

### DIFF
--- a/archicad-addon/Sources/Config.cpp
+++ b/archicad-addon/Sources/Config.cpp
@@ -1,0 +1,127 @@
+#include "Config.hpp"
+#include "File.hpp"
+#include "FileSystem.hpp"
+#include "ObjectStateJSONConversion.hpp"
+#include "APIEnvir.h"
+#include "ACAPinc.h"
+
+Config& Config::Instance ()
+{
+    static Config instance;
+    if (IsFileNewer (*instance.configFilePtr, instance.configFileTimestamp)) {
+        instance.LoadFromFile (*instance.configFilePtr);
+    }
+    return instance;
+}
+
+Config::Config ()
+{
+    const IO::Location configFileLoc = GetConfigFileLocation ();
+    const bool exist = FileExist (configFileLoc);
+    configFilePtr = std::make_unique<IO::File> (configFileLoc, IO::File::OnNotFound::Create);
+    if (!exist) {
+        GetDefaults ();
+        SaveToFile (*configFilePtr);
+        configFilePtr->GetModificationTime (&configFileTimestamp);
+    }
+}
+
+void Config::GetDefaults ()
+{
+    repositories.push_back ({
+        "Tapir",
+        "ENZYME-APD",
+        "tapir-archicad-automation",
+        "builtin-scripts",
+        ""
+    });
+}
+
+void Config::LoadFromFile (IO::File& file)
+{
+    GS::ObjectState os;
+    file.Open (IO::File::OpenMode::ReadMode);
+    GSErrCode err = JSON::ConvertToObjectState (file, os);
+    file.Close ();
+    if (err != NoError || os.IsEmpty ()) {
+        ACAPI_WriteReport (
+            "Tapir::Config: Failed to load config file: %T",
+            false,
+            file.GetLocation().ToDisplayText().ToPrintf()
+        );
+        return;
+    }
+
+    GS::Array<GS::ObjectState> repositoriesArray;
+    os.Get ("repositories", repositoriesArray);
+
+    repositories.clear ();
+    for (auto& repoOS : repositoriesArray) {
+        repositories.emplace_back ();
+        Config::Repository& repo = repositories.back ();
+        repoOS.Get ("displayName", repo.displayName);
+        repoOS.Get ("repoOwner", repo.repoOwner);
+        repoOS.Get ("repoName", repo.repoName);
+        repoOS.Get ("relativeLoc", repo.relativeLoc);
+        repoOS.Get ("token", repo.token);
+    }
+}
+
+void Config::SaveToFile (IO::File& file) const
+{
+    GS::ObjectState os;
+    const auto& repositoriesArray = os.AddList<GS::ObjectState> ("repositories");
+    for (auto& repo : repositories) {
+        GS::ObjectState repoOS (
+            "repoOwner", repo.repoOwner,
+            "repoName", repo.repoName,
+            "relativeLoc", repo.relativeLoc,
+            "token", repo.token);
+        if (!repo.displayName.IsEmpty()) repoOS.Add ("displayName", repo.displayName);
+        repositoriesArray (repoOS);
+    }
+
+    constexpr bool prettyPrint = true;
+    file.Open (IO::File::OpenMode::WriteEmptyMode);
+    GSErrCode err = JSON::CreateFromObjectState (
+        os,
+        file,
+        prettyPrint
+    );
+    file.Close ();
+    if (err != NoError) {
+        ACAPI_WriteReport (
+            "Tapir::Config: Failed to save config file: %T",
+            false,
+            file.GetLocation().ToDisplayText().ToPrintf()
+        );
+    }
+}
+
+bool Config::FileExist (const IO::Location& fileLocation)
+{
+    bool exists = false;
+    return IO::fileSystem.Contains (fileLocation, &exists) == NoError && exists;
+}
+
+IO::Location Config::GetConfigFileLocation ()
+{
+    IO::Location docsFolderLoc;
+    IO::fileSystem.GetSpecialLocation (IO::FileSystem::UserDocuments, &docsFolderLoc);
+    IO::Location configFileLoc = docsFolderLoc;
+    configFileLoc.AppendToLocal (IO::Name ("Tapir"));
+    configFileLoc.AppendToLocal (IO::Name ("config.json"));
+    return configFileLoc;
+}
+
+bool Config::IsFileNewer (const IO::File& file, GSTime& timestamp)
+{
+    GSTime newTimestamp = 0;
+    file.GetModificationTime (&newTimestamp);
+    if (newTimestamp <= timestamp) {
+        return false;
+    }
+
+    timestamp = newTimestamp;
+    return true;
+}

--- a/archicad-addon/Sources/Config.hpp
+++ b/archicad-addon/Sources/Config.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "UniString.hpp"
+#include "File.hpp"
+#include "Location.hpp"
+
+#include <vector>
+#include <memory>
+
+class Config
+{
+public:
+    struct Repository {
+        GS::UniString displayName;
+        GS::UniString repoOwner;
+        GS::UniString repoName;
+        GS::UniString relativeLoc;
+        GS::UniString token;
+    };
+
+public:
+    static Config& Instance ();
+
+    const std::vector<Repository>& Repositories () const { return repositories; }
+
+private:
+    Config ();
+    void GetDefaults ();
+    void LoadFromFile (IO::File& file);
+    void SaveToFile (IO::File& file) const;
+    static bool FileExist (const IO::Location& fileLocation);
+    static IO::Location GetConfigFileLocation ();
+    static bool IsFileNewer (const IO::File& file, GSTime& timestamp);
+
+private:
+
+    std::unique_ptr<IO::File> configFilePtr;
+    GSTime configFileTimestamp = 0;
+    std::vector<Repository> repositories;
+};

--- a/archicad-addon/Sources/TapirPalette.hpp
+++ b/archicad-addon/Sources/TapirPalette.hpp
@@ -5,6 +5,7 @@
 #include "DGModule.hpp"
 #include "ThreadedExecutor.hpp"
 #include "Process.hpp"
+#include "Config.hpp"
 #include "UvManager.hpp"
 
 class TapirPalette final : public DG::Palette,
@@ -27,6 +28,19 @@ public:
     static GSErrCode RegisterPaletteControlCallBack ();
 
 private:
+    struct PopUpItemData : public GS::Object
+    {
+        IO::Location fileLocation;
+        const GS::UniString repoRelLoc;
+        const Config::Repository* repo = nullptr;
+
+        explicit PopUpItemData (
+            const IO::Location& _fileLocation,
+            const GS::UniString& _repoRelLoc = GS::EmptyUniString,
+            const Config::Repository* _repo = nullptr)
+            : fileLocation(_fileLocation), repoRelLoc(_repoRelLoc), repo(_repo) {}
+    };
+
     DG::IconButton tapirButton;
     DG::PopUp      scriptSelectionPopUp;
     DG::IconButton runScriptButton;
@@ -42,8 +56,8 @@ private:
 
     void SetMenuItemCheckedState (bool);
     void ExecuteScript (const IO::Location& fileLocation, const GS::Array<GS::UniString>& additionalArgv = {});
-    bool AddScriptToPopUp (const IO::Location& fileLocation, short index = DG::PopUp::TopItem);
-    void AddBuiltInScriptsFromGithub ();
+    bool AddScriptToPopUp (GS::Ref<PopUpItemData> popUpData, short index = DG::PopUp::TopItem);
+    void AddScriptsFromRepositories ();
     void AddScriptsFromCustomScriptsFolder ();
     void LoadScriptsToPopUp ();
     bool IsPopUpContainsFile (const IO::Location& fileLocation) const;

--- a/archicad-addon/Sources/VersionChecker.hpp
+++ b/archicad-addon/Sources/VersionChecker.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "Definitions.hpp"
 #include "UniString.hpp"
 


### PR DESCRIPTION
In user's Documents/Tapir folder it creates a config.json.
By default it uses the Tapir repository, but anybody can add custom repositories.

**repoOwner** and **repoName** fields are required.
**token** field is required for private repositories: a fine-grained personal access token has to be generated, see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token
**relativeLoc** field is the relative location of the folder of the scripts inside the repository.
**displayName** is optional, it appears on Tapir Palette next to the script's filename. 

<img width="989" height="378" alt="image" src="https://github.com/user-attachments/assets/1626e8a3-4484-485e-8a33-4db07e8ff1fc" />
