### PR TITLE
Improve config.json and fix usability issues

### DIFF
--- a/archicad-addon/Sources/Config.cpp
+++ b/archicad-addon/Sources/Config.cpp
@@ -5,6 +5,32 @@
 #include "APIEnvir.h"
 #include "ACAPinc.h"
 
+Config::Repository Config::Repository::FromOS (const GS::ObjectState& os) {
+    Repository repo;
+    os.Get ("displayName", repo.displayName);
+    os.Get ("repoOwner", repo.repoOwner);
+    os.Get ("repoName", repo.repoName);
+    os.Get ("relativeLoc", repo.relativeLoc);
+    os.Get ("token", repo.token);
+    os.Get ("excludeFromDownloadPattern", repo.excludeFromDownloadPattern);
+    os.Get ("includePattern", repo.includePattern);
+    os.Get ("excludePattern", repo.excludePattern);
+    return repo;
+}
+
+GS::ObjectState Config::Repository::ToOS () const {
+    return {
+        "displayName", displayName,
+        "repoOwner", repoOwner,
+        "repoName", repoName,
+        "relativeLoc", relativeLoc,
+        "token", token,
+        "excludeFromDownloadPattern", excludeFromDownloadPattern,
+        "includePattern", includePattern,
+        "excludePattern", excludePattern
+    };
+}
+
 Config& Config::Instance ()
 {
     static Config instance;
@@ -32,8 +58,7 @@ void Config::GetDefaults ()
         "Tapir",
         "ENZYME-APD",
         "tapir-archicad-automation",
-        "builtin-scripts",
-        ""
+        "builtin-scripts"
     });
     askUpdatingAddOnBeforeEachExecution = false;
 }
@@ -58,13 +83,7 @@ void Config::LoadFromFile (IO::File& file)
 
     repositories.clear ();
     for (auto& repoOS : repositoriesArray) {
-        repositories.emplace_back ();
-        Config::Repository& repo = repositories.back ();
-        repoOS.Get ("displayName", repo.displayName);
-        repoOS.Get ("repoOwner", repo.repoOwner);
-        repoOS.Get ("repoName", repo.repoName);
-        repoOS.Get ("relativeLoc", repo.relativeLoc);
-        repoOS.Get ("token", repo.token);
+        repositories.push_back (Config::Repository::FromOS (repoOS));
     }
 
     os.Get ("askUpdatingAddOnBeforeEachExecution", askUpdatingAddOnBeforeEachExecution);
@@ -75,13 +94,7 @@ void Config::SaveToFile (IO::File& file) const
     GS::ObjectState os;
     const auto& repositoriesArray = os.AddList<GS::ObjectState> ("repositories");
     for (auto& repo : repositories) {
-        GS::ObjectState repoOS (
-            "repoOwner", repo.repoOwner,
-            "repoName", repo.repoName,
-            "relativeLoc", repo.relativeLoc,
-            "token", repo.token);
-        if (!repo.displayName.IsEmpty()) repoOS.Add ("displayName", repo.displayName);
-        repositoriesArray (repoOS);
+        repositoriesArray (repo.ToOS ());
     }
 
     os.Add ("askUpdatingAddOnBeforeEachExecution", askUpdatingAddOnBeforeEachExecution);

--- a/archicad-addon/Sources/Config.cpp
+++ b/archicad-addon/Sources/Config.cpp
@@ -35,6 +35,7 @@ void Config::GetDefaults ()
         "builtin-scripts",
         ""
     });
+    askUpdatingAddOnBeforeEachExecution = false;
 }
 
 void Config::LoadFromFile (IO::File& file)
@@ -65,6 +66,8 @@ void Config::LoadFromFile (IO::File& file)
         repoOS.Get ("relativeLoc", repo.relativeLoc);
         repoOS.Get ("token", repo.token);
     }
+
+    os.Get ("askUpdatingAddOnBeforeEachExecution", askUpdatingAddOnBeforeEachExecution);
 }
 
 void Config::SaveToFile (IO::File& file) const
@@ -80,6 +83,8 @@ void Config::SaveToFile (IO::File& file) const
         if (!repo.displayName.IsEmpty()) repoOS.Add ("displayName", repo.displayName);
         repositoriesArray (repoOS);
     }
+
+    os.Add ("askUpdatingAddOnBeforeEachExecution", askUpdatingAddOnBeforeEachExecution);
 
     constexpr bool prettyPrint = true;
     file.Open (IO::File::OpenMode::WriteEmptyMode);

--- a/archicad-addon/Sources/Config.hpp
+++ b/archicad-addon/Sources/Config.hpp
@@ -11,11 +11,37 @@ class Config
 {
 public:
     struct Repository {
+        Repository () = default;
+        Repository (
+            const GS::UniString& _displayName,
+            const GS::UniString& _repoOwner,
+            const GS::UniString& _repoName,
+            const GS::UniString& _relativeLoc = GS::EmptyUniString,
+            const GS::UniString& _token = GS::EmptyUniString,
+            const GS::UniString& _excludeFromDownloadPattern = GS::EmptyUniString,
+            const GS::UniString& _includePattern = GS::EmptyUniString,
+            const GS::UniString& _excludePattern = GS::EmptyUniString)
+            : displayName(_displayName)
+            , repoOwner(_repoOwner)
+            , repoName(_repoName)
+            , relativeLoc(_relativeLoc)
+            , token(_token)
+            , excludeFromDownloadPattern(_excludeFromDownloadPattern)
+            , includePattern(_includePattern)
+            , excludePattern(_excludePattern)
+        {}
+
         GS::UniString displayName;
         GS::UniString repoOwner;
         GS::UniString repoName;
         GS::UniString relativeLoc;
         GS::UniString token;
+        GS::UniString excludeFromDownloadPattern;
+        GS::UniString includePattern;
+        GS::UniString excludePattern;
+
+        GS::ObjectState ToOS () const;
+        static Repository FromOS (const GS::ObjectState& os);
     };
 
 public:

--- a/archicad-addon/Sources/Config.hpp
+++ b/archicad-addon/Sources/Config.hpp
@@ -22,6 +22,7 @@ public:
     static Config& Instance ();
 
     const std::vector<Repository>& Repositories () const { return repositories; }
+    bool AskUpdatingAddOnBeforeEachExecution () const { return askUpdatingAddOnBeforeEachExecution; }
 
 private:
     Config ();
@@ -33,8 +34,8 @@ private:
     static bool IsFileNewer (const IO::File& file, GSTime& timestamp);
 
 private:
-
     std::unique_ptr<IO::File> configFilePtr;
     GSTime configFileTimestamp = 0;
     std::vector<Repository> repositories;
+    bool askUpdatingAddOnBeforeEachExecution;
 };

--- a/archicad-addon/Sources/TapirPalette.cpp
+++ b/archicad-addon/Sources/TapirPalette.cpp
@@ -260,7 +260,7 @@ void TapirPalette::ButtonClicked (const DG::ButtonClickEvent& ev)
 
             GS::Ref<PopUpItemData> popUpItemData = GS::DynamicCast<PopUpItemData> (scriptSelectionPopUp.GetItemObjectData (scriptSelectionPopUp.GetSelectedItem ()));
             if (popUpItemData != nullptr) {
-                ExecuteScript (popUpItemData->fileLocation);
+                ExecuteScript (*popUpItemData);
             }
         }
     } else if (ev.GetSource () == &tapirButton) {
@@ -360,10 +360,10 @@ GSErrCode TapirPalette::RegisterPaletteControlCallBack ()
                     GSGuid2APIGuid (paletteGuid));
 }
 
-void TapirPalette::ExecuteScript (const IO::Location& fileLocation, const GS::Array<GS::UniString>& additionalArgv)
+void TapirPalette::ExecuteScript (const PopUpItemData& popUpItemData)
 {
     GS::UniString filePath;
-    fileLocation.ToPath (&filePath);
+    popUpItemData.fileLocation.ToPath (&filePath);
 
     class UIUpdaterThread : public GS::Runnable
     {
@@ -467,12 +467,12 @@ void TapirPalette::ExecuteScript (const IO::Location& fileLocation, const GS::Ar
             }
             command = uvCommand;
             argv = {"run", "--script", filePath, "--port", GS::ValueToUniString (GetConnectionPort ())};
+            if (!popUpItemData.repo->token.IsEmpty ()) {
+                argv.Append ({"--token", popUpItemData.repo->token});
+            }
         } else {
             command = filePath;
             argv = {"--port", GS::ValueToUniString (GetConnectionPort ())};
-        }
-        if (additionalArgv.GetSize () > 0) {
-            argv.Append (additionalArgv);
         }
 
         constexpr bool redirectStandardOutput = true;

--- a/archicad-addon/Sources/TapirPalette.cpp
+++ b/archicad-addon/Sources/TapirPalette.cpp
@@ -254,7 +254,7 @@ void TapirPalette::ButtonClicked (const DG::ButtonClickEvent& ev)
         if (IsProcessRunning ()) {
             process.Kill ();
         } else {
-            if (UpdateAddOn ()) {
+            if (Config::Instance().AskUpdatingAddOnBeforeEachExecution () && UpdateAddOn ()) {
                 return;
             }
 

--- a/archicad-addon/Sources/TapirPalette.cpp
+++ b/archicad-addon/Sources/TapirPalette.cpp
@@ -396,8 +396,7 @@ void TapirPalette::ExecuteScript (const PopUpItemData& popUpItemData)
                 return;
             }
 
-            GS::UniString lowerContent = stderrContent;
-            lowerContent.ToLowerCase ();
+            const GS::UniString lowerContent = stderrContent.ToLowerCase ();
 
             if (lowerContent.Contains ("error:") || lowerContent.Contains ("failed") || lowerContent.Contains ("traceback (most recent call last)")) {
                 GS::MessageLoopExecutor ().Execute (new OutputUpdateTask (DG_ERROR, stderrContent));

--- a/archicad-addon/Sources/TapirPalette.hpp
+++ b/archicad-addon/Sources/TapirPalette.hpp
@@ -55,7 +55,7 @@ private:
     UvManager uvManager;
 
     void SetMenuItemCheckedState (bool);
-    void ExecuteScript (const IO::Location& fileLocation, const GS::Array<GS::UniString>& additionalArgv = {});
+    void ExecuteScript (const PopUpItemData& popUpItemData);
     bool AddScriptToPopUp (GS::Ref<PopUpItemData> popUpData, short index = DG::PopUp::TopItem);
     void AddScriptsFromRepositories ();
     void AddScriptsFromCustomScriptsFolder ();

--- a/archicad-addon/Sources/UvManager.cpp
+++ b/archicad-addon/Sources/UvManager.cpp
@@ -1,4 +1,5 @@
 #include "UvManager.hpp"
+#include "APIEnvir.h"
 #include "ACAPinc.h"
 #include "Process.hpp"
 #include "StringConversion.hpp"


### PR DESCRIPTION
- When reloading scripts, it first completely deletes temp/Tapir directory.
(fixed bug: after a rename in github, the old files remain)
- New config.json fields:
  - askUpdatingAddOnBeforeEachExecution: by default false
  - repositories / includePattern: to be able to filter files to be added to Tapir popup
  - repositories / excludePattern: to be able to filter files to be added to Tapir popup
  (fixed bug: \_\_init\_\_.py should be added to the future list of ignored files)
  - repositories / excludeFromDownloadPattern: to be able to filter files to be downloaded from github
- Show dialog when script execution has errror
(fixed bug: there is no dialog for errors; they just appear in the report)
- Pass the token to uv
(fixed bug: when using a private repo, GitHub token (PAT) is needed to access private package dependencies)