### PR TITLE
Additional json schema fixes

### DIFF
--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -172,7 +172,7 @@ GS::Optional<GS::UniString> CreateSlabsCommand::GetInputParametersSchema () cons
                         "type": "array",
                         "description": "The 2D coordinates of the edge of the slab.",
                         "items": {
-                            "$ref": "#/2DCoordinate"
+                            "$ref": "#/Coordinate2D"
                         },
                         "minItems": 3
                     },
@@ -371,7 +371,7 @@ GS::Optional<GS::UniString> CreateZonesCommand::GetInputParametersSchema () cons
                         "description" : "The identifier of the zone category attribute."	
                     },
                     "stampPosition": {
-                        "$ref": "#/2DCoordinate",
+                        "$ref": "#/Coordinate2D",
                         "description" : "Position of the origin of the zone stamp."
                     },
                     "geometry": {
@@ -522,7 +522,7 @@ GS::Optional<GS::UniString> CreatePolylinesCommand::GetInputParametersSchema () 
                         "type": "array",
                         "description": "The 2D coordinates of the polyline.",
                         "items": {
-                            "$ref": "#/2DCoordinate"
+                            "$ref": "#/Coordinate2D"
                         },
                         "minItems": 2
                     },
@@ -613,10 +613,10 @@ GS::Optional<GS::UniString> CreateObjectsCommand::GetInputParametersSchema () co
                             "description" : "The name of the library part to use."	
                         },
                         "coordinates": {
-                            "$ref": "#/3DCoordinate"
+                            "$ref": "#/Coordinate3D"
                         },
                         "dimensions": {
-                            "$ref": "#/3DDimensions"
+                            "$ref": "#/Dimensions3D"
                         }
                     },
                     "additionalProperties": false,
@@ -788,7 +788,7 @@ GS::Optional<GS::UniString> CreateMeshesCommand::GetInputParametersSchema () con
                         "type": "array",
                         "description": "The 3D coordinates of the outline polygon of the mesh.",
                         "items": {
-                            "$ref": "#/3DCoordinate"
+                            "$ref": "#/Coordinate3D"
                         },
                         "minItems": 3
                     },
@@ -812,7 +812,7 @@ GS::Optional<GS::UniString> CreateMeshesCommand::GetInputParametersSchema () con
                                     "type": "array",
                                     "description": "The 3D coordinates of the leveling subline of the mesh.",
                                     "items": {
-                                        "$ref": "#/3DCoordinate"
+                                        "$ref": "#/Coordinate3D"
                                     }
                                 }
                             },

--- a/archicad-addon/Sources/PropertyCommands.cpp
+++ b/archicad-addon/Sources/PropertyCommands.cpp
@@ -748,28 +748,7 @@ GS::Optional<GS::UniString> CreatePropertyGroupsCommand::GetInputParametersSchem
                 "type": "array",
                 "description": "The parameters of the new property groups.",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "propertyGroup": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "description": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false,
-                            "required": [
-                                "name"
-                            ]
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "propertyGroup"
-                    ]
+                    "$ref": "#/PropertyGroupArrayItem"
                 }
             }
         },
@@ -789,16 +768,7 @@ GS::Optional<GS::UniString> CreatePropertyGroupsCommand::GetResponseSchema () co
                 "type": "array",
                 "description": "The identifiers of the created property groups.",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "propertyGroupId": {
-                            "$ref": "#/PropertyGroupId"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "propertyGroupId"
-                    ]
+                    "$ref": "#/PropertyGroupIdArrayItem"
                 }
             }
         },
@@ -866,16 +836,7 @@ GS::Optional<GS::UniString> DeletePropertyGroupsCommand::GetInputParametersSchem
                 "type": "array",
                 "description": "The identifiers of property groups to delete.",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "propertyGroupId": {
-                            "$ref": "#/PropertyGroupId"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "propertyGroupId"
-                    ]
+                    "$ref": "#/PropertyGroupIdArrayItem"
                 }
             }
         },
@@ -952,96 +913,7 @@ GS::Optional<GS::UniString> CreatePropertyDefinitionsCommand::GetInputParameters
                 "type": "array",
                 "description": "The parameters of the new properties.",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "propertyDefinition": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "description": {
-                                    "type": "string"
-                                },
-                                "type": {
-                                    "$ref": "#/PropertyDataType"
-                                },
-                                "isEditable": {
-                                    "type": "boolean"
-                                },
-                                "defaultValue": {
-                                    "$ref": "#/PropertyDefaultValue"
-                                },
-                                "possibleEnumValues": {
-                                    "type": "array",
-                                    "description": "The possible enum values of the property when the property type is enumeration.",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "enumValue": {
-                                                "type": "object",
-                                                "description": "The description of an enumeration value.",
-                                                "properties": {
-                                                    "enumValueId": {
-                                                        "$ref": "#/EnumValueId"
-                                                    },
-                                                    "displayValue": {
-                                                        "type": "string",
-                                                        "description": "Displayed value of the enumeration."
-                                                    },
-                                                    "nonLocalizedValue": {
-                                                        "type": "string",
-                                                        "description": "Nonlocalized value of the enumeration if there is one."
-                                                    }
-                                                },
-                                                "required": [
-                                                    "displayValue"
-                                                ]
-                                            }
-                                        },
-                                        "additionalProperties": false,
-                                        "required": [
-                                            "enumValue"
-                                        ]
-                                    }
-                                },
-                                "availability": {
-                                    "type": "array",
-                                    "description": "The identifiers of classification items the new property is available for.",    
-                                    "items": {
-                                        "$ref": "#/ClassificationItemIdArrayItem"
-                                    }
-                                },
-                                "group": {
-                                    "type": "object",
-                                    "description": "The property group defined by name or id. If both fields exists the id will be used.",
-                                    "properties": {
-                                        "propertyGroupId": {
-                                            "$ref": "#/PropertyGroupId"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": []
-                                }
-                            },
-                            "additionalProperties": false,
-                            "required": [
-                                "name",
-                                "description",
-                                "type",
-                                "isEditable",
-                                "availability",
-                                "group"
-                            ]
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "propertyDefinition"
-                    ]
+                    "$ref" : "#/PropertyDefinitionArrayItem"
                 }
             }
         },

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -542,6 +542,7 @@
     },
     "PropertyIdArrayItem": {
         "type": "object",
+        "description": "A wrapper containing the property values.",
         "properties": {
             "propertyId": {
                 "$ref": "#/PropertyId"
@@ -641,19 +642,24 @@
             "value"
         ]
     },
+    "PropertyValueArrayItem": {
+        "type": "object",
+        "description": "A wrapper containing the property value.",
+        "properties": {
+            "propertyValue": {
+                "$ref": "#/PropertyValue"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "propertyValue" ]
+    },
     "PropertyValueOrErrorItem": {
         "type": "object",
         "description": "A property value or an error",
         "oneOf": [
             {
                 "title": "propertyValue",
-                "properties": {
-                    "propertyValue": {
-                        "$ref": "#/PropertyValue"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "propertyValue" ]
+                "$ref": "#/PropertyValueArrayItem"
             },
             {
                 "title": "error",
@@ -668,19 +674,23 @@
             "$ref": "#/PropertyValueOrErrorItem"
         }
     },
+    "PropertyValuesItem": {
+        "description": "A wrapper containing the property values.",
+        "properties": {
+            "propertyValues": {
+                "$ref": "#/PropertyValues"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "propertyValues" ]
+    },
     "PropertyValuesOrError": {
         "type": "object",
         "description": "A list of property values or an error.",
         "oneOf": [
             {
                 "title": "propertyValues",
-                "properties": {
-                    "propertyValues": {
-                        "$ref": "#/PropertyValues"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "propertyValues" ]
+                "$ref": "#/ErrorItem"
             },
             {
                 "title": "error",
@@ -700,13 +710,7 @@
         "description": "A propertyId or an error.",
         "oneOf": [
             {
-                "properties": {
-                    "propertyId": {
-                        "$ref": "#/PropertyId"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "propertyId" ]
+                "$ref": "#/PropertyIdArrayItem"
             },
             {
                 "$ref": "#/ErrorItem"
@@ -1449,19 +1453,24 @@
             "classificationSystemId"
         ]
     },
+    "ClassificationIdArrayItem": {
+        "type": "object",
+        "description": "A wrapper containing the classification identifier.",
+        "properties": {
+            "classificationId": {
+                "$ref": "#/ClassificationId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "classificationId" ]
+    },
     "ClassificationIdOrError": {
         "type": "object",
         "description": "A classification identifier or an error.",
         "oneOf": [
             {
-                "title": "classificationId",
-                "properties": {
-                    "classificationId": {
-                        "$ref": "#/ClassificationId"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "classificationId" ]
+                "title": "ClassificationIdArrayItem",
+                "$ref": "#/ErrorItem"
             },
             {
                 "title": "error",
@@ -1476,19 +1485,23 @@
             "$ref": "#/ClassificationIdOrError"
         }
     },
+    "ElementClassificationItemArray": {
+        "description": "A wrapper containing a list of element classification identifiers or errors.",
+        "properties": {
+            "classificationIds": {
+                "$ref": "#/ClassificationIdsOrErrors"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "classificationIds" ]
+    },
     "ElementClassificationOrError": {
         "type": "object",
         "description": "Element classification identifiers or errors.",
         "oneOf": [
             {
-                "title": "classificationIds",
-                "properties": {
-                    "classificationIds": {
-                        "$ref": "#/ClassificationIdsOrErrors"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "classificationIds" ]
+                "title": "elementClassificationItem",
+                "$ref": "#/ElementClassificationItemArray"
             },
             {
                 "title": "error",
@@ -1566,19 +1579,26 @@
             "zMax"
         ]
     },
+    "BoundingBox3DArrayItem": {
+        "type": "object",
+        "description": "A wrapper containing a 3D bounding box.",
+        "properties": {
+            "boundingBox3D": {
+                "$ref": "#/BoundingBox3D"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "boundingBox3D"
+        ]
+    },
     "BoundingBox3DOrError": {
         "type": "object",
         "description": "A 3D bounding box or an error.",
         "oneOf": [
             {
                 "title": "boundingBox3D",
-                "properties": {
-                    "boundingBox3D": {
-                        "$ref": "#/BoundingBox3D"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "boundingBox3D" ]
+                "$ref": "#/BoundingBox3DArrayItem"
             },
             {
                 "title": "error",
@@ -2774,23 +2794,24 @@
             "layoutInfo"
         ]
     },
+    "RevisionChangeArrayItem": {
+        "type": "object",
+        "description": "A wrapper containing revision changes",
+        "properties": {
+            "revisionChange": {
+                "$ref": "#/RevisionChange"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "revisionChange"
+        ]
+    },
     "RevisionChangesOfEntities": {
         "type": "object",
         "oneOf": [
             {
-                "type": "object",
-                "properties": {
-                    "revisionChanges": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/RevisionChange"
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "revisionChanges"
-                ]
+                "$ref": "#/RevisionChangeArrayItem"
             },
             {
                 "$ref": "#/ErrorItem"

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -2571,6 +2571,26 @@
             ]
         }
     },
+    "DocumentRevisionReference": {
+        "type": "object",
+        "description": "A reference to a document revision belonging to the current issue",
+        "properties": {
+            "revisionId": {
+                "$ref": "#/DocumentRevisionId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "revisionId"
+        ]
+    },
+    "DocumentRevisionReferences": {
+        "type": "array",
+        "description": "All document revisions belong to the current issue.",
+        "items": {
+            "$ref": "#/DocumentRevisionReference"
+        }
+    },
     "RevisionIssue": {
         "type": "object",
         "properties": {
@@ -2602,20 +2622,7 @@
                 "type": "boolean"
             },
             "documentRevisions": {
-                "type": "array",
-                "description": "All document revisions belong to the given issue.",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "revisionId": {
-                            "$ref": "#/DocumentRevisionId"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "revisionId"
-                    ]
-                }
+                "$ref": "#/DocumentRevisionReferences"
             },
             "customSchemeData": {
                 "$ref": "#/RevisionCustomSchemeData"

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -190,7 +190,7 @@
             "arcAngle"
         ]
     },
-    "2DCoordinate": {
+    "Coordinate2D": {
         "type": "object",
         "description": "2D coordinate.",
         "properties": {
@@ -209,7 +209,7 @@
             "y"
         ]
     },
-    "3DCoordinate": {
+    "Coordinate3D": {
         "type": "object",
         "description": "3D coordinate.",
         "properties": {
@@ -233,7 +233,7 @@
             "z"
         ]
     },
-    "3DDimensions": {
+    "Dimensions3D": {
         "type": "object",
         "description": "Dimensions in 3D.",
         "properties": {
@@ -1812,7 +1812,7 @@
                 "type": "array",
                 "description": "The 2D coordinates of the edge of the hole.",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 },
                 "minItems": 3
             },
@@ -1844,7 +1844,7 @@
                 "type": "array",
                 "description": "The 3D coordinates of the polygon of the hole.",
                 "items": {
-                    "$ref": "#/3DCoordinate"
+                    "$ref": "#/Coordinate3D"
                 },
                 "minItems": 3
             },
@@ -1880,10 +1880,10 @@
                 ]
             },
             "begCoordinate": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "endCoordinate": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "zCoordinate": {
                 "type": "number"
@@ -1916,7 +1916,7 @@
                 "type": "array",
                 "description": "Polygon outline in case of polygonal wall",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 }
             },
             "polygonArcs": {
@@ -1941,10 +1941,10 @@
         "type": "object",
         "properties": {
             "begCoordinate": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "endCoordinate": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "zCoordinate": {
                 "type": "number"
@@ -2003,7 +2003,7 @@
                 "type": "array",
                 "description": "Polygon outline of the slab.",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 }
             },
             "polygonArcs": {
@@ -2030,7 +2030,7 @@
         "type": "object",
         "properties": {
             "origin": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "zCoordinate": {
                 "type": "number"
@@ -2055,7 +2055,7 @@
         "type": "object",
         "properties": {
             "basePoint": {
-                "$ref": "#/2DCoordinate",
+                "$ref": "#/Coordinate2D",
                 "description": "Coordinate of the base point"
             },
             "angle": {
@@ -2086,7 +2086,7 @@
                 "type": "array",
                 "description": "The clip polygon of the detail/worksheet",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 }
             },
             "linkData": {
@@ -2142,10 +2142,10 @@
         "$ref": "#/LibPartBasedElementDetails",
         "properties": {
             "origin": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "dimensions": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "angle": {
                 "type": "number"
@@ -2163,7 +2163,7 @@
             "coordinates": {
                 "type": "array",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 }
             },
             "arcs": {
@@ -2198,7 +2198,7 @@
                 "description": "The identifier of the zone category attribute."
             },
             "stampPosition": {
-                "$ref": "#/2DCoordinate",
+                "$ref": "#/Coordinate2D",
                 "description": "Position of the origin of the zone stamp."
             },
             "isManual": {
@@ -2209,7 +2209,7 @@
                 "type": "array",
                 "description": "The 2D coordinates of the edge of the zone.",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 },
                 "minItems": 3
             },
@@ -2257,23 +2257,23 @@
         "type": "object",
         "properties": {
             "begCoordinate": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "endCoordinate": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "extrusionVector": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "gridOrigin": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "gridAngle": {
                 "type": "number",
                 "description": "The angle of the grid in radians."
             },
             "arcOrigin": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "isNegativeArc": {
                 "type": "boolean",
@@ -2296,7 +2296,7 @@
                 "type": "array",
                 "description": "The 3D coordinates of the panel polygon.",
                 "items": {
-                    "$ref": "#/3DCoordinate"
+                    "$ref": "#/Coordinate3D"
                 },
                 "minItems": 3
             },
@@ -2333,13 +2333,13 @@
         "type": "object",
         "properties": {
             "begCoordinate": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "endCoordinate": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "orientationVector": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "panelConnectionHole": {
                 "type": "object",
@@ -2446,7 +2446,7 @@
                 "type": "array",
                 "description": "The 3D coordinates of the outline polygon of the mesh.",
                 "items": {
-                    "$ref": "#/3DCoordinate"
+                    "$ref": "#/Coordinate3D"
                 },
                 "minItems": 3
             },
@@ -2470,7 +2470,7 @@
                             "type": "array",
                             "description": "The 3D coordinates of the leveling subline of the mesh.",
                             "items": {
-                                "$ref": "#/3DCoordinate"
+                                "$ref": "#/Coordinate3D"
                             }
                         }
                     },
@@ -2902,7 +2902,7 @@
         "description": "Automatic zone placement.",
         "properties": {
             "referencePosition": {
-                "$ref": "#/2DCoordinate",
+                "$ref": "#/Coordinate2D",
                 "description": "Reference point to automatically find zone."
             }
         },
@@ -2919,7 +2919,7 @@
                 "type": "array",
                 "description": "The 2D coordinates of the edge of the zone.",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 },
                 "minItems": 3
             },
@@ -2944,10 +2944,10 @@
         "description": "Settings for modifying a wall.",
         "properties": {
             "begCoordinate": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "endCoordinate": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "height": {
                 "type": "number",

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -540,9 +540,22 @@
             "guid"
         ]
     },
+    "PropertyGroupIdArrayItem": {
+        "type": "object",
+        "description": "A wrapper containing the property group identifier.",
+        "properties": {
+            "propertyGroupId": {
+                "$ref": "#/PropertyGroupId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "propertyGroupId"
+        ]
+    },
     "PropertyIdArrayItem": {
         "type": "object",
-        "description": "A wrapper containing the property values.",
+        "description": "A wrapper containing the property identifier.",
         "properties": {
             "propertyId": {
                 "$ref": "#/PropertyId"
@@ -658,11 +671,9 @@
         "description": "A property value or an error",
         "oneOf": [
             {
-                "title": "propertyValue",
                 "$ref": "#/PropertyValueArrayItem"
             },
             {
-                "title": "error",
                 "$ref": "#/ErrorItem"
             }
         ]
@@ -674,7 +685,7 @@
             "$ref": "#/PropertyValueOrErrorItem"
         }
     },
-    "PropertyValuesItem": {
+    "PropertyValuesArrayItem": {
         "description": "A wrapper containing the property values.",
         "properties": {
             "propertyValues": {
@@ -689,11 +700,9 @@
         "description": "A list of property values or an error.",
         "oneOf": [
             {
-                "title": "propertyValues",
-                "$ref": "#/ErrorItem"
+                "$ref": "#/PropertyValuesArrayItem"
             },
             {
-                "title": "error",
                 "$ref": "#/ErrorItem"
             }
         ]
@@ -1469,11 +1478,9 @@
         "description": "A classification identifier or an error.",
         "oneOf": [
             {
-                "title": "ClassificationIdArrayItem",
-                "$ref": "#/ErrorItem"
+                "$ref": "#/ClassificationIdArrayItem"
             },
             {
-                "title": "error",
                 "$ref": "#/ErrorItem"
             }
         ]
@@ -1500,11 +1507,9 @@
         "description": "Element classification identifiers or errors.",
         "oneOf": [
             {
-                "title": "elementClassificationItem",
                 "$ref": "#/ElementClassificationItemArray"
             },
             {
-                "title": "error",
                 "$ref": "#/ErrorItem"
             }
         ]
@@ -1597,11 +1602,9 @@
         "description": "A 3D bounding box or an error.",
         "oneOf": [
             {
-                "title": "boundingBox3D",
                 "$ref": "#/BoundingBox3DArrayItem"
             },
             {
-                "title": "error",
                 "$ref": "#/ErrorItem"
             }
         ]
@@ -2794,12 +2797,15 @@
             "layoutInfo"
         ]
     },
-    "RevisionChangeArrayItem": {
+    "RevisionChangesArrayItem": {
         "type": "object",
-        "description": "A wrapper containing revision changes",
+        "description": "A wrapper containing an array of revision changes",
         "properties": {
-            "revisionChange": {
-                "$ref": "#/RevisionChange"
+            "revisionChanges": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/RevisionChange"
+                }
             }
         },
         "additionalProperties": false,
@@ -2811,7 +2817,7 @@
         "type": "object",
         "oneOf": [
             {
-                "$ref": "#/RevisionChangeArrayItem"
+                "$ref": "#/RevisionChangesArrayItem"
             },
             {
                 "$ref": "#/ErrorItem"
@@ -2974,6 +2980,140 @@
                 "$ref": "#/WallSettings"
             }
         ]
-    }
+    },
+    "PropertyGroup": {
+        "description": "Represents a property group.",
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "description": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
+        ]
+    },
+    "PropertyGroupArrayItem": {
+        "description": "A wrapper containing a property group",
+        "type": "object",
+        "properties": {
+            "propertyGroup": {
+                "$ref": "#/PropertyGroup"
+            },
+            "additionalProperties": false,
+            "required": [
+                "propertyGroup"
+            ]
 
+        }
+    },
+    "PropertyDefinition": {
+        "type": "object",
+        "properties": {
+            "propertyDefinition": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/PropertyDataType"
+                    },
+                    "isEditable": {
+                        "type": "boolean"
+                    },
+                    "defaultValue": {
+                        "$ref": "#/PropertyDefaultValue"
+                    },
+                    "possibleEnumValues": {
+                        "type": "array",
+                        "description": "The possible enum values of the property when the property type is enumeration.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "enumValue": {
+                                    "type": "object",
+                                    "description": "The description of an enumeration value.",
+                                    "properties": {
+                                        "enumValueId": {
+                                            "$ref": "#/EnumValueId"
+                                        },
+                                        "displayValue": {
+                                            "type": "string",
+                                            "description": "Displayed value of the enumeration."
+                                        },
+                                        "nonLocalizedValue": {
+                                            "type": "string",
+                                            "description": "Nonlocalized value of the enumeration if there is one."
+                                        }
+                                    },
+                                    "required": [
+                                        "displayValue"
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "enumValue"
+                            ]
+                        }
+                    },
+                    "availability": {
+                        "type": "array",
+                        "description": "The identifiers of classification items the new property is available for.",
+                        "items": {
+                            "$ref": "#/ClassificationItemIdArrayItem"
+                        }
+                    },
+                    "group": {
+                        "type": "object",
+                        "description": "The property group defined by name or id. If both fields exists the id will be used.",
+                        "properties": {
+                            "propertyGroupId": {
+                                "$ref": "#/PropertyGroupId"
+                            },
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": []
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "description",
+                    "type",
+                    "isEditable",
+                    "availability",
+                    "group"
+                ]
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "propertyDefinition"
+        ]
+    },
+    "PropertyDefinitionArrayItem": {
+        "description": "A wrapper containing a property definition",
+        "type": "object",
+        "properties": {
+            "propertyDefinition": {
+                "$ref": "#/PropertyDefinition"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "propertyDefinition"
+        ]
+    }
 }

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -1203,7 +1203,7 @@ var gCommands = [{
                         "type": "array",
                         "description": "The 2D coordinates of the edge of the slab.",
                         "items": {
-                            "$ref": "#/2DCoordinate"
+                            "$ref": "#/Coordinate2D"
                         },
                         "minItems": 3
                     },
@@ -1273,7 +1273,7 @@ var gCommands = [{
                         "description" : "The identifier of the zone category attribute."	
                     },
                     "stampPosition": {
-                        "$ref": "#/2DCoordinate",
+                        "$ref": "#/Coordinate2D",
                         "description" : "Position of the origin of the zone stamp."
                     },
                     "geometry": {
@@ -1336,7 +1336,7 @@ var gCommands = [{
                         "type": "array",
                         "description": "The 2D coordinates of the polyline.",
                         "items": {
-                            "$ref": "#/2DCoordinate"
+                            "$ref": "#/Coordinate2D"
                         },
                         "minItems": 2
                     },
@@ -1391,10 +1391,10 @@ var gCommands = [{
                             "description" : "The name of the library part to use."	
                         },
                         "coordinates": {
-                            "$ref": "#/3DCoordinate"
+                            "$ref": "#/Coordinate3D"
                         },
                         "dimensions": {
-                            "$ref": "#/3DDimensions"
+                            "$ref": "#/Dimensions3D"
                         }
                     },
                     "additionalProperties": false,
@@ -1454,7 +1454,7 @@ var gCommands = [{
                         "type": "array",
                         "description": "The 3D coordinates of the outline polygon of the mesh.",
                         "items": {
-                            "$ref": "#/3DCoordinate"
+                            "$ref": "#/Coordinate3D"
                         },
                         "minItems": 3
                     },
@@ -1478,7 +1478,7 @@ var gCommands = [{
                                     "type": "array",
                                     "description": "The 3D coordinates of the leveling subline of the mesh.",
                                     "items": {
-                                        "$ref": "#/3DCoordinate"
+                                        "$ref": "#/Coordinate3D"
                                     }
                                 }
                             },
@@ -1752,28 +1752,7 @@ var gCommands = [{
                 "type": "array",
                 "description": "The parameters of the new property groups.",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "propertyGroup": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "description": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false,
-                            "required": [
-                                "name"
-                            ]
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "propertyGroup"
-                    ]
+                    "$ref": "#/PropertyGroupArrayItem"
                 }
             }
         },
@@ -1789,16 +1768,7 @@ var gCommands = [{
                 "type": "array",
                 "description": "The identifiers of the created property groups.",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "propertyGroupId": {
-                            "$ref": "#/PropertyGroupId"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "propertyGroupId"
-                    ]
+                    "$ref": "#/PropertyGroupIdArrayItem"
                 }
             }
         },
@@ -1818,16 +1788,7 @@ var gCommands = [{
                 "type": "array",
                 "description": "The identifiers of property groups to delete.",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "propertyGroupId": {
-                            "$ref": "#/PropertyGroupId"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "propertyGroupId"
-                    ]
+                    "$ref": "#/PropertyGroupIdArrayItem"
                 }
             }
         },
@@ -1859,96 +1820,7 @@ var gCommands = [{
                 "type": "array",
                 "description": "The parameters of the new properties.",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "propertyDefinition": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "description": {
-                                    "type": "string"
-                                },
-                                "type": {
-                                    "$ref": "#/PropertyDataType"
-                                },
-                                "isEditable": {
-                                    "type": "boolean"
-                                },
-                                "defaultValue": {
-                                    "$ref": "#/PropertyDefaultValue"
-                                },
-                                "possibleEnumValues": {
-                                    "type": "array",
-                                    "description": "The possible enum values of the property when the property type is enumeration.",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "enumValue": {
-                                                "type": "object",
-                                                "description": "The description of an enumeration value.",
-                                                "properties": {
-                                                    "enumValueId": {
-                                                        "$ref": "#/EnumValueId"
-                                                    },
-                                                    "displayValue": {
-                                                        "type": "string",
-                                                        "description": "Displayed value of the enumeration."
-                                                    },
-                                                    "nonLocalizedValue": {
-                                                        "type": "string",
-                                                        "description": "Nonlocalized value of the enumeration if there is one."
-                                                    }
-                                                },
-                                                "required": [
-                                                    "displayValue"
-                                                ]
-                                            }
-                                        },
-                                        "additionalProperties": false,
-                                        "required": [
-                                            "enumValue"
-                                        ]
-                                    }
-                                },
-                                "availability": {
-                                    "type": "array",
-                                    "description": "The identifiers of classification items the new property is available for.",    
-                                    "items": {
-                                        "$ref": "#/ClassificationItemIdArrayItem"
-                                    }
-                                },
-                                "group": {
-                                    "type": "object",
-                                    "description": "The property group defined by name or id. If both fields exists the id will be used.",
-                                    "properties": {
-                                        "propertyGroupId": {
-                                            "$ref": "#/PropertyGroupId"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": []
-                                }
-                            },
-                            "additionalProperties": false,
-                            "required": [
-                                "name",
-                                "description",
-                                "type",
-                                "isEditable",
-                                "availability",
-                                "group"
-                            ]
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "propertyDefinition"
-                    ]
+                    "$ref" : "#/PropertyDefinitionArrayItem"
                 }
             }
         },

--- a/docs/archicad-addon/common_schema_definitions.js
+++ b/docs/archicad-addon/common_schema_definitions.js
@@ -190,7 +190,7 @@ var gSchemaDefinitions = {
             "arcAngle"
         ]
     },
-    "2DCoordinate": {
+    "Coordinate2D": {
         "type": "object",
         "description": "2D coordinate.",
         "properties": {
@@ -209,7 +209,7 @@ var gSchemaDefinitions = {
             "y"
         ]
     },
-    "3DCoordinate": {
+    "Coordinate3D": {
         "type": "object",
         "description": "3D coordinate.",
         "properties": {
@@ -233,7 +233,7 @@ var gSchemaDefinitions = {
             "z"
         ]
     },
-    "3DDimensions": {
+    "Dimensions3D": {
         "type": "object",
         "description": "Dimensions in 3D.",
         "properties": {
@@ -540,8 +540,22 @@ var gSchemaDefinitions = {
             "guid"
         ]
     },
+    "PropertyGroupIdArrayItem": {
+        "type": "object",
+        "description": "A wrapper containing the property group identifier.",
+        "properties": {
+            "propertyGroupId": {
+                "$ref": "#/PropertyGroupId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "propertyGroupId"
+        ]
+    },
     "PropertyIdArrayItem": {
         "type": "object",
+        "description": "A wrapper containing the property identifier.",
         "properties": {
             "propertyId": {
                 "$ref": "#/PropertyId"
@@ -641,22 +655,25 @@ var gSchemaDefinitions = {
             "value"
         ]
     },
+    "PropertyValueArrayItem": {
+        "type": "object",
+        "description": "A wrapper containing the property value.",
+        "properties": {
+            "propertyValue": {
+                "$ref": "#/PropertyValue"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "propertyValue" ]
+    },
     "PropertyValueOrErrorItem": {
         "type": "object",
         "description": "A property value or an error",
         "oneOf": [
             {
-                "title": "propertyValue",
-                "properties": {
-                    "propertyValue": {
-                        "$ref": "#/PropertyValue"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "propertyValue" ]
+                "$ref": "#/PropertyValueArrayItem"
             },
             {
-                "title": "error",
                 "$ref": "#/ErrorItem"
             }
         ]
@@ -668,22 +685,24 @@ var gSchemaDefinitions = {
             "$ref": "#/PropertyValueOrErrorItem"
         }
     },
+    "PropertyValuesArrayItem": {
+        "description": "A wrapper containing the property values.",
+        "properties": {
+            "propertyValues": {
+                "$ref": "#/PropertyValues"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "propertyValues" ]
+    },
     "PropertyValuesOrError": {
         "type": "object",
         "description": "A list of property values or an error.",
         "oneOf": [
             {
-                "title": "propertyValues",
-                "properties": {
-                    "propertyValues": {
-                        "$ref": "#/PropertyValues"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "propertyValues" ]
+                "$ref": "#/PropertyValuesArrayItem"
             },
             {
-                "title": "error",
                 "$ref": "#/ErrorItem"
             }
         ]
@@ -700,13 +719,7 @@ var gSchemaDefinitions = {
         "description": "A propertyId or an error.",
         "oneOf": [
             {
-                "properties": {
-                    "propertyId": {
-                        "$ref": "#/PropertyId"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "propertyId" ]
+                "$ref": "#/PropertyIdArrayItem"
             },
             {
                 "$ref": "#/ErrorItem"
@@ -1449,22 +1462,25 @@ var gSchemaDefinitions = {
             "classificationSystemId"
         ]
     },
+    "ClassificationIdArrayItem": {
+        "type": "object",
+        "description": "A wrapper containing the classification identifier.",
+        "properties": {
+            "classificationId": {
+                "$ref": "#/ClassificationId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "classificationId" ]
+    },
     "ClassificationIdOrError": {
         "type": "object",
         "description": "A classification identifier or an error.",
         "oneOf": [
             {
-                "title": "classificationId",
-                "properties": {
-                    "classificationId": {
-                        "$ref": "#/ClassificationId"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "classificationId" ]
+                "$ref": "#/ClassificationIdArrayItem"
             },
             {
-                "title": "error",
                 "$ref": "#/ErrorItem"
             }
         ]
@@ -1476,22 +1492,24 @@ var gSchemaDefinitions = {
             "$ref": "#/ClassificationIdOrError"
         }
     },
+    "ElementClassificationItemArray": {
+        "description": "A wrapper containing a list of element classification identifiers or errors.",
+        "properties": {
+            "classificationIds": {
+                "$ref": "#/ClassificationIdsOrErrors"
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "classificationIds" ]
+    },
     "ElementClassificationOrError": {
         "type": "object",
         "description": "Element classification identifiers or errors.",
         "oneOf": [
             {
-                "title": "classificationIds",
-                "properties": {
-                    "classificationIds": {
-                        "$ref": "#/ClassificationIdsOrErrors"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "classificationIds" ]
+                "$ref": "#/ElementClassificationItemArray"
             },
             {
-                "title": "error",
                 "$ref": "#/ErrorItem"
             }
         ]
@@ -1566,22 +1584,27 @@ var gSchemaDefinitions = {
             "zMax"
         ]
     },
+    "BoundingBox3DArrayItem": {
+        "type": "object",
+        "description": "A wrapper containing a 3D bounding box.",
+        "properties": {
+            "boundingBox3D": {
+                "$ref": "#/BoundingBox3D"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "boundingBox3D"
+        ]
+    },
     "BoundingBox3DOrError": {
         "type": "object",
         "description": "A 3D bounding box or an error.",
         "oneOf": [
             {
-                "title": "boundingBox3D",
-                "properties": {
-                    "boundingBox3D": {
-                        "$ref": "#/BoundingBox3D"
-                    }
-                },
-                "additionalProperties": false,
-                "required": [ "boundingBox3D" ]
+                "$ref": "#/BoundingBox3DArrayItem"
             },
             {
-                "title": "error",
                 "$ref": "#/ErrorItem"
             }
         ]
@@ -1789,7 +1812,7 @@ var gSchemaDefinitions = {
                 "type": "array",
                 "description": "The 2D coordinates of the edge of the hole.",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 },
                 "minItems": 3
             },
@@ -1821,7 +1844,7 @@ var gSchemaDefinitions = {
                 "type": "array",
                 "description": "The 3D coordinates of the polygon of the hole.",
                 "items": {
-                    "$ref": "#/3DCoordinate"
+                    "$ref": "#/Coordinate3D"
                 },
                 "minItems": 3
             },
@@ -1857,10 +1880,10 @@ var gSchemaDefinitions = {
                 ]
             },
             "begCoordinate": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "endCoordinate": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "zCoordinate": {
                 "type": "number"
@@ -1893,7 +1916,7 @@ var gSchemaDefinitions = {
                 "type": "array",
                 "description": "Polygon outline in case of polygonal wall",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 }
             },
             "polygonArcs": {
@@ -1918,10 +1941,10 @@ var gSchemaDefinitions = {
         "type": "object",
         "properties": {
             "begCoordinate": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "endCoordinate": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "zCoordinate": {
                 "type": "number"
@@ -1980,7 +2003,7 @@ var gSchemaDefinitions = {
                 "type": "array",
                 "description": "Polygon outline of the slab.",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 }
             },
             "polygonArcs": {
@@ -2007,7 +2030,7 @@ var gSchemaDefinitions = {
         "type": "object",
         "properties": {
             "origin": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "zCoordinate": {
                 "type": "number"
@@ -2032,7 +2055,7 @@ var gSchemaDefinitions = {
         "type": "object",
         "properties": {
             "basePoint": {
-                "$ref": "#/2DCoordinate",
+                "$ref": "#/Coordinate2D",
                 "description": "Coordinate of the base point"
             },
             "angle": {
@@ -2063,7 +2086,7 @@ var gSchemaDefinitions = {
                 "type": "array",
                 "description": "The clip polygon of the detail/worksheet",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 }
             },
             "linkData": {
@@ -2119,10 +2142,10 @@ var gSchemaDefinitions = {
         "$ref": "#/LibPartBasedElementDetails",
         "properties": {
             "origin": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "dimensions": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "angle": {
                 "type": "number"
@@ -2140,7 +2163,7 @@ var gSchemaDefinitions = {
             "coordinates": {
                 "type": "array",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 }
             },
             "arcs": {
@@ -2175,7 +2198,7 @@ var gSchemaDefinitions = {
                 "description": "The identifier of the zone category attribute."
             },
             "stampPosition": {
-                "$ref": "#/2DCoordinate",
+                "$ref": "#/Coordinate2D",
                 "description": "Position of the origin of the zone stamp."
             },
             "isManual": {
@@ -2186,7 +2209,7 @@ var gSchemaDefinitions = {
                 "type": "array",
                 "description": "The 2D coordinates of the edge of the zone.",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 },
                 "minItems": 3
             },
@@ -2234,23 +2257,23 @@ var gSchemaDefinitions = {
         "type": "object",
         "properties": {
             "begCoordinate": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "endCoordinate": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "extrusionVector": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "gridOrigin": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "gridAngle": {
                 "type": "number",
                 "description": "The angle of the grid in radians."
             },
             "arcOrigin": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "isNegativeArc": {
                 "type": "boolean",
@@ -2273,7 +2296,7 @@ var gSchemaDefinitions = {
                 "type": "array",
                 "description": "The 3D coordinates of the panel polygon.",
                 "items": {
-                    "$ref": "#/3DCoordinate"
+                    "$ref": "#/Coordinate3D"
                 },
                 "minItems": 3
             },
@@ -2310,13 +2333,13 @@ var gSchemaDefinitions = {
         "type": "object",
         "properties": {
             "begCoordinate": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "endCoordinate": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "orientationVector": {
-                "$ref": "#/3DCoordinate"
+                "$ref": "#/Coordinate3D"
             },
             "panelConnectionHole": {
                 "type": "object",
@@ -2423,7 +2446,7 @@ var gSchemaDefinitions = {
                 "type": "array",
                 "description": "The 3D coordinates of the outline polygon of the mesh.",
                 "items": {
-                    "$ref": "#/3DCoordinate"
+                    "$ref": "#/Coordinate3D"
                 },
                 "minItems": 3
             },
@@ -2447,7 +2470,7 @@ var gSchemaDefinitions = {
                             "type": "array",
                             "description": "The 3D coordinates of the leveling subline of the mesh.",
                             "items": {
-                                "$ref": "#/3DCoordinate"
+                                "$ref": "#/Coordinate3D"
                             }
                         }
                     },
@@ -2571,6 +2594,26 @@ var gSchemaDefinitions = {
             ]
         }
     },
+    "DocumentRevisionReference": {
+        "type": "object",
+        "description": "A reference to a document revision belonging to the current issue",
+        "properties": {
+            "revisionId": {
+                "$ref": "#/DocumentRevisionId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "revisionId"
+        ]
+    },
+    "DocumentRevisionReferences": {
+        "type": "array",
+        "description": "All document revisions belong to the current issue.",
+        "items": {
+            "$ref": "#/DocumentRevisionReference"
+        }
+    },
     "RevisionIssue": {
         "type": "object",
         "properties": {
@@ -2602,20 +2645,7 @@ var gSchemaDefinitions = {
                 "type": "boolean"
             },
             "documentRevisions": {
-                "type": "array",
-                "description": "All document revisions belong to the given issue.",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "revisionId": {
-                            "$ref": "#/DocumentRevisionId"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "revisionId"
-                    ]
-                }
+                "$ref": "#/DocumentRevisionReferences"
             },
             "customSchemeData": {
                 "$ref": "#/RevisionCustomSchemeData"
@@ -2767,23 +2797,27 @@ var gSchemaDefinitions = {
             "layoutInfo"
         ]
     },
+    "RevisionChangesArrayItem": {
+        "type": "object",
+        "description": "A wrapper containing an array of revision changes",
+        "properties": {
+            "revisionChanges": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/RevisionChange"
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "revisionChange"
+        ]
+    },
     "RevisionChangesOfEntities": {
         "type": "object",
         "oneOf": [
             {
-                "type": "object",
-                "properties": {
-                    "revisionChanges": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/RevisionChange"
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "revisionChanges"
-                ]
+                "$ref": "#/RevisionChangesArrayItem"
             },
             {
                 "$ref": "#/ErrorItem"
@@ -2868,7 +2902,7 @@ var gSchemaDefinitions = {
         "description": "Automatic zone placement.",
         "properties": {
             "referencePosition": {
-                "$ref": "#/2DCoordinate",
+                "$ref": "#/Coordinate2D",
                 "description": "Reference point to automatically find zone."
             }
         },
@@ -2885,7 +2919,7 @@ var gSchemaDefinitions = {
                 "type": "array",
                 "description": "The 2D coordinates of the edge of the zone.",
                 "items": {
-                    "$ref": "#/2DCoordinate"
+                    "$ref": "#/Coordinate2D"
                 },
                 "minItems": 3
             },
@@ -2910,10 +2944,10 @@ var gSchemaDefinitions = {
         "description": "Settings for modifying a wall.",
         "properties": {
             "begCoordinate": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "endCoordinate": {
-                "$ref": "#/2DCoordinate"
+                "$ref": "#/Coordinate2D"
             },
             "height": {
                 "type": "number",
@@ -2946,6 +2980,140 @@ var gSchemaDefinitions = {
                 "$ref": "#/WallSettings"
             }
         ]
-    }
+    },
+    "PropertyGroup": {
+        "description": "Represents a property group.",
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "description": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
+        ]
+    },
+    "PropertyGroupArrayItem": {
+        "description": "A wrapper containing a property group",
+        "type": "object",
+        "properties": {
+            "propertyGroup": {
+                "$ref": "#/PropertyGroup"
+            },
+            "additionalProperties": false,
+            "required": [
+                "propertyGroup"
+            ]
 
+        }
+    },
+    "PropertyDefinition": {
+        "type": "object",
+        "properties": {
+            "propertyDefinition": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/PropertyDataType"
+                    },
+                    "isEditable": {
+                        "type": "boolean"
+                    },
+                    "defaultValue": {
+                        "$ref": "#/PropertyDefaultValue"
+                    },
+                    "possibleEnumValues": {
+                        "type": "array",
+                        "description": "The possible enum values of the property when the property type is enumeration.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "enumValue": {
+                                    "type": "object",
+                                    "description": "The description of an enumeration value.",
+                                    "properties": {
+                                        "enumValueId": {
+                                            "$ref": "#/EnumValueId"
+                                        },
+                                        "displayValue": {
+                                            "type": "string",
+                                            "description": "Displayed value of the enumeration."
+                                        },
+                                        "nonLocalizedValue": {
+                                            "type": "string",
+                                            "description": "Nonlocalized value of the enumeration if there is one."
+                                        }
+                                    },
+                                    "required": [
+                                        "displayValue"
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "enumValue"
+                            ]
+                        }
+                    },
+                    "availability": {
+                        "type": "array",
+                        "description": "The identifiers of classification items the new property is available for.",
+                        "items": {
+                            "$ref": "#/ClassificationItemIdArrayItem"
+                        }
+                    },
+                    "group": {
+                        "type": "object",
+                        "description": "The property group defined by name or id. If both fields exists the id will be used.",
+                        "properties": {
+                            "propertyGroupId": {
+                                "$ref": "#/PropertyGroupId"
+                            },
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": []
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "description",
+                    "type",
+                    "isEditable",
+                    "availability",
+                    "group"
+                ]
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "propertyDefinition"
+        ]
+    },
+    "PropertyDefinitionArrayItem": {
+        "description": "A wrapper containing a property definition",
+        "type": "object",
+        "properties": {
+            "propertyDefinition": {
+                "$ref": "#/PropertyDefinition"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "propertyDefinition"
+        ]
+    }
 };


### PR DESCRIPTION
1. Document revision - one conflict I missed in my previous commit
2. / 3. - Code generator does not like unnamed wrappers, as it needs a name for the class it creates. I used the ArrayItem suffix for all wrapper objects. I have noticed a trend where wrappers inside arrays are suffixed ArrayItem, and wrappers inside oneOfs are suffixes Item, but decided against useing it because some of the wrappers appear in both oneOfs and arrays. Keeping this convention would have meant duplivateing the same object with different names.
4. Purely asthetic. The code generator handles this by adding a prefix, but it can be confuseing for the end user.