### PR TITLE
refactor: remove "Response" from common schema definition names

### DIFF
--- a/archicad-addon/Sources/AttributeCommands.cpp
+++ b/archicad-addon/Sources/AttributeCommands.cpp
@@ -72,7 +72,7 @@ GS::Optional<GS::UniString> GetAttributesByTypeCommand::GetInputParametersSchema
 GS::Optional<GS::UniString> GetAttributesByTypeCommand::GetResponseSchema () const
 {
     return R"({
-        "$ref": "#/GetAttributesByTypeResponseOrError"
+        "$ref": "#/AttributeHeadersOrError"
     })";
 }
 

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -123,7 +123,7 @@ GS::Optional<GS::UniString> GetElementsByTypeCommand::GetInputParametersSchema (
 GS::Optional<GS::UniString> GetElementsByTypeCommand::GetResponseSchema () const
 {
     return R"({
-        "$ref": "#/GetElementsByTypeResponseOrError"
+        "$ref": "#/ElementsWithExecutionResultsOrError"
     })";
 }
 
@@ -1259,7 +1259,7 @@ GS::Optional<GS::UniString> GetConnectedElementsCommand::GetInputParametersSchem
 GS::Optional<GS::UniString> GetConnectedElementsCommand::GetResponseSchema () const
 {
     return R"({
-        "$ref": "#/GetConnectedElementsResponseOrError"
+        "$ref": "#/ConnectedElementsOrError"
     })";
 }
 
@@ -1334,7 +1334,7 @@ GS::Optional<GS::UniString> GetZoneBoundariesCommand::GetInputParametersSchema (
 GS::Optional<GS::UniString> GetZoneBoundariesCommand::GetResponseSchema () const
 {
     return R"({
-        "$ref": "#/ZoneBoundariesResponseOrError"
+        "$ref": "#/ZoneBoundariesOrError"
     })";
 }
 

--- a/archicad-addon/Sources/FavoritesCommands.cpp
+++ b/archicad-addon/Sources/FavoritesCommands.cpp
@@ -33,7 +33,7 @@ GS::Optional<GS::UniString> GetFavoritesByTypeCommand::GetInputParametersSchema 
 GS::Optional<GS::UniString> GetFavoritesByTypeCommand::GetResponseSchema () const
 {
     return R"({
-        "$ref": "#/GetFavoritesByTypeResponseOrError"
+        "$ref": "#/FavoritesOrError"
     })";
 }
 

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -3503,7 +3503,7 @@
             "description": "The name of a favorite."
         }
     },
-    "ZoneBoundariesResponse": {
+    "ZoneBoundariesWrapper": {
         "type": "object",
         "properties": {
             "zoneBoundaries": {
@@ -3551,12 +3551,12 @@
             "zoneBoundaries"
         ]
     },
-    "ZoneBoundariesResponseOrError": {
+    "ZoneBoundariesOrError": {
         "type": "object",
         "description": "The response of the zone boundaries command or an error.",
         "oneOf": [
             {
-                "$ref": "#/ZoneBoundariesResponse"
+                "$ref": "#/ZoneBoundariesWrapper"
             },
             {
                 "$ref": "#/ErrorItem"
@@ -3694,7 +3694,7 @@
             "OpeningSymbol"
         ]
     },
-    "GetElementsByTypeResponse": {
+    "ElementsWithExecutionResults": {
         "type": "object",
         "description": "The response of the GetElementsByType command.",
         "properties": {
@@ -3710,19 +3710,19 @@
             "elements"
         ]
     },
-    "GetElementsByTypeResponseOrError": {
+    "ElementsWithExecutionResultsOrError": {
         "type": "object",
         "description": "The response of the GetElementsByType command or an error.",
         "oneOf": [
             {
-                "$ref": "#/GetElementsByTypeResponse"
+                "$ref": "#/ElementsWithExecutionResults"
             },
             {
                 "$ref": "#/ErrorItem"
             }
         ]
     },
-    "GetFavoritesByTypeResponse": {
+    "FavoritesWrapper": {
         "type": "object",
         "description": "The response of the GetFavoritesByType command.",
         "properties": {
@@ -3735,19 +3735,19 @@
             "favorites"
         ]
     },
-    "GetFavoritesByTypeResponseOrError": {
+    "FavoritesOrError": {
         "type": "object",
         "description": "The response of the GetFavoritesByType command or an error.",
         "oneOf": [
             {
-                "$ref": "#/GetFavoritesByTypeResponse"
+                "$ref": "#/FavoritesWrapper"
             },
             {
                 "$ref": "#/ErrorItem"
             }
         ]
     },
-    "GetConnectedElementsResponse": {
+    "ConnectedElementsWrapper": {
         "type": "object",
         "description": "The response of the GetConnectedElements command.",
         "properties": {
@@ -3772,47 +3772,51 @@
             "connectedElements"
         ]
     },
-    "GetConnectedElementsResponseOrError": {
+    "ConnectedElementsOrError": {
         "type": "object",
         "description": "The response of the GetConnectedElements command or an error.",
         "oneOf": [
             {
-                "$ref": "#/GetConnectedElementsResponse"
+                "$ref": "#/ConnectedElementsWrapper"
             },
             {
                 "$ref": "#/ErrorItem"
             }
         ]
     },
-    "GetAttributesByTypeResponse": {
+    "AttributeHeaders": {
+        "type": "array",
+        "description": "Details of attributes.",
+        "items": {
+            "type": "object",
+            "properties": {
+                "attributeId": {
+                    "$ref": "#/AttributeId"
+                },
+                "index": {
+                    "type": "number",
+                    "description": "Index of the attribute."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the attribute."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "attributeId",
+                "index",
+                "name"
+            ]
+
+        }
+    },
+    "AttributeHeadersWrapper": {
         "type": "object",
         "description": "The response of the GetAttributesByType command.",
         "properties": {
             "attributes": {
-                "type": "array",
-                "description": "Details of attributes.",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "attributeId": {
-                            "$ref": "#/AttributeId"
-                        },
-                        "index": {
-                            "type": "number",
-                            "description": "Index of the attribute."
-                        },
-                        "name": {
-                            "type": "string",
-                            "description": "Name of the attribute."
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "attributeId",
-                        "index",
-                        "name"
-                    ]
-                }
+                "$ref": "#/AttributeHeaders"
             }
         },
         "additionalProperties": false,
@@ -3820,12 +3824,12 @@
             "attributes"
         ]
     },
-    "GetAttributesByTypeResponseOrError": {
+    "AttributeHeadersOrError": {
         "type": "object",
         "description": "The response of the GetAttributesByType command or an error.",
         "oneOf": [
             {
-                "$ref": "#/GetAttributesByTypeResponse"
+                "$ref": "#/AttributeHeadersWrapper"
             },
             {
                 "$ref": "#/ErrorItem"

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -549,7 +549,7 @@ var gCommands = [{
         ]
     },
                 "outputScheme": {
-        "$ref": "#/GetElementsByTypeResponseOrError"
+        "$ref": "#/ElementsWithExecutionResultsOrError"
     }
             },{
                 "name": "GetAllElements",
@@ -573,7 +573,7 @@ var gCommands = [{
         "required": []
     },
                 "outputScheme": {
-        "$ref": "#/GetElementsByTypeResponseOrError"
+        "$ref": "#/ElementsWithExecutionResultsOrError"
     }
             },{
                 "name": "ChangeSelectionOfElements",
@@ -933,7 +933,7 @@ var gCommands = [{
         ]
     },
                 "outputScheme": {
-        "$ref": "#/GetConnectedElementsResponseOrError"
+        "$ref": "#/ConnectedElementsOrError"
     }
             },{
                 "name": "GetZoneBoundaries",
@@ -952,7 +952,7 @@ var gCommands = [{
         ]
     },
                 "outputScheme": {
-        "$ref": "#/ZoneBoundariesResponseOrError"
+        "$ref": "#/ZoneBoundariesOrError"
     }
             },{
                 "name": "GetCollisions",
@@ -1929,7 +1929,7 @@ var gCommands = [{
         ]
     },
                 "outputScheme": {
-        "$ref": "#/GetFavoritesByTypeResponseOrError"
+        "$ref": "#/FavoritesOrError"
     }
             },{
                 "name": "GetFavoritePreviewImage",
@@ -2350,7 +2350,7 @@ var gCommands = [{
         ]
     },
                 "outputScheme": {
-        "$ref": "#/GetAttributesByTypeResponseOrError"
+        "$ref": "#/AttributeHeadersOrError"
     }
             },{
                 "name": "CreateLayers",

--- a/docs/archicad-addon/common_schema_definitions.js
+++ b/docs/archicad-addon/common_schema_definitions.js
@@ -3503,7 +3503,7 @@ var gSchemaDefinitions = {
             "description": "The name of a favorite."
         }
     },
-    "ZoneBoundariesResponse": {
+    "ZoneBoundariesWrapper": {
         "type": "object",
         "properties": {
             "zoneBoundaries": {
@@ -3551,12 +3551,12 @@ var gSchemaDefinitions = {
             "zoneBoundaries"
         ]
     },
-    "ZoneBoundariesResponseOrError": {
+    "ZoneBoundariesOrError": {
         "type": "object",
         "description": "The response of the zone boundaries command or an error.",
         "oneOf": [
             {
-                "$ref": "#/ZoneBoundariesResponse"
+                "$ref": "#/ZoneBoundariesWrapper"
             },
             {
                 "$ref": "#/ErrorItem"
@@ -3694,7 +3694,7 @@ var gSchemaDefinitions = {
             "OpeningSymbol"
         ]
     },
-    "GetElementsByTypeResponse": {
+    "ElementsWithExecutionResults": {
         "type": "object",
         "description": "The response of the GetElementsByType command.",
         "properties": {
@@ -3710,19 +3710,19 @@ var gSchemaDefinitions = {
             "elements"
         ]
     },
-    "GetElementsByTypeResponseOrError": {
+    "ElementsWithExecutionResultsOrError": {
         "type": "object",
         "description": "The response of the GetElementsByType command or an error.",
         "oneOf": [
             {
-                "$ref": "#/GetElementsByTypeResponse"
+                "$ref": "#/ElementsWithExecutionResults"
             },
             {
                 "$ref": "#/ErrorItem"
             }
         ]
     },
-    "GetFavoritesByTypeResponse": {
+    "FavoritesWrapper": {
         "type": "object",
         "description": "The response of the GetFavoritesByType command.",
         "properties": {
@@ -3735,19 +3735,19 @@ var gSchemaDefinitions = {
             "favorites"
         ]
     },
-    "GetFavoritesByTypeResponseOrError": {
+    "FavoritesOrError": {
         "type": "object",
         "description": "The response of the GetFavoritesByType command or an error.",
         "oneOf": [
             {
-                "$ref": "#/GetFavoritesByTypeResponse"
+                "$ref": "#/FavoritesWrapper"
             },
             {
                 "$ref": "#/ErrorItem"
             }
         ]
     },
-    "GetConnectedElementsResponse": {
+    "ConnectedElementsWrapper": {
         "type": "object",
         "description": "The response of the GetConnectedElements command.",
         "properties": {
@@ -3772,47 +3772,51 @@ var gSchemaDefinitions = {
             "connectedElements"
         ]
     },
-    "GetConnectedElementsResponseOrError": {
+    "ConnectedElementsOrError": {
         "type": "object",
         "description": "The response of the GetConnectedElements command or an error.",
         "oneOf": [
             {
-                "$ref": "#/GetConnectedElementsResponse"
+                "$ref": "#/ConnectedElementsWrapper"
             },
             {
                 "$ref": "#/ErrorItem"
             }
         ]
     },
-    "GetAttributesByTypeResponse": {
+    "AttributeHeaders": {
+        "type": "array",
+        "description": "Details of attributes.",
+        "items": {
+            "type": "object",
+            "properties": {
+                "attributeId": {
+                    "$ref": "#/AttributeId"
+                },
+                "index": {
+                    "type": "number",
+                    "description": "Index of the attribute."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the attribute."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "attributeId",
+                "index",
+                "name"
+            ]
+
+        }
+    },
+    "AttributeHeadersWrapper": {
         "type": "object",
         "description": "The response of the GetAttributesByType command.",
         "properties": {
             "attributes": {
-                "type": "array",
-                "description": "Details of attributes.",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "attributeId": {
-                            "$ref": "#/AttributeId"
-                        },
-                        "index": {
-                            "type": "number",
-                            "description": "Index of the attribute."
-                        },
-                        "name": {
-                            "type": "string",
-                            "description": "Name of the attribute."
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "attributeId",
-                        "index",
-                        "name"
-                    ]
-                }
+                "$ref": "#/AttributeHeaders"
             }
         },
         "additionalProperties": false,
@@ -3820,12 +3824,12 @@ var gSchemaDefinitions = {
             "attributes"
         ]
     },
-    "GetAttributesByTypeResponseOrError": {
+    "AttributeHeadersOrError": {
         "type": "object",
         "description": "The response of the GetAttributesByType command or an error.",
         "oneOf": [
             {
-                "$ref": "#/GetAttributesByTypeResponse"
+                "$ref": "#/AttributeHeadersWrapper"
             },
             {
                 "$ref": "#/ErrorItem"


### PR DESCRIPTION
In a recent PR several obejcts have been moved to the CommonSchemaDefinitions with CommandNameResponseOrError or CommandNameResponse names, and some of those are reused for other commands than CommandName. In my oppinion the "CommandNameResponse" object name should be reserved for the top lvl response, and only when it is unique to the command.

The PR does not change the behaviour of the addon, no breaking changes.

*   Removed the "Response" suffix from all internal data models.
*   Named attribute identification objects `AttributeHeader` instead of `Details`.
*   Renamed shared list objects to describe their content (e.g., `ElementsWithResults`) rather than the command that fetched them.