### PR TITLE
GetFavoritesByType command

### DIFF
--- a/archicad-addon/Examples/test_favorites_commands.py
+++ b/archicad-addon/Examples/test_favorites_commands.py
@@ -16,6 +16,11 @@ aclib.RunTapirCommand (
     })
 
 aclib.RunTapirCommand (
+    'GetFavoritesByType', {
+        'elementType': 'Column'
+    })
+
+aclib.RunTapirCommand (
     'ApplyFavoritesToElementDefaults', {
         'favorites': ['ColumnFromPython']
     })

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -282,7 +282,7 @@ GSErrCode Initialize (void)
     { // Favorites Commands
         CommandGroup favoritesCommands ("Favorites Commands");
         err |= RegisterCommand<GetFavoritesByTypeCommand> (
-            favoritesCommands, "1.2.1",
+            favoritesCommands, "1.2.2",
             "Returns a list of the names of all favorites with the given element type"
         );
         err |= RegisterCommand<ApplyFavoritesToElementDefaultsCommand> (

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -281,6 +281,10 @@ GSErrCode Initialize (void)
 
     { // Favorites Commands
         CommandGroup favoritesCommands ("Favorites Commands");
+        err |= RegisterCommand<GetFavoritesByTypeCommand> (
+            favoritesCommands, "1.2.1",
+            "Returns a list of the names of all favorites with the given element type"
+        );
         err |= RegisterCommand<ApplyFavoritesToElementDefaultsCommand> (
             favoritesCommands, "1.1.2",
             "Apply the given favorites to element defaults."

--- a/archicad-addon/Sources/FavoritesCommands.cpp
+++ b/archicad-addon/Sources/FavoritesCommands.cpp
@@ -50,8 +50,12 @@ GS::ObjectState GetFavoritesByTypeCommand::Execute (const GS::ObjectState& param
     }
 
     GS::Array< GS::UniString > names;
-
+#ifdef ServerMainVers_2600
     GSErrCode err = ACAPI_Favorite_GetNum (elemType, nullptr, nullptr, &names);
+#else
+    API_ElemVariationID variation = APIVarId_Generic;
+    GSErrCode err = ACAPI_Favorite_GetNum (elemType, variation, nullptr, nullptr, &names);
+#endif
     if (err != NoError) {
         return CreateErrorResponse (err, "Failed to retrieve favorites of the given type.");
     }

--- a/archicad-addon/Sources/FavoritesCommands.hpp
+++ b/archicad-addon/Sources/FavoritesCommands.hpp
@@ -2,6 +2,16 @@
 
 #include "CommandBase.hpp"
 
+class GetFavoritesByTypeCommand : public CommandBase
+{
+public:
+    GetFavoritesByTypeCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
 class ApplyFavoritesToElementDefaultsCommand : public CommandBase
 {
 public:

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -3110,5 +3110,13 @@
         "required": [
             "propertyDefinition"
         ]
+    },
+    "Favorites": {
+        "type": "array",
+        "description": "A list of favorite names",
+        "items": {
+            "type": "string",
+            "description": "The name of a favorite."
+        }
     }
 }

--- a/archicad-addon/Test/ExpectedOutputs/test_favorites_commands.py.output
+++ b/archicad-addon/Test/ExpectedOutputs/test_favorites_commands.py.output
@@ -38,6 +38,26 @@ Response:
         }
     ]
 }
+Command: GetFavoritesByType
+Parameters:
+{
+    "elementType": "Column"
+}
+Response:
+{
+    "favorites": [
+        "ColumnFromPython",
+        "Precast Column with Drop Panel",
+        "Column - Rectangular Reinforced Concrete",
+        "Steel Segmented Column",
+        "External Column",
+        "Round Column",
+        "Precast Sleeve Foundation",
+        "Generic Column",
+        "Precast Column with Corbel",
+        "Column - Steel"
+    ]
+}
 Command: ApplyFavoritesToElementDefaults
 Parameters:
 {

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -1518,20 +1518,39 @@ var gCommands = [{
         },{
             "name": "Favorites Commands",
             "commands": [{
+                "name": "GetFavoritesByType",
+                "version": "1.2.1",
+                "description": "Returns a list of the names of all favorites with the given element type",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "elementType": {
+                "$ref": "#/ElementType"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "elementType"
+        ]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "favorites": "#/Favorites"
+        },
+        "additionalProperties": false,
+        "required": [
+            "favorites"
+        ]
+    }
+            },{
                 "name": "ApplyFavoritesToElementDefaults",
                 "version": "1.1.2",
                 "description": "Apply the given favorites to element defaults.",
                 "inputScheme": {
         "type": "object",
         "properties": {
-            "favorites": {
-                "type": "array",
-                "description": "The favorites to apply.",
-                "items": {
-                    "type": "string",
-                    "description": "The name of a favorite."
-                }
-            }
+            "favorites": "#/Favorites"
         },
         "additionalProperties": false,
         "required": [

--- a/docs/archicad-addon/common_schema_definitions.js
+++ b/docs/archicad-addon/common_schema_definitions.js
@@ -3110,5 +3110,13 @@ var gSchemaDefinitions = {
         "required": [
             "propertyDefinition"
         ]
+    },
+    "Favorites": {
+        "type": "array",
+        "description": "A list of favorite names",
+        "items": {
+            "type": "string",
+            "description": "The name of a favorite."
+        }
     }
 };


### PR DESCRIPTION
Implemented get favorites by type command.

Did not use folders return  parameter as Archicad 29's new FavoriteManager class seams to be a more convinient way to handle favorite folders in the future.