### PR TITLE
Fix documentation for `SetGDLParametersOfElements`

### DIFF
--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -1102,7 +1102,10 @@ var gCommands = [{
                         "$ref": "#/ElementId"
                     },
                     "gdlParameters": {
-                        "$ref": "#/GDLParameterList"
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/GDLParameterList"
+                        }
                     }
                 },
                 "additionalProperties": false,


### PR DESCRIPTION
Correct the type definition for `SetGDLParametersOfElements` → `gdlParameters` to specify it as an array.