### PR TITLE
CreateSurfaces and AddFilesToEmbeddedLibrary commands

### DIFF
--- a/archicad-addon/Examples/create_surfaces.py
+++ b/archicad-addon/Examples/create_surfaces.py
@@ -1,0 +1,49 @@
+import aclib
+
+result = aclib.RunTapirCommand ('AddFilesToEmbeddedLibrary', {
+    'files' : [{
+        'inputPath' : 'C:\\Users\\loran\\Pictures\\MyPicture.jpg', # Change this to a valid path on your system
+        'outputPath' : 'TexturesCreatedByTapir\\New Texture 1.jpg'
+    }]
+})
+
+surfaces = [{
+        'name' : 'New Surface ' + str (i),
+        'materialType' : 'General',
+        'ambientReflection': 77,
+        'diffuseReflection': 73,
+        'specularReflection': 0,
+        'transparency': 0,
+        'shine': 0,
+        'transparencyAttenuation': 0,
+        'emissionAttenuation': 0,
+        'surfaceColor': {
+            'red': 0.337254902,
+            'green': 0.662745098,
+            'blue': 0.180392157
+        },
+        'specularColor': {
+            'red': 1,
+            'green': 1,
+            'blue': 1
+        },
+        'emissionColor': {
+            'red': 0,
+            'green': 0,
+            'blue': 0
+        },
+        'texture': {
+            'name': 'New Texture ' + str (i)
+        }
+    } for i in range (1, 11)]
+
+result = aclib.RunTapirCommand ('CreateSurfaces', {
+    'surfaceDataArray' : surfaces,
+    'overwriteExisting' : True
+})
+
+result = aclib.RunCommand ('API.GetSurfaceAttributes', {
+    'attributeIds' : result['attributeIds']
+})
+
+print ('New surfaces:\n' + aclib.JsonDumpDictionary (result))

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -359,6 +359,10 @@ GSErrCode Initialize (void)
             attributeCommands, "1.0.2",
             "Creates Composite attributes based on the given parameters."
         );
+        err |= RegisterCommand<CreateSurfacesCommand> (
+            attributeCommands, "1.2.2",
+            "Creates Surface attributes based on the given parameters."
+        );
         err |= RegisterCommand<GetBuildingMaterialPhysicalPropertiesCommand> (
             attributeCommands, "0.1.3",
             "Retrieves the physical properties of the given Building Materials."
@@ -375,6 +379,10 @@ GSErrCode Initialize (void)
         err |= RegisterCommand<ReloadLibrariesCommand> (
             libraryCommands, "1.0.0",
             "Executes the reload libraries command."
+        );
+        err |= RegisterCommand<AddFilesToEmbeddedLibraryCommand> (
+            libraryCommands, "1.2.2",
+            "Adds the given files into the embedded library."
         );
         AddCommandGroup (libraryCommands);
     }

--- a/archicad-addon/Sources/AttributeCommands.cpp
+++ b/archicad-addon/Sources/AttributeCommands.cpp
@@ -562,6 +562,179 @@ void CreateLayersCommand::SetTypeSpecificParameters (API_Attribute& attribute, c
     }
 }
 
+CreateSurfacesCommand::CreateSurfacesCommand () :
+    CreateAttributesCommandBase ("CreateSurfaces", API_MaterialID, "surfaceDataArray")
+{
+}
+
+GS::Optional<GS::UniString> CreateSurfacesCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "surfaceDataArray": {
+                "type": "array",
+                "description" : "Array of data to create new surfaces.",
+                "items": {
+                    "type": "object",
+                    "description": "Data to create a surface.",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name."
+                        },
+                        "materialType": {
+                            "$ref": "#/SurfaceType"
+                        },
+                        "ambientReflection": {
+                            "type": "number",
+                            "description": "Ambient percentage [0..100]."
+                        },
+                        "diffuseReflection": {
+                            "type": "number",
+                            "description": "Diffuse percentage [0..100]."
+                        },
+                        "specularReflection": {
+                            "type": "number",
+                            "description": "Specular percentage [0..100]."
+                        },
+                        "transparency": {
+                            "type": "number",
+                            "description": "Transparency percentage [0..100]."
+                        },
+                        "shine": {
+                            "type": "number",
+                            "description": "The shininess factor multiplied by 100 [0..10000]."
+                        },
+                        "transparencyAttenuation": {
+                            "type": "number",
+                            "description": "Transparency attenuation multiplied by 100 [0..10000]."
+                        },
+                        "emissionAttenuation": {
+                            "type": "number",
+                            "description": "Emission attenuation multiplied by 100 [0..10000]."
+                        },
+                        "surfaceColor": {
+                            "$ref": "#/ColorRGB"
+                        },
+                        "specularColor": {
+                            "$ref": "#/ColorRGB"
+                        },
+                        "emissionColor": {
+                            "$ref": "#/ColorRGB"
+                        },
+                        "fillId": {
+                            "$ref": "#/AttributeIdArrayItem"
+                        },
+                        "texture": {
+                            "$ref": "#/Texture"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required" : [
+                        "name",
+                        "materialType",
+                        "ambientReflection",
+                        "diffuseReflection",
+                        "specularReflection",
+                        "transparency",
+                        "shine",
+                        "transparencyAttenuation",
+                        "emissionAttenuation",
+                        "surfaceColor",
+                        "specularColor",
+                        "emissionColor"
+                    ]
+                }
+            },
+            "overwriteExisting": {
+                "type": "boolean",
+                "description": "Overwrite the Surface if exists with the same name. The default is false."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "surfaceDataArray"
+        ]
+    })";
+}
+
+void CreateSurfacesCommand::SetTypeSpecificParameters (API_Attribute& attribute, const GS::ObjectState& parameters) const
+{
+    GS::UniString typeStr;
+    if (parameters.Get ("materialType", typeStr)) {
+        if (typeStr == "Matte")
+            attribute.material.mtype = APIMater_MatteID;
+        else if (typeStr == "Metal")
+            attribute.material.mtype = APIMater_MetalID;
+        else if (typeStr == "Plastic")
+            attribute.material.mtype = APIMater_PlasticID;
+        else if (typeStr == "Glass")
+            attribute.material.mtype = APIMater_GlassID;
+        else if (typeStr == "Glowing")
+            attribute.material.mtype = APIMater_GlowingID;
+        else if (typeStr == "Constant")
+            attribute.material.mtype = APIMater_ConstID;
+        else if (typeStr == "Simple")
+            attribute.material.mtype = APIMater_SimpleID;
+        else
+            attribute.material.mtype = APIMater_GeneralID;
+    }
+
+    short ambientReflection;
+    if (parameters.Get ("ambientReflection", ambientReflection)) {
+        attribute.material.ambientPc = ambientReflection;
+    }
+
+    short diffuseReflection;
+    if (parameters.Get ("diffuseReflection", diffuseReflection)) {
+        attribute.material.diffusePc = diffuseReflection;
+    }
+
+    short specularReflection;
+    if (parameters.Get ("specularReflection", specularReflection)) {
+        attribute.material.specularPc = specularReflection;
+    }
+
+    short transparency;
+    if (parameters.Get ("transparency", transparency)) {
+        attribute.material.transpPc = transparency;
+    }
+
+    short shine;
+    if (parameters.Get ("shine", shine)) {
+        attribute.material.shine = shine;
+    }
+
+    short transparencyAttenuation;
+    if (parameters.Get ("transparencyAttenuation", transparencyAttenuation)) {
+        attribute.material.transpAtt = transparencyAttenuation;
+    }
+
+    short emissionAttenuation;
+    if (parameters.Get ("emissionAttenuation", emissionAttenuation)) {
+        attribute.material.emissionAtt = emissionAttenuation;
+    }
+
+    GetColor (parameters, "surfaceColor", attribute.material.surfaceRGB);
+    GetColor (parameters, "specularColor", attribute.material.specularRGB);
+    GetColor (parameters, "emissionColor", attribute.material.emissionRGB);
+
+    GS::ObjectState fillId;
+    if (parameters.Get ("fillId", fillId)) {
+        API_AttributeIndex fillIndex;
+        if (GetAttributeIndexFromAttributeId (fillId, API_FilltypeID, fillIndex)) {
+            attribute.material.ifill = fillIndex;
+        }
+    }
+
+    GS::ObjectState textureObj;
+    if (parameters.Get ("texture", textureObj)) {
+        attribute.material.texture.status |= APITxtr_LinkMat;
+        SetUCharProperty(&textureObj, "name", attribute.material.texture.texName);
+    }
+}
+
 CreateCompositesCommand::CreateCompositesCommand () :
     CommandBase (CommonSchema::Used)
 {

--- a/archicad-addon/Sources/AttributeCommands.hpp
+++ b/archicad-addon/Sources/AttributeCommands.hpp
@@ -53,6 +53,14 @@ public:
     virtual void SetTypeSpecificParameters (API_Attribute& attribute, const GS::ObjectState& parameters) const override;
 };
 
+class CreateSurfacesCommand : public CreateAttributesCommandBase
+{
+public:
+    CreateSurfacesCommand ();
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual void SetTypeSpecificParameters (API_Attribute& attribute, const GS::ObjectState& parameters) const override;
+};
+
 class CreateCompositesCommand : public CommandBase
 {
 public:

--- a/archicad-addon/Sources/CommandBase.cpp
+++ b/archicad-addon/Sources/CommandBase.cpp
@@ -298,6 +298,27 @@ API_Coord3D Get3DCoordinateFromObjectState (const GS::ObjectState& objectState)
     return coordinate;
 }
 
+API_RGBColor GetColorFromObjectState (const GS::ObjectState& objectState)
+{
+    API_RGBColor color = {};
+    objectState.Get ("red", color.f_red);
+    objectState.Get ("green", color.f_green);
+    objectState.Get ("blue", color.f_blue);
+    return color;
+}
+
+bool GetColor (const GS::ObjectState& objectState, const GS::String& fieldName, API_RGBColor& outColor)
+{
+    GS::ObjectState colorOS;
+    if (!objectState.Get (fieldName, colorOS)) {
+        return false;
+    }
+
+    outColor = GetColorFromObjectState(colorOS);
+
+    return true;
+}
+
 Stories GetStories ()
 {
     Stories stories;

--- a/archicad-addon/Sources/CommandBase.hpp
+++ b/archicad-addon/Sources/CommandBase.hpp
@@ -52,6 +52,8 @@ bool   IsSame2DCoordinate (const GS::ObjectState& o1, const GS::ObjectState& o2)
 bool   IsSame3DCoordinate (const GS::ObjectState& o1, const GS::ObjectState& o2);
 API_Coord   Get2DCoordinateFromObjectState (const GS::ObjectState& objectState);
 API_Coord3D Get3DCoordinateFromObjectState (const GS::ObjectState& objectState);
+API_RGBColor GetColorFromObjectState (const GS::ObjectState& objectState);
+bool GetColor (const GS::ObjectState& objectState, const GS::String& fieldName, API_RGBColor& outColor);
 GS::ObjectState Create2DCoordinateObjectState (const API_Coord& c);
 GS::ObjectState Create3DCoordinateObjectState (const API_Coord3D& c);
 GS::ObjectState CreatePolyArcObjectState (const API_PolyArc& a);

--- a/archicad-addon/Sources/LibraryCommands.hpp
+++ b/archicad-addon/Sources/LibraryCommands.hpp
@@ -2,6 +2,16 @@
 
 #include "CommandBase.hpp"
 
+class AddFilesToEmbeddedLibraryCommand : public CommandBase
+{
+public:
+    AddFilesToEmbeddedLibraryCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
 class GetLibrariesCommand : public CommandBase
 {
 public:

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -46,6 +46,7 @@
 
 #define ACAPI_GeoLocation_GetGeoLocation(par1) ACAPI_Environment (APIEnv_GetGeoLocationID, par1)
 #define ACAPI_ProjectSetting_GetProjectNotes(par1) ACAPI_Environment (APIEnv_GetProjectNotesID, par1)
+#define ACAPI_ProjectSettings_GetSpecFolder(par1, par2) ACAPI_Environment (APIEnv_GetSpecFolderID, par1, par2)
 
 #define ACAPI_Element_CalcBounds(par1,par2) ACAPI_Database (APIDb_CalcBoundsID, par1, par2)
 #define ACAPI_View_GetZoom(par1, par2) ACAPI_Database (APIDb_GetZoomID, par1, par2)
@@ -59,6 +60,8 @@
 #define ACAPI_Revision_GetRVMLayoutCurrentRevisionChanges(par1, par2) ACAPI_Database (APIDb_GetRVMLayoutCurrentRevisionChangesID, (void*)par1, par2)
 #define ACAPI_Revision_GetRVMElemChangeIds(par1, par2) ACAPI_Database (APIDb_GetRVMElemChangeIdsID, (void*)par1, par2)
 #define ACAPI_Revision_GetRVMChangesFromChangeIds(par1, par2) ACAPI_Database (APIDb_GetRVMChangesFromChangeIdsID, (void*)par1, par2)
+
+#define ACAPI_LibraryPart_Register(par1) ACAPI_LibPart_Register(par1)
 
 inline API_AttributeIndex ACAPI_CreateAttributeIndex (Int32 index)
 {

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -31,6 +31,20 @@
             "guid"
         ]
     },
+    "SurfaceType": {
+        "type": "string",
+        "description": "The type of a surface material.",
+        "enum": [
+            "General",
+            "Simple",
+            "Matte",
+            "Metal",
+            "Plastic",
+            "Glass",
+            "Glowing",
+            "Constant"
+        ]
+    },
     "AttributeType": {
         "type": "string",
         "description": "The type of an attribute.",
@@ -256,6 +270,44 @@
             "x",
             "y",
             "z"
+        ]
+    },
+    "ColorRGB": {
+        "type": "object",
+        "description": "RGB color.",
+        "properties": {
+            "red": {
+                "type": "number",
+                "description": "Red value between 0.0 and 1.0"
+            },
+            "green": {
+                "type": "number",
+                "description": "Green value between 0.0 and 1.0"
+            },
+            "blue": {
+                "type": "number",
+                "description": "Blue value between 0.0 and 1.0"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "red",
+            "green",
+            "blue"
+        ]
+    },
+    "Texture": {
+        "type": "object",
+        "description": "Texture parameters",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "The filename of the texture in the library (without extension)."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
         ]
     },
     "Error": {

--- a/archicad-addon/Test/ExpectedOutputs/create_surfaces.py.output
+++ b/archicad-addon/Test/ExpectedOutputs/create_surfaces.py.output
@@ -1,0 +1,775 @@
+Command: AddFilesToEmbeddedLibrary
+Parameters:
+{
+    "files": [
+        {
+            "inputPath": "<PATH>MyPicture.jpg",
+            "outputPath": "TexturesCreatedByTapir\\New Texture 1.jpg"
+        }
+    ]
+}
+Response:
+{
+    "executionResults": [
+        {
+            "success": true
+        }
+    ]
+}
+Command: CreateSurfaces
+Parameters:
+{
+    "surfaceDataArray": [
+        {
+            "name": "New Surface 1",
+            "materialType": "General",
+            "ambientReflection": 77,
+            "diffuseReflection": 73,
+            "specularReflection": 0,
+            "transparency": 0,
+            "shine": 0,
+            "transparencyAttenuation": 0,
+            "emissionAttenuation": 0,
+            "surfaceColor": {
+                "red": 0.337254902,
+                "green": 0.662745098,
+                "blue": 0.180392157
+            },
+            "specularColor": {
+                "red": 1,
+                "green": 1,
+                "blue": 1
+            },
+            "emissionColor": {
+                "red": 0,
+                "green": 0,
+                "blue": 0
+            },
+            "texture": {
+                "name": "New Texture 1"
+            }
+        },
+        {
+            "name": "New Surface 2",
+            "materialType": "General",
+            "ambientReflection": 77,
+            "diffuseReflection": 73,
+            "specularReflection": 0,
+            "transparency": 0,
+            "shine": 0,
+            "transparencyAttenuation": 0,
+            "emissionAttenuation": 0,
+            "surfaceColor": {
+                "red": 0.337254902,
+                "green": 0.662745098,
+                "blue": 0.180392157
+            },
+            "specularColor": {
+                "red": 1,
+                "green": 1,
+                "blue": 1
+            },
+            "emissionColor": {
+                "red": 0,
+                "green": 0,
+                "blue": 0
+            },
+            "texture": {
+                "name": "New Texture 2"
+            }
+        },
+        {
+            "name": "New Surface 3",
+            "materialType": "General",
+            "ambientReflection": 77,
+            "diffuseReflection": 73,
+            "specularReflection": 0,
+            "transparency": 0,
+            "shine": 0,
+            "transparencyAttenuation": 0,
+            "emissionAttenuation": 0,
+            "surfaceColor": {
+                "red": 0.337254902,
+                "green": 0.662745098,
+                "blue": 0.180392157
+            },
+            "specularColor": {
+                "red": 1,
+                "green": 1,
+                "blue": 1
+            },
+            "emissionColor": {
+                "red": 0,
+                "green": 0,
+                "blue": 0
+            },
+            "texture": {
+                "name": "New Texture 3"
+            }
+        },
+        {
+            "name": "New Surface 4",
+            "materialType": "General",
+            "ambientReflection": 77,
+            "diffuseReflection": 73,
+            "specularReflection": 0,
+            "transparency": 0,
+            "shine": 0,
+            "transparencyAttenuation": 0,
+            "emissionAttenuation": 0,
+            "surfaceColor": {
+                "red": 0.337254902,
+                "green": 0.662745098,
+                "blue": 0.180392157
+            },
+            "specularColor": {
+                "red": 1,
+                "green": 1,
+                "blue": 1
+            },
+            "emissionColor": {
+                "red": 0,
+                "green": 0,
+                "blue": 0
+            },
+            "texture": {
+                "name": "New Texture 4"
+            }
+        },
+        {
+            "name": "New Surface 5",
+            "materialType": "General",
+            "ambientReflection": 77,
+            "diffuseReflection": 73,
+            "specularReflection": 0,
+            "transparency": 0,
+            "shine": 0,
+            "transparencyAttenuation": 0,
+            "emissionAttenuation": 0,
+            "surfaceColor": {
+                "red": 0.337254902,
+                "green": 0.662745098,
+                "blue": 0.180392157
+            },
+            "specularColor": {
+                "red": 1,
+                "green": 1,
+                "blue": 1
+            },
+            "emissionColor": {
+                "red": 0,
+                "green": 0,
+                "blue": 0
+            },
+            "texture": {
+                "name": "New Texture 5"
+            }
+        },
+        {
+            "name": "New Surface 6",
+            "materialType": "General",
+            "ambientReflection": 77,
+            "diffuseReflection": 73,
+            "specularReflection": 0,
+            "transparency": 0,
+            "shine": 0,
+            "transparencyAttenuation": 0,
+            "emissionAttenuation": 0,
+            "surfaceColor": {
+                "red": 0.337254902,
+                "green": 0.662745098,
+                "blue": 0.180392157
+            },
+            "specularColor": {
+                "red": 1,
+                "green": 1,
+                "blue": 1
+            },
+            "emissionColor": {
+                "red": 0,
+                "green": 0,
+                "blue": 0
+            },
+            "texture": {
+                "name": "New Texture 6"
+            }
+        },
+        {
+            "name": "New Surface 7",
+            "materialType": "General",
+            "ambientReflection": 77,
+            "diffuseReflection": 73,
+            "specularReflection": 0,
+            "transparency": 0,
+            "shine": 0,
+            "transparencyAttenuation": 0,
+            "emissionAttenuation": 0,
+            "surfaceColor": {
+                "red": 0.337254902,
+                "green": 0.662745098,
+                "blue": 0.180392157
+            },
+            "specularColor": {
+                "red": 1,
+                "green": 1,
+                "blue": 1
+            },
+            "emissionColor": {
+                "red": 0,
+                "green": 0,
+                "blue": 0
+            },
+            "texture": {
+                "name": "New Texture 7"
+            }
+        },
+        {
+            "name": "New Surface 8",
+            "materialType": "General",
+            "ambientReflection": 77,
+            "diffuseReflection": 73,
+            "specularReflection": 0,
+            "transparency": 0,
+            "shine": 0,
+            "transparencyAttenuation": 0,
+            "emissionAttenuation": 0,
+            "surfaceColor": {
+                "red": 0.337254902,
+                "green": 0.662745098,
+                "blue": 0.180392157
+            },
+            "specularColor": {
+                "red": 1,
+                "green": 1,
+                "blue": 1
+            },
+            "emissionColor": {
+                "red": 0,
+                "green": 0,
+                "blue": 0
+            },
+            "texture": {
+                "name": "New Texture 8"
+            }
+        },
+        {
+            "name": "New Surface 9",
+            "materialType": "General",
+            "ambientReflection": 77,
+            "diffuseReflection": 73,
+            "specularReflection": 0,
+            "transparency": 0,
+            "shine": 0,
+            "transparencyAttenuation": 0,
+            "emissionAttenuation": 0,
+            "surfaceColor": {
+                "red": 0.337254902,
+                "green": 0.662745098,
+                "blue": 0.180392157
+            },
+            "specularColor": {
+                "red": 1,
+                "green": 1,
+                "blue": 1
+            },
+            "emissionColor": {
+                "red": 0,
+                "green": 0,
+                "blue": 0
+            },
+            "texture": {
+                "name": "New Texture 9"
+            }
+        },
+        {
+            "name": "New Surface 10",
+            "materialType": "General",
+            "ambientReflection": 77,
+            "diffuseReflection": 73,
+            "specularReflection": 0,
+            "transparency": 0,
+            "shine": 0,
+            "transparencyAttenuation": 0,
+            "emissionAttenuation": 0,
+            "surfaceColor": {
+                "red": 0.337254902,
+                "green": 0.662745098,
+                "blue": 0.180392157
+            },
+            "specularColor": {
+                "red": 1,
+                "green": 1,
+                "blue": 1
+            },
+            "emissionColor": {
+                "red": 0,
+                "green": 0,
+                "blue": 0
+            },
+            "texture": {
+                "name": "New Texture 10"
+            }
+        }
+    ],
+    "overwriteExisting": true
+}
+Response:
+{
+    "attributeIds": [
+        {
+            "attributeId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "attributeId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "attributeId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "attributeId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "attributeId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "attributeId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "attributeId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "attributeId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "attributeId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "attributeId": {
+                "guid": "<GUID>"
+            }
+        }
+    ]
+}
+New surfaces:
+{
+    "attributes": [
+        {
+            "surfaceAttribute": {
+                "attributeId": {
+                    "guid": "<GUID>"
+                },
+                "name": "New Surface 1",
+                "materialType": "General",
+                "ambientReflection": 77,
+                "diffuseReflection": 73,
+                "specularReflection": 0,
+                "transparencyAttenuation": 0,
+                "emissionAttenuation": 0,
+                "surfaceColor": {
+                    "red": 0.337254902,
+                    "green": 0.662729839,
+                    "blue": 0.180392157
+                },
+                "specularColor": {
+                    "red": 1,
+                    "green": 1,
+                    "blue": 1
+                },
+                "emissionColor": {
+                    "red": 0,
+                    "green": 0,
+                    "blue": 0
+                },
+                "fillId": {
+                    "error": {
+                        "code": 6100,
+                        "message": "Attribute is missing"
+                    }
+                },
+                "transparency": 0,
+                "shine": 0,
+                "texture": {
+                    "name": "New Texture 1"
+                }
+            }
+        },
+        {
+            "surfaceAttribute": {
+                "attributeId": {
+                    "guid": "<GUID>"
+                },
+                "name": "New Surface 2",
+                "materialType": "General",
+                "ambientReflection": 77,
+                "diffuseReflection": 73,
+                "specularReflection": 0,
+                "transparencyAttenuation": 0,
+                "emissionAttenuation": 0,
+                "surfaceColor": {
+                    "red": 0.337254902,
+                    "green": 0.662729839,
+                    "blue": 0.180392157
+                },
+                "specularColor": {
+                    "red": 1,
+                    "green": 1,
+                    "blue": 1
+                },
+                "emissionColor": {
+                    "red": 0,
+                    "green": 0,
+                    "blue": 0
+                },
+                "fillId": {
+                    "error": {
+                        "code": 6100,
+                        "message": "Attribute is missing"
+                    }
+                },
+                "transparency": 0,
+                "shine": 0,
+                "texture": {
+                    "name": "New Texture 2"
+                }
+            }
+        },
+        {
+            "surfaceAttribute": {
+                "attributeId": {
+                    "guid": "<GUID>"
+                },
+                "name": "New Surface 3",
+                "materialType": "General",
+                "ambientReflection": 77,
+                "diffuseReflection": 73,
+                "specularReflection": 0,
+                "transparencyAttenuation": 0,
+                "emissionAttenuation": 0,
+                "surfaceColor": {
+                    "red": 0.337254902,
+                    "green": 0.662729839,
+                    "blue": 0.180392157
+                },
+                "specularColor": {
+                    "red": 1,
+                    "green": 1,
+                    "blue": 1
+                },
+                "emissionColor": {
+                    "red": 0,
+                    "green": 0,
+                    "blue": 0
+                },
+                "fillId": {
+                    "error": {
+                        "code": 6100,
+                        "message": "Attribute is missing"
+                    }
+                },
+                "transparency": 0,
+                "shine": 0,
+                "texture": {
+                    "name": "New Texture 3"
+                }
+            }
+        },
+        {
+            "surfaceAttribute": {
+                "attributeId": {
+                    "guid": "<GUID>"
+                },
+                "name": "New Surface 4",
+                "materialType": "General",
+                "ambientReflection": 77,
+                "diffuseReflection": 73,
+                "specularReflection": 0,
+                "transparencyAttenuation": 0,
+                "emissionAttenuation": 0,
+                "surfaceColor": {
+                    "red": 0.337254902,
+                    "green": 0.662729839,
+                    "blue": 0.180392157
+                },
+                "specularColor": {
+                    "red": 1,
+                    "green": 1,
+                    "blue": 1
+                },
+                "emissionColor": {
+                    "red": 0,
+                    "green": 0,
+                    "blue": 0
+                },
+                "fillId": {
+                    "error": {
+                        "code": 6100,
+                        "message": "Attribute is missing"
+                    }
+                },
+                "transparency": 0,
+                "shine": 0,
+                "texture": {
+                    "name": "New Texture 4"
+                }
+            }
+        },
+        {
+            "surfaceAttribute": {
+                "attributeId": {
+                    "guid": "<GUID>"
+                },
+                "name": "New Surface 5",
+                "materialType": "General",
+                "ambientReflection": 77,
+                "diffuseReflection": 73,
+                "specularReflection": 0,
+                "transparencyAttenuation": 0,
+                "emissionAttenuation": 0,
+                "surfaceColor": {
+                    "red": 0.337254902,
+                    "green": 0.662729839,
+                    "blue": 0.180392157
+                },
+                "specularColor": {
+                    "red": 1,
+                    "green": 1,
+                    "blue": 1
+                },
+                "emissionColor": {
+                    "red": 0,
+                    "green": 0,
+                    "blue": 0
+                },
+                "fillId": {
+                    "error": {
+                        "code": 6100,
+                        "message": "Attribute is missing"
+                    }
+                },
+                "transparency": 0,
+                "shine": 0,
+                "texture": {
+                    "name": "New Texture 5"
+                }
+            }
+        },
+        {
+            "surfaceAttribute": {
+                "attributeId": {
+                    "guid": "<GUID>"
+                },
+                "name": "New Surface 6",
+                "materialType": "General",
+                "ambientReflection": 77,
+                "diffuseReflection": 73,
+                "specularReflection": 0,
+                "transparencyAttenuation": 0,
+                "emissionAttenuation": 0,
+                "surfaceColor": {
+                    "red": 0.337254902,
+                    "green": 0.662729839,
+                    "blue": 0.180392157
+                },
+                "specularColor": {
+                    "red": 1,
+                    "green": 1,
+                    "blue": 1
+                },
+                "emissionColor": {
+                    "red": 0,
+                    "green": 0,
+                    "blue": 0
+                },
+                "fillId": {
+                    "error": {
+                        "code": 6100,
+                        "message": "Attribute is missing"
+                    }
+                },
+                "transparency": 0,
+                "shine": 0,
+                "texture": {
+                    "name": "New Texture 6"
+                }
+            }
+        },
+        {
+            "surfaceAttribute": {
+                "attributeId": {
+                    "guid": "<GUID>"
+                },
+                "name": "New Surface 7",
+                "materialType": "General",
+                "ambientReflection": 77,
+                "diffuseReflection": 73,
+                "specularReflection": 0,
+                "transparencyAttenuation": 0,
+                "emissionAttenuation": 0,
+                "surfaceColor": {
+                    "red": 0.337254902,
+                    "green": 0.662729839,
+                    "blue": 0.180392157
+                },
+                "specularColor": {
+                    "red": 1,
+                    "green": 1,
+                    "blue": 1
+                },
+                "emissionColor": {
+                    "red": 0,
+                    "green": 0,
+                    "blue": 0
+                },
+                "fillId": {
+                    "error": {
+                        "code": 6100,
+                        "message": "Attribute is missing"
+                    }
+                },
+                "transparency": 0,
+                "shine": 0,
+                "texture": {
+                    "name": "New Texture 7"
+                }
+            }
+        },
+        {
+            "surfaceAttribute": {
+                "attributeId": {
+                    "guid": "<GUID>"
+                },
+                "name": "New Surface 8",
+                "materialType": "General",
+                "ambientReflection": 77,
+                "diffuseReflection": 73,
+                "specularReflection": 0,
+                "transparencyAttenuation": 0,
+                "emissionAttenuation": 0,
+                "surfaceColor": {
+                    "red": 0.337254902,
+                    "green": 0.662729839,
+                    "blue": 0.180392157
+                },
+                "specularColor": {
+                    "red": 1,
+                    "green": 1,
+                    "blue": 1
+                },
+                "emissionColor": {
+                    "red": 0,
+                    "green": 0,
+                    "blue": 0
+                },
+                "fillId": {
+                    "error": {
+                        "code": 6100,
+                        "message": "Attribute is missing"
+                    }
+                },
+                "transparency": 0,
+                "shine": 0,
+                "texture": {
+                    "name": "New Texture 8"
+                }
+            }
+        },
+        {
+            "surfaceAttribute": {
+                "attributeId": {
+                    "guid": "<GUID>"
+                },
+                "name": "New Surface 9",
+                "materialType": "General",
+                "ambientReflection": 77,
+                "diffuseReflection": 73,
+                "specularReflection": 0,
+                "transparencyAttenuation": 0,
+                "emissionAttenuation": 0,
+                "surfaceColor": {
+                    "red": 0.337254902,
+                    "green": 0.662729839,
+                    "blue": 0.180392157
+                },
+                "specularColor": {
+                    "red": 1,
+                    "green": 1,
+                    "blue": 1
+                },
+                "emissionColor": {
+                    "red": 0,
+                    "green": 0,
+                    "blue": 0
+                },
+                "fillId": {
+                    "error": {
+                        "code": 6100,
+                        "message": "Attribute is missing"
+                    }
+                },
+                "transparency": 0,
+                "shine": 0,
+                "texture": {
+                    "name": "New Texture 9"
+                }
+            }
+        },
+        {
+            "surfaceAttribute": {
+                "attributeId": {
+                    "guid": "<GUID>"
+                },
+                "name": "New Surface 10",
+                "materialType": "General",
+                "ambientReflection": 77,
+                "diffuseReflection": 73,
+                "specularReflection": 0,
+                "transparencyAttenuation": 0,
+                "emissionAttenuation": 0,
+                "surfaceColor": {
+                    "red": 0.337254902,
+                    "green": 0.662729839,
+                    "blue": 0.180392157
+                },
+                "specularColor": {
+                    "red": 1,
+                    "green": 1,
+                    "blue": 1
+                },
+                "emissionColor": {
+                    "red": 0,
+                    "green": 0,
+                    "blue": 0
+                },
+                "fillId": {
+                    "error": {
+                        "code": 6100,
+                        "message": "Attribute is missing"
+                    }
+                },
+                "transparency": 0,
+                "shine": 0,
+                "texture": {
+                    "name": "New Texture 10"
+                }
+            }
+        }
+    ]
+}

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -2297,6 +2297,110 @@ var gCommands = [{
         ]
     }
             },{
+                "name": "CreateSurfaces",
+                "version": "1.2.2",
+                "description": "Creates Surface attributes based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "surfaceDataArray": {
+                "type": "array",
+                "description" : "Array of data to create new surfaces.",
+                "items": {
+                    "type": "object",
+                    "description": "Data to create a surface.",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name."
+                        },
+                        "materialType": {
+                            "$ref": "#/SurfaceType"
+                        },
+                        "ambientReflection": {
+                            "type": "number",
+                            "description": "Ambient percentage [0..100]."
+                        },
+                        "diffuseReflection": {
+                            "type": "number",
+                            "description": "Diffuse percentage [0..100]."
+                        },
+                        "specularReflection": {
+                            "type": "number",
+                            "description": "Specular percentage [0..100]."
+                        },
+                        "transparency": {
+                            "type": "number",
+                            "description": "Transparency percentage [0..100]."
+                        },
+                        "shine": {
+                            "type": "number",
+                            "description": "The shininess factor multiplied by 100 [0..10000]."
+                        },
+                        "transparencyAttenuation": {
+                            "type": "number",
+                            "description": "Transparency attenuation multiplied by 100 [0..10000]."
+                        },
+                        "emissionAttenuation": {
+                            "type": "number",
+                            "description": "Emission attenuation multiplied by 100 [0..10000]."
+                        },
+                        "surfaceColor": {
+                            "$ref": "#/ColorRGB"
+                        },
+                        "specularColor": {
+                            "$ref": "#/ColorRGB"
+                        },
+                        "emissionColor": {
+                            "$ref": "#/ColorRGB"
+                        },
+                        "fillId": {
+                            "$ref": "#/AttributeIdArrayItem"
+                        },
+                        "texture": {
+                            "$ref": "#/Texture"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required" : [
+                        "name",
+                        "materialType",
+                        "ambientReflection",
+                        "diffuseReflection",
+                        "specularReflection",
+                        "transparency",
+                        "shine",
+                        "transparencyAttenuation",
+                        "emissionAttenuation",
+                        "surfaceColor",
+                        "specularColor",
+                        "emissionColor"
+                    ]
+                }
+            },
+            "overwriteExisting": {
+                "type": "boolean",
+                "description": "Overwrite the Surface if exists with the same name. The default is false."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "surfaceDataArray"
+        ]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "attributeIds": {
+                "$ref": "#/AttributeIds"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "attributeIds"
+        ]
+    }
+            },{
                 "name": "GetBuildingMaterialPhysicalProperties",
                 "version": "0.1.3",
                 "description": "Retrieves the physical properties of the given Building Materials.",
@@ -2424,6 +2528,53 @@ var gCommands = [{
                 "inputScheme": null,
                 "outputScheme": {
         "$ref": "#/ExecutionResult"
+    }
+            },{
+                "name": "AddFilesToEmbeddedLibrary",
+                "version": "1.2.2",
+                "description": "Adds the given files into the embedded library.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "files": {
+                "type": "array",
+                "description": "A list of files",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "inputPath": {
+                            "type": "string",
+                            "description": "The path to the input file."
+                        },
+                        "outputPath": {
+                            "type": "string",
+                            "description": "The relative path to the new file inside embedded library."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "inputPath",
+                        "outputPath"
+                    ]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "files"
+        ]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "executionResults": {
+                "$ref": "#/ExecutionResults"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executionResults"
+        ]
     }
             }]
         },{

--- a/docs/archicad-addon/common_schema_definitions.js
+++ b/docs/archicad-addon/common_schema_definitions.js
@@ -31,6 +31,20 @@ var gSchemaDefinitions = {
             "guid"
         ]
     },
+    "SurfaceType": {
+        "type": "string",
+        "description": "The type of a surface material.",
+        "enum": [
+            "General",
+            "Simple",
+            "Matte",
+            "Metal",
+            "Plastic",
+            "Glass",
+            "Glowing",
+            "Constant"
+        ]
+    },
     "AttributeType": {
         "type": "string",
         "description": "The type of an attribute.",
@@ -256,6 +270,44 @@ var gSchemaDefinitions = {
             "x",
             "y",
             "z"
+        ]
+    },
+    "ColorRGB": {
+        "type": "object",
+        "description": "RGB color.",
+        "properties": {
+            "red": {
+                "type": "number",
+                "description": "Red value between 0.0 and 1.0"
+            },
+            "green": {
+                "type": "number",
+                "description": "Green value between 0.0 and 1.0"
+            },
+            "blue": {
+                "type": "number",
+                "description": "Blue value between 0.0 and 1.0"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "red",
+            "green",
+            "blue"
+        ]
+    },
+    "Texture": {
+        "type": "object",
+        "description": "Texture parameters",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "The filename of the texture in the library (without extension)."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "name"
         ]
     },
     "Error": {


### PR DESCRIPTION
Implemented AddFilesToEmbeddedLibrary to be able to add new texture image files into the library.

CreateSurfaces command is able to create new surface material attributes. It can set textures to the new surfaces.

So now we can import new textures and create new surfaces using those textures.