### PR TITLE
Fix 3D Bounding Box accuracy for Roofs and Zones by excluding drafting elements

### DIFF
--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -1970,11 +1970,7 @@ static GSErrCode CalculateSolidBodyBounds (const API_Elem_Head& elemHead, API_Bo
     outBounds.xMax = outBounds.yMax = outBounds.zMax = -1e30;
 
     API_ElemInfo3D info3D = {};
-#if defined(ServerMainVers_2700)
     GSErrCode err = ACAPI_ModelAccess_Get3DInfo (elemHead, &info3D);
-#else
-    GSErrCode err = ACAPI_Element_Get3DInfo (elemHead, &info3D);
-#endif
     if (err != NoError) {
         return err;
     }
@@ -1986,11 +1982,7 @@ static GSErrCode CalculateSolidBodyBounds (const API_Elem_Head& elemHead, API_Bo
         bodyComp.header.typeID = API_BodyID;
         bodyComp.header.index = iBody;
 
-#if defined(ServerMainVers_2700)
         if (ACAPI_ModelAccess_GetComponent (&bodyComp) != NoError) continue;
-#else
-        if (ACAPI_3D_GetComponent (&bodyComp) != NoError) continue;
-#endif
 
         if (bodyComp.body.nPgon == 0) { // Skip non-solid bodies
             continue;

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -77,6 +77,10 @@
 #define ACAPI_Notification_GetParentElement ACAPI_Notify_GetParentElement
 #define ACAPI_Notification_CatchElementReservationChange ACAPI_Notify_CatchElementReservationChange
 
+#define ACAPI_ModelAccess_Get3DInfo ACAPI_Element_Get3DInfo
+#define ACAPI_ModelAccess_GetComponent ACAPI_3D_GetComponent
+
+
 inline API_AttributeIndex ACAPI_CreateAttributeIndex (Int32 index)
 {
     return index;


### PR DESCRIPTION
**Problem:**
The standard `ACAPI_Element_CalcBounds` returns the "Model Extent," which includes non-geometric drafting aids. This can result in significantly inflated bounding boxes for **Roofs** (due to pivot lines) and **Zones** (due to 3D text stamps).

**Solution:**
Implemented a new helper, `CalculateSolidBodyBounds`, which filters out wireframe bodies (`nPgon == 0`) and calculates bounds from the solid geometry only. For roofs and zones we use this function instead of  `ACAPI_Element_CalcBounds`.

**Reasoning**
At first I wanted to add a "calculationMethod" enum to the schema, and let the user decide how to calculate bbs to avoid changes to behaviour. After testing the new function it is clear that this simple implementation while working for the real pain points (zones and roofs, even multi-plane) fails for a number of element types. We would need to implement it on a per elemen-type base, so I opted out of this approach.

**Additional thouths**

- API_BodyType stores it's bounds in float, API_Box3D stores it in a double. The conversion causes an accuracy issue. I did not round it in the addon, left it for the script user
- The new method might be good for objects as well, but relies on the correct use of BODY ENDBODY tags, which I did not use correctly in my gdl objects. Needs further testing, left behaviour unchanged.
- ACAPI_Element_CalcBounds behaves wierd on doors / windows. For most doors it only considers the 2d symbol, but for some it considers the 3d as well. Needs further testing. Needs further testing, left behaviour unchanged.

<img width="1916" height="1028" alt="image" src="https://github.com/user-attachments/assets/4cbe565c-9750-420d-81c3-5ac18ae17bf2" />
