### PR TITLE
Review additional properties in JSON schema

### DIFF
--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -235,6 +235,7 @@ GS::Optional<GS::UniString> GetDetailsOfElementsCommand::GetResponseSchema () co
                             "$ref": "#/TypeSpecificDetails"
                         }
                     },
+                    "additionalProperties": false,
                     "required": [
                         "type",
                         "id",
@@ -713,6 +714,7 @@ GS::Optional<GS::UniString> SetDetailsOfElementsCommand::GetInputParametersSchem
                                     "$ref": "#/TypeSpecificSettings"
                                 }
                             },
+                            "additionalProperties": false,
                             "required": []
                         }
                     },

--- a/archicad-addon/Sources/IssueCommands.cpp
+++ b/archicad-addon/Sources/IssueCommands.cpp
@@ -674,7 +674,7 @@ GS::Optional<GS::UniString> GetElementsAttachedToIssueCommand::GetResponseSchema
                 "$ref": "#/Elements"
             }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
             "elements"
         ]

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -394,7 +394,7 @@ GS::Optional<GS::UniString> SetStoriesCommand::GetInputParametersSchema () const
                 "$ref": "#/StoriesSettings"
             }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
             "stories"
         ]

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -127,6 +127,7 @@
                 "$ref": "#/GDLParameterArray"
             }
         },
+        "additionalProperties": false,
         "required": [
             "parameters"
         ]
@@ -159,7 +160,7 @@
                 "description": "The value of the parameter."
             }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
             "index",
             "type",
@@ -650,7 +651,7 @@
                 "type": "string"
             }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
             "value"
         ]
@@ -1931,6 +1932,7 @@
                 }
             }
         },
+        "additionalProperties": false,
         "required": [
             "geometryType",
             "begCoordinate",
@@ -1974,6 +1976,7 @@
                 "description": "The height of the vertical curve of the beam."
             }
         },
+        "additionalProperties": false,
         "required": [
             "begCoordinate",
             "endCoordinate",
@@ -2021,6 +2024,7 @@
                 "$ref": "#/Holes2D"
             }
         },
+        "additionalProperties": false,
         "required": [
             "thickness",
             "level",
@@ -2048,6 +2052,7 @@
                 "description": "base level of the column relative to the floor level"
             }
         },
+        "additionalProperties": false,
         "required": [
             "origin",
             "zCoordinate",
@@ -2110,9 +2115,11 @@
                         "description": "Guid of the referred view point. Only if the marker refers to a view point."
                     }
                 },
+                "additionalProperties": false,
                 "required": []
             }
         },
+        "additionalProperties": false,
         "required": [
             "basePoint",
             "angle",
@@ -2138,6 +2145,7 @@
                 "$ref": "#/ElementType"
             }
         },
+        "additionalProperties": false,
         "required": [
             "libPart"
         ]
@@ -2155,6 +2163,7 @@
                 "type": "number"
             }
         },
+        "additionalProperties": false,
         "required": [
             "origin",
             "dimensions",
@@ -2181,6 +2190,7 @@
                 "type": "number"
             }
         },
+        "additionalProperties": false,
         "required": [
             "coordinates",
             "zCoordinate"
@@ -2231,6 +2241,7 @@
                 "type": "number"
             }
         },
+        "additionalProperties": false,
         "required": [
             "name",
             "numberStr",
@@ -2501,6 +2512,7 @@
                 "type": "string"
             }
         },
+        "additionalProperties": false,
         "required": [
             "error"
         ]
@@ -2655,6 +2667,7 @@
                 "$ref": "#/RevisionCustomSchemeData"
             }
         },
+        "additionalProperties": false,
         "required": [
             "revisionIssueId",
             "id",
@@ -2695,6 +2708,7 @@
                 "$ref": "#/RevisionCustomSchemeData"
             }
         },
+        "additionalProperties": false,
         "required": [
             "id",
             "description",
@@ -2738,6 +2752,7 @@
                 "$ref": "#/RevisionCustomSchemeData"
             }
         },
+        "additionalProperties": false,
         "required": [
             "id",
             "databaseId",
@@ -2792,6 +2807,7 @@
                 "$ref": "#/LayoutInfo"
             }
         },
+        "additionalProperties": false,
         "required": [
             "revisionId",
             "id",
@@ -2887,7 +2903,7 @@
                 "description": "The name of the story."
             }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
             "dispOnSections",
             "level",
@@ -2974,6 +2990,7 @@
                 "description": "Thickness at the end in case of trapezoid wall"
             }
         },
+        "additionalProperties": false,
         "required": []
     },
     "TypeSpecificSettings": {
@@ -3054,6 +3071,7 @@
                                     "description": "Nonlocalized value of the enumeration if there is one."
                                 }
                             },
+                            "additionalProperties": false,
                             "required": [
                                 "displayValue"
                             ]

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -212,7 +212,7 @@ var gCommands = [{
                 "$ref": "#/StoriesSettings"
             }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
             "stories"
         ]
@@ -581,6 +581,7 @@ var gCommands = [{
                             "$ref": "#/TypeSpecificDetails"
                         }
                     },
+                    "additionalProperties": false,
                     "required": [
                         "type",
                         "id",
@@ -630,6 +631,7 @@ var gCommands = [{
                                     "$ref": "#/TypeSpecificSettings"
                                 }
                             },
+                            "additionalProperties": false,
                             "required": []
                         }
                     },
@@ -1519,7 +1521,7 @@ var gCommands = [{
             "name": "Favorites Commands",
             "commands": [{
                 "name": "GetFavoritesByType",
-                "version": "1.2.1",
+                "version": "1.2.2",
                 "description": "Returns a list of the names of all favorites with the given element type",
                 "inputScheme": {
         "type": "object",
@@ -2944,7 +2946,7 @@ var gCommands = [{
                 "$ref": "#/Elements"
             }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
             "elements"
         ]

--- a/docs/archicad-addon/common_schema_definitions.js
+++ b/docs/archicad-addon/common_schema_definitions.js
@@ -127,6 +127,7 @@ var gSchemaDefinitions = {
                 "$ref": "#/GDLParameterArray"
             }
         },
+        "additionalProperties": false,
         "required": [
             "parameters"
         ]
@@ -159,7 +160,7 @@ var gSchemaDefinitions = {
                 "description": "The value of the parameter."
             }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
             "index",
             "type",
@@ -650,7 +651,7 @@ var gSchemaDefinitions = {
                 "type": "string"
             }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
             "value"
         ]
@@ -1931,6 +1932,7 @@ var gSchemaDefinitions = {
                 }
             }
         },
+        "additionalProperties": false,
         "required": [
             "geometryType",
             "begCoordinate",
@@ -1974,6 +1976,7 @@ var gSchemaDefinitions = {
                 "description": "The height of the vertical curve of the beam."
             }
         },
+        "additionalProperties": false,
         "required": [
             "begCoordinate",
             "endCoordinate",
@@ -2021,6 +2024,7 @@ var gSchemaDefinitions = {
                 "$ref": "#/Holes2D"
             }
         },
+        "additionalProperties": false,
         "required": [
             "thickness",
             "level",
@@ -2048,6 +2052,7 @@ var gSchemaDefinitions = {
                 "description": "base level of the column relative to the floor level"
             }
         },
+        "additionalProperties": false,
         "required": [
             "origin",
             "zCoordinate",
@@ -2110,9 +2115,11 @@ var gSchemaDefinitions = {
                         "description": "Guid of the referred view point. Only if the marker refers to a view point."
                     }
                 },
+                "additionalProperties": false,
                 "required": []
             }
         },
+        "additionalProperties": false,
         "required": [
             "basePoint",
             "angle",
@@ -2138,6 +2145,7 @@ var gSchemaDefinitions = {
                 "$ref": "#/ElementType"
             }
         },
+        "additionalProperties": false,
         "required": [
             "libPart"
         ]
@@ -2155,6 +2163,7 @@ var gSchemaDefinitions = {
                 "type": "number"
             }
         },
+        "additionalProperties": false,
         "required": [
             "origin",
             "dimensions",
@@ -2181,6 +2190,7 @@ var gSchemaDefinitions = {
                 "type": "number"
             }
         },
+        "additionalProperties": false,
         "required": [
             "coordinates",
             "zCoordinate"
@@ -2231,6 +2241,7 @@ var gSchemaDefinitions = {
                 "type": "number"
             }
         },
+        "additionalProperties": false,
         "required": [
             "name",
             "numberStr",
@@ -2501,6 +2512,7 @@ var gSchemaDefinitions = {
                 "type": "string"
             }
         },
+        "additionalProperties": false,
         "required": [
             "error"
         ]
@@ -2655,6 +2667,7 @@ var gSchemaDefinitions = {
                 "$ref": "#/RevisionCustomSchemeData"
             }
         },
+        "additionalProperties": false,
         "required": [
             "revisionIssueId",
             "id",
@@ -2695,6 +2708,7 @@ var gSchemaDefinitions = {
                 "$ref": "#/RevisionCustomSchemeData"
             }
         },
+        "additionalProperties": false,
         "required": [
             "id",
             "description",
@@ -2738,6 +2752,7 @@ var gSchemaDefinitions = {
                 "$ref": "#/RevisionCustomSchemeData"
             }
         },
+        "additionalProperties": false,
         "required": [
             "id",
             "databaseId",
@@ -2792,6 +2807,7 @@ var gSchemaDefinitions = {
                 "$ref": "#/LayoutInfo"
             }
         },
+        "additionalProperties": false,
         "required": [
             "revisionId",
             "id",
@@ -2887,7 +2903,7 @@ var gSchemaDefinitions = {
                 "description": "The name of the story."
             }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": [
             "dispOnSections",
             "level",
@@ -2974,6 +2990,7 @@ var gSchemaDefinitions = {
                 "description": "Thickness at the end in case of trapezoid wall"
             }
         },
+        "additionalProperties": false,
         "required": []
     },
     "TypeSpecificSettings": {
@@ -3054,6 +3071,7 @@ var gSchemaDefinitions = {
                                     "description": "Nonlocalized value of the enumeration if there is one."
                                 }
                             },
+                            "additionalProperties": false,
                             "required": [
                                 "displayValue"
                             ]


### PR DESCRIPTION
Aim: improve the consistency of the schema, and the type safety of generated datamodels.

Most JSON objects explicitly forbid additional parameters, but there are some that do not. I looked at all JSON objects that explicitly or inplicitly allowed additional parameters. I haven't found any where we actually need to allow them. 

- Added additional parameters: false to all objects where it was missing
- looked at all occurences of additional properties: true. I think none of them are required, changed them to false.

At first I thouth the settings for the GDL parameter related objects were deliberate because of the legacy implementation and/or the untyped value parameter, but on closer inspection I think we do not need to allow the additional parameters. Can you confirm @tlorantfy when you have the time?