### PR TITLE
Add document creation commands and navigator enhancements (v1.4)

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -30,6 +30,7 @@
 #include "FavoritesCommands.hpp"
 #include "MigrationHelper.hpp"
 #include "NavigatorCommands.hpp"
+#include "DocumentCreationCommands.hpp"
 #include "RevisionCommands.hpp"
 #include "NotificationCommands.hpp"
 #include "DesignOptionCommands.hpp"
@@ -487,6 +488,26 @@ GSErrCode Initialize (void)
         err |= RegisterCommand<GetDatabaseIdFromNavigatorItemIdCommand> (
             navigatorCommands, "1.1.4",
             "Gets the ID of the database associated with the supplied navigator item id"
+        );
+        err |= RegisterCommand<CreateDetailsCommand> (
+            navigatorCommands, "1.4.0",
+            "Creates independent Detail databases."
+        );
+        err |= RegisterCommand<CreateWorksheetsCommand> (
+            navigatorCommands, "1.4.0",
+            "Creates independent Worksheet databases."
+        );
+        err |= RegisterCommand<CreateLayoutsCommand> (
+            navigatorCommands, "1.4.0",
+            "Creates Layouts and their backing master layouts."
+        );
+        err |= RegisterCommand<CreateSubsetsCommand> (
+            navigatorCommands, "1.4.0",
+            "Creates Layout Book subsets."
+        );
+        err |= RegisterCommand<CreateDrawingsCommand> (
+            navigatorCommands, "1.4.0",
+            "Creates Drawing elements on the specified or active layout from navigator items."
         );
         err |= RegisterCommand<GetModelViewOptionsCommand> (
             navigatorCommands, "1.1.4",

--- a/archicad-addon/Sources/ApplicationCommands.cpp
+++ b/archicad-addon/Sources/ApplicationCommands.cpp
@@ -253,6 +253,9 @@ GS::Optional<GS::UniString> ChangeWindowCommand::GetInputParametersSchema () con
         "properties": {
             "windowType": {
                 "$ref": "#/WindowType"
+            },
+            "databaseId": {
+                "$ref": "#/DatabaseId"
             }
         },
         "additionalProperties": false,
@@ -278,6 +281,30 @@ GS::ObjectState ChangeWindowCommand::Execute (const GS::ObjectState& parameters,
 
     API_WindowInfo windowInfo = {};
     windowInfo.typeID = ConvertWindowTypeToString (windowTypeStr);
+    if (windowInfo.typeID == API_ZombieWindowID) {
+        return CreateFailedExecutionResult (APIERR_BADPARS, "Invalid parameter: windowType.");
+    }
+
+    const GS::ObjectState* databaseId = parameters.Get ("databaseId");
+    if (databaseId != nullptr) {
+        API_DatabaseInfo targetDatabase = DatabaseIdResolver::Instance ().GetDatabaseWithId (GetGuidFromObjectState (*databaseId));
+        GSErrCode err = ACAPI_Window_GetDatabaseInfo (&targetDatabase);
+        if (err != NoError) {
+            return CreateErrorResponse (err, "Failed to resolve target database.");
+        }
+
+        if (targetDatabase.typeID != windowInfo.typeID) {
+            return CreateFailedExecutionResult (APIERR_BADPARS, "databaseId does not belong to the requested windowType.");
+        }
+
+        err = ACAPI_Database_ChangeCurrentDatabase (&targetDatabase);
+        if (err != NoError) {
+            return CreateErrorResponse (err, "Failed to change current database.");
+        }
+
+        windowInfo = targetDatabase;
+    }
+
     GSErrCode err = ACAPI_Window_ChangeWindow (&windowInfo);
     return err == NoError
         ? CreateSuccessfulExecutionResult ()

--- a/archicad-addon/Sources/DocumentCreationCommands.cpp
+++ b/archicad-addon/Sources/DocumentCreationCommands.cpp
@@ -1,0 +1,552 @@
+#include "DocumentCreationCommands.hpp"
+
+#include "MigrationHelper.hpp"
+
+namespace {
+
+GS::ObjectState CreateDatabasesResponse (const GS::Array<GS::ObjectState>& databases)
+{
+    GS::ObjectState response;
+    const auto& databasesList = response.AddList<GS::ObjectState> ("databases");
+    for (const auto& database : databases) {
+        databasesList (database);
+    }
+    return response;
+}
+
+GS::ObjectState CreateExecutionResultsResponse (const GS::Array<GS::ObjectState>& executionResults)
+{
+    GS::ObjectState response;
+    const auto& results = response.AddList<GS::ObjectState> ("executionResults");
+    for (const auto& result : executionResults) {
+        results (result);
+    }
+    return response;
+}
+
+bool GetItems (const GS::ObjectState& parameters, const char* fieldName, GS::Array<GS::ObjectState>& outItems, GS::ObjectState& errorResponse)
+{
+    if (!parameters.Get (fieldName, outItems)) {
+        errorResponse = CreateErrorResponse (APIERR_BADPARS, GS::UniString::Printf ("Missing required array field '%s'.", fieldName));
+        return false;
+    }
+    return true;
+}
+
+GS::Array<API_Guid> GetLayoutDatabaseGuids ()
+{
+    GS::Array<API_Guid> guids;
+    API_DatabaseUnId* dbases = nullptr;
+    if (ACAPI_Database_GetLayoutDatabases (&dbases) == NoError && dbases != nullptr) {
+        const GSSize nDbases = BMpGetSize (reinterpret_cast<GSPtr> (dbases)) / Sizeof32 (API_DatabaseUnId);
+        for (GSSize i = 0; i < nDbases; ++i) {
+            API_DatabaseInfo info = {};
+            info.typeID = APIWind_LayoutID;
+            info.databaseUnId = dbases[i];
+            guids.Push (DatabaseIdResolver::Instance ().GetIdOfDatabase (info));
+        }
+    }
+    BMpKill (reinterpret_cast<GSPtr*> (&dbases));
+    return guids;
+}
+
+GS::Optional<API_Guid> FindNewLayoutDatabaseGuid (const GS::Array<API_Guid>& before)
+{
+    const GS::Array<API_Guid> after = GetLayoutDatabaseGuids ();
+    for (const auto& guid : after) {
+        if (!before.Contains (guid)) {
+            return guid;
+        }
+    }
+    return {};
+}
+
+GS::Optional<API_DatabaseInfo> FindMasterLayoutDatabaseByName (const GS::UniString& masterLayoutName)
+{
+    API_DatabaseUnId* dbases = nullptr;
+    GS::Optional<API_DatabaseInfo> foundMasterLayout;
+
+    if (ACAPI_Database_GetMasterLayoutDatabases (&dbases) == NoError && dbases != nullptr) {
+        const GSSize nDbases = BMpGetSize (reinterpret_cast<GSPtr> (dbases)) / Sizeof32 (API_DatabaseUnId);
+        for (GSSize i = 0; i < nDbases; ++i) {
+            API_DatabaseInfo candidate = {};
+            candidate.typeID = APIWind_MasterLayoutID;
+            candidate.databaseUnId = dbases[i];
+
+            if (ACAPI_Window_GetDatabaseInfo (&candidate) == NoError && GS::UniString (candidate.name) == masterLayoutName) {
+                foundMasterLayout = candidate;
+                break;
+            }
+        }
+    }
+
+    BMpKill (reinterpret_cast<GSPtr*> (&dbases));
+    return foundMasterLayout;
+}
+
+GS::Optional<API_Guid> FindLayoutDatabaseGuidByName (const GS::UniString& layoutName)
+{
+    API_DatabaseUnId* dbases = nullptr;
+    GS::Optional<API_Guid> foundLayoutGuid;
+
+    if (ACAPI_Database_GetLayoutDatabases (&dbases) == NoError && dbases != nullptr) {
+        const GSSize nDbases = BMpGetSize (reinterpret_cast<GSPtr> (dbases)) / Sizeof32 (API_DatabaseUnId);
+        for (GSSize i = 0; i < nDbases; ++i) {
+            API_DatabaseInfo candidate = {};
+            candidate.typeID = APIWind_LayoutID;
+            candidate.databaseUnId = dbases[i];
+
+            if (ACAPI_Window_GetDatabaseInfo (&candidate) == NoError && GS::UniString (candidate.name) == layoutName) {
+                foundLayoutGuid = DatabaseIdResolver::Instance ().GetIdOfDatabase (candidate);
+                break;
+            }
+        }
+    }
+
+    BMpKill (reinterpret_cast<GSPtr*> (&dbases));
+    return foundLayoutGuid;
+}
+
+bool GetLayoutInfoForDatabase (const API_DatabaseUnId& databaseUnId, API_LayoutInfo& layoutInfo)
+{
+    BNZeroMemory (&layoutInfo, sizeof (layoutInfo));
+    return ACAPI_Navigator_GetLayoutSets (&layoutInfo, const_cast<API_DatabaseUnId*> (&databaseUnId), nullptr) == NoError;
+}
+
+}
+
+CreateDetailsCommand::CreateDetailsCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String CreateDetailsCommand::GetName () const
+{
+    return "CreateDetails";
+}
+
+GS::Optional<GS::UniString> CreateDetailsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "detailsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string", "minLength": 1 },
+                        "referenceId": { "type": "string", "minLength": 1 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["name", "referenceId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["detailsData"]
+    })";
+}
+
+GS::Optional<GS::UniString> CreateDetailsCommand::GetResponseSchema () const
+{
+    return R"({"type":"object","properties":{"databases":{"$ref":"#/Databases"}},"additionalProperties":false,"required":["databases"]})";
+}
+
+GS::ObjectState CreateDetailsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
+{
+    GS::Array<GS::ObjectState> items;
+    GS::ObjectState errorResponse;
+    if (!GetItems (parameters, "detailsData", items, errorResponse)) {
+        return errorResponse;
+    }
+
+    GS::Array<GS::ObjectState> databases;
+    for (const auto& item : items) {
+        API_DatabaseInfo dbInfo = {};
+        dbInfo.typeID = APIWind_DetailID;
+        SetUCharProperty (&item, "name", dbInfo.name);
+        SetUCharProperty (&item, "referenceId", dbInfo.ref);
+
+        const GSErrCode err = ACAPI_Database_NewDatabase (&dbInfo);
+        if (err != NoError) {
+            databases.Push (CreateErrorResponse (err, "Failed to create detail database."));
+            continue;
+        }
+
+        databases.Push (CreateDatabaseIdObjectState (DatabaseIdResolver::Instance ().GetIdOfDatabase (dbInfo)));
+    }
+    return CreateDatabasesResponse (databases);
+}
+
+CreateWorksheetsCommand::CreateWorksheetsCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String CreateWorksheetsCommand::GetName () const
+{
+    return "CreateWorksheets";
+}
+
+GS::Optional<GS::UniString> CreateWorksheetsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "worksheetsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string", "minLength": 1 },
+                        "referenceId": { "type": "string", "minLength": 1 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["name", "referenceId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["worksheetsData"]
+    })";
+}
+
+GS::Optional<GS::UniString> CreateWorksheetsCommand::GetResponseSchema () const
+{
+    return CreateDetailsCommand ().GetResponseSchema ();
+}
+
+GS::ObjectState CreateWorksheetsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
+{
+    GS::Array<GS::ObjectState> items;
+    GS::ObjectState errorResponse;
+    if (!GetItems (parameters, "worksheetsData", items, errorResponse)) {
+        return errorResponse;
+    }
+
+    GS::Array<GS::ObjectState> databases;
+    for (const auto& item : items) {
+        API_DatabaseInfo dbInfo = {};
+        dbInfo.typeID = APIWind_WorksheetID;
+        SetUCharProperty (&item, "name", dbInfo.name);
+        SetUCharProperty (&item, "referenceId", dbInfo.ref);
+
+        const GSErrCode err = ACAPI_Database_NewDatabase (&dbInfo);
+        if (err != NoError) {
+            databases.Push (CreateErrorResponse (err, "Failed to create worksheet database."));
+            continue;
+        }
+
+        databases.Push (CreateDatabaseIdObjectState (DatabaseIdResolver::Instance ().GetIdOfDatabase (dbInfo)));
+    }
+    return CreateDatabasesResponse (databases);
+}
+
+CreateLayoutsCommand::CreateLayoutsCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String CreateLayoutsCommand::GetName () const
+{
+    return "CreateLayouts";
+}
+
+GS::Optional<GS::UniString> CreateLayoutsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "layoutsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "masterLayoutName": { "type": "string", "minLength": 1 },
+                        "layoutName": { "type": "string", "minLength": 1 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["masterLayoutName", "layoutName"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["layoutsData"]
+    })";
+}
+
+GS::Optional<GS::UniString> CreateLayoutsCommand::GetResponseSchema () const
+{
+    return CreateDetailsCommand ().GetResponseSchema ();
+}
+
+GS::ObjectState CreateLayoutsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
+{
+    GS::Array<GS::ObjectState> items;
+    GS::ObjectState errorResponse;
+    if (!GetItems (parameters, "layoutsData", items, errorResponse)) {
+        return errorResponse;
+    }
+
+    GS::Array<GS::ObjectState> databases;
+    for (const auto& item : items) {
+        GS::UniString masterLayoutName;
+        item.Get ("masterLayoutName", masterLayoutName);
+
+        API_DatabaseInfo masterLayoutDbInfo = {};
+        if (const auto existingMasterLayout = FindMasterLayoutDatabaseByName (masterLayoutName); existingMasterLayout.HasValue ()) {
+            masterLayoutDbInfo = existingMasterLayout.Get ();
+        } else {
+            masterLayoutDbInfo.typeID = APIWind_MasterLayoutID;
+            SetUCharProperty (&item, "masterLayoutName", masterLayoutDbInfo.name);
+
+            const GSErrCode createMasterErr = ACAPI_Database_NewDatabase (&masterLayoutDbInfo);
+            if (createMasterErr != NoError) {
+                databases.Push (CreateErrorResponse (createMasterErr, "Failed to create master layout."));
+                continue;
+            }
+        }
+
+        API_LayoutInfo layoutInfo = {};
+        SetUCharProperty (&item, "layoutName", layoutInfo.layoutName);
+
+        API_LayoutInfo masterLayoutInfo = {};
+        if (GetLayoutInfoForDatabase (masterLayoutDbInfo.databaseUnId, masterLayoutInfo)) {
+            layoutInfo.sizeX = masterLayoutInfo.sizeX;
+            layoutInfo.sizeY = masterLayoutInfo.sizeY;
+            layoutInfo.leftMargin = masterLayoutInfo.leftMargin;
+            layoutInfo.topMargin = masterLayoutInfo.topMargin;
+            layoutInfo.rightMargin = masterLayoutInfo.rightMargin;
+            layoutInfo.bottomMargin = masterLayoutInfo.bottomMargin;
+            layoutInfo.showMasterBelow = masterLayoutInfo.showMasterBelow;
+        }
+
+        const GS::Array<API_Guid> before = GetLayoutDatabaseGuids ();
+        GSErrCode err = ACAPI_Navigator_CreateLayout (&layoutInfo, &masterLayoutDbInfo.databaseUnId);
+        if (err != NoError) {
+            databases.Push (CreateErrorResponse (err, "Failed to create layout."));
+            continue;
+        }
+
+        const auto newLayoutGuid = FindNewLayoutDatabaseGuid (before);
+        if (newLayoutGuid.HasValue ()) {
+            databases.Push (CreateDatabaseIdObjectState (newLayoutGuid.Get ()));
+        } else if (const auto layoutGuid = FindLayoutDatabaseGuidByName (GS::UniString (layoutInfo.layoutName)); layoutGuid.HasValue ()) {
+            databases.Push (CreateDatabaseIdObjectState (layoutGuid.Get ()));
+        } else {
+            databases.Push (CreateErrorResponse (APIERR_GENERAL, "Layout created but could not resolve its database id."));
+        }
+    }
+
+    return CreateDatabasesResponse (databases);
+}
+
+CreateSubsetsCommand::CreateSubsetsCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String CreateSubsetsCommand::GetName () const
+{
+    return "CreateSubsets";
+}
+
+GS::Optional<GS::UniString> CreateSubsetsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "subsetsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string", "minLength": 1 },
+                        "parentNavigatorItemId": { "$ref": "#/NavigatorItemId" },
+                        "ownPrefix": { "type": "string" },
+                        "customNumber": { "type": "string" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["name"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["subsetsData"]
+    })";
+}
+
+GS::Optional<GS::UniString> CreateSubsetsCommand::GetResponseSchema () const
+{
+    return R"({"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]})";
+}
+
+GS::ObjectState CreateSubsetsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
+{
+    GS::Array<GS::ObjectState> items;
+    GS::ObjectState errorResponse;
+    if (!GetItems (parameters, "subsetsData", items, errorResponse)) {
+        return errorResponse;
+    }
+
+    GS::Array<GS::ObjectState> executionResults;
+    for (const auto& item : items) {
+        API_SubSet subSet = {};
+        GSErrCode err = ACAPI_Navigator_GetSubSetDefault (&subSet);
+        if (err != NoError) {
+            executionResults.Push (CreateFailedExecutionResult (err, "Failed to get subset defaults."));
+            continue;
+        }
+
+        SetUCharProperty (&item, "name", subSet.name);
+        if (item.Contains ("ownPrefix")) {
+            subSet.addOwnPrefix = true;
+            SetUCharProperty (&item, "ownPrefix", subSet.ownPrefix);
+        }
+        if (item.Contains ("customNumber")) {
+            subSet.customNumbering = true;
+            SetUCharProperty (&item, "customNumber", subSet.customNumber);
+        }
+
+        const GS::ObjectState* parent = item.Get ("parentNavigatorItemId");
+        const API_Guid* parentGuidPtr = nullptr;
+        API_Guid parentGuid = APINULLGuid;
+        if (parent != nullptr) {
+            parentGuid = GetGuidFromObjectState (*parent);
+            parentGuidPtr = &parentGuid;
+        }
+
+        err = ACAPI_Navigator_CreateSubSet (&subSet, parentGuidPtr);
+        executionResults.Push (err == NoError ? CreateSuccessfulExecutionResult () : CreateFailedExecutionResult (err, "Failed to create subset."));
+    }
+    return CreateExecutionResultsResponse (executionResults);
+}
+
+CreateDrawingsCommand::CreateDrawingsCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String CreateDrawingsCommand::GetName () const
+{
+    return "CreateDrawings";
+}
+
+GS::Optional<GS::UniString> CreateDrawingsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "drawingsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "navigatorItemId": { "$ref": "#/NavigatorItemId" },
+                        "layoutDatabaseId": { "$ref": "#/DatabaseId" },
+                        "name": { "type": "string", "minLength": 1 },
+                        "position": { "$ref": "#/Coordinate2D" },
+                        "scale": { "type": "number", "exclusiveMinimum": 0.0 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["navigatorItemId", "name", "position"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["drawingsData"]
+    })";
+}
+
+GS::Optional<GS::UniString> CreateDrawingsCommand::GetResponseSchema () const
+{
+    return R"({"type":"object","properties":{"elements":{"$ref":"#/Elements"}},"additionalProperties":false,"required":["elements"]})";
+}
+
+GS::ObjectState CreateDrawingsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
+{
+    GS::Array<GS::ObjectState> items;
+    GS::ObjectState errorResponse;
+    if (!GetItems (parameters, "drawingsData", items, errorResponse)) {
+        return errorResponse;
+    }
+
+    API_DatabaseInfo startingDatabase = {};
+    const GSErrCode startingDatabaseErr = ACAPI_Database_GetCurrentDatabase (&startingDatabase);
+
+    GS::Array<GS::ObjectState> elementResults;
+    const GSErrCode undoErr = ACAPI_CallUndoableCommand ("CreateDrawingsCommand", [&]() -> GSErrCode {
+        for (const auto& item : items) {
+            if (startingDatabaseErr == NoError) {
+                const GS::ObjectState* layoutDatabaseId = item.Get ("layoutDatabaseId");
+                if (layoutDatabaseId != nullptr) {
+                    API_DatabaseInfo targetDatabase = DatabaseIdResolver::Instance ().GetDatabaseWithId (GetGuidFromObjectState (*layoutDatabaseId));
+                    GSErrCode err = ACAPI_Window_GetDatabaseInfo (&targetDatabase);
+                    if (err != NoError) {
+                        elementResults.Push (CreateErrorResponse (err, "Failed to resolve layout database."));
+                        continue;
+                    }
+
+                    err = ACAPI_Database_ChangeCurrentDatabase (&targetDatabase);
+                    if (err != NoError) {
+                        elementResults.Push (CreateErrorResponse (err, "Failed to activate layout database."));
+                        continue;
+                    }
+
+                    API_WindowInfo windowInfo = targetDatabase;
+                    err = ACAPI_Window_ChangeWindow (&windowInfo);
+                    if (err != NoError) {
+                        elementResults.Push (CreateErrorResponse (err, "Failed to activate layout window."));
+                        continue;
+                    }
+                }
+            }
+
+            API_Element element = {};
+            element.header.type = API_DrawingID;
+            GSErrCode err = ACAPI_Element_GetDefaults (&element, nullptr);
+            if (err != NoError) {
+                elementResults.Push (CreateErrorResponse (err, "Failed to get drawing defaults."));
+                continue;
+            }
+
+            element.drawing.drawingGuid = GetGuidFromObjectState (*item.Get ("navigatorItemId"));
+            SetCharProperty (&item, "name", element.drawing.name);
+            element.drawing.nameType = APIName_CustomName;
+            element.drawing.anchorPoint = APIAnc_MM;
+            element.drawing.pos = Get2DCoordinateFromObjectState (*item.Get ("position"));
+            if (item.Contains ("scale")) {
+                item.Get ("scale", element.drawing.ratio);
+            } else {
+                element.drawing.ratio = 1.0;
+            }
+
+            API_ElementMemo memo = {};
+            err = ACAPI_Element_Create (&element, &memo);
+            ACAPI_DisposeElemMemoHdls (&memo);
+
+            if (err != NoError) {
+                elementResults.Push (CreateErrorResponse (err, "Failed to create drawing."));
+                continue;
+            }
+            elementResults.Push (CreateElementIdObjectState (element.header.guid));
+        }
+
+        return NoError;
+    });
+
+    if (startingDatabaseErr == NoError) {
+        ACAPI_Database_ChangeCurrentDatabase (&startingDatabase);
+    }
+    if (undoErr != NoError) {
+        elementResults.Push (CreateErrorResponse (undoErr, "Failed to execute command in undo scope."));
+    }
+
+    GS::ObjectState response;
+    const auto& elements = response.AddList<GS::ObjectState> ("elements");
+    for (const auto& elementResult : elementResults) {
+        elements (elementResult);
+    }
+    return response;
+}

--- a/archicad-addon/Sources/DocumentCreationCommands.hpp
+++ b/archicad-addon/Sources/DocumentCreationCommands.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "CommandBase.hpp"
+
+class CreateDetailsCommand : public CommandBase
+{
+public:
+    CreateDetailsCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class CreateWorksheetsCommand : public CommandBase
+{
+public:
+    CreateWorksheetsCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class CreateLayoutsCommand : public CommandBase
+{
+public:
+    CreateLayoutsCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class CreateSubsetsCommand : public CommandBase
+{
+public:
+    CreateSubsetsCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class CreateDrawingsCommand : public CommandBase
+{
+public:
+    CreateDrawingsCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};

--- a/archicad-addon/Sources/NavigatorCommands.cpp
+++ b/archicad-addon/Sources/NavigatorCommands.cpp
@@ -47,6 +47,10 @@ GS::Optional<GS::UniString> PublishPublisherSetCommand::GetInputParametersSchema
                 "type": "string",
                 "description": "Full local or LAN path for publishing. Optional, by default the path set in the settings of the publisher set will be used.",
                 "minLength": 1
+            },
+            "selectedNavigatorItemIds": {
+                "$ref": "#/NavigatorItemIds",
+                "description": "Optional publisher-tree navigator items to publish instead of the whole publisher set."
             }
         },
         "additionalProperties": false,
@@ -75,7 +79,27 @@ GS::ObjectState PublishPublisherSetCommand::Execute(const GS::ObjectState& param
         publishPars.path = new IO::Location(outputPath);
     }
 
-    GSErrCode err = ACAPI_ProjectOperation_Publish(&publishPars);
+    GS::Array<API_Guid> selectedLinks;
+    const GS::Array<API_Guid>* selectedLinksPtr = nullptr;
+    if (parameters.Contains("selectedNavigatorItemIds")) {
+        GS::Array<GS::ObjectState> selectedNavigatorItemIds;
+        parameters.Get("selectedNavigatorItemIds", selectedNavigatorItemIds);
+
+        for (const GS::ObjectState& navigatorItemIdArrayItem : selectedNavigatorItemIds) {
+            const API_Guid selectedGuid = GetGuidFromNavigatorItemIdArrayItem(navigatorItemIdArrayItem);
+            if (selectedGuid == APINULLGuid) {
+                delete publishPars.path;
+                return CreateErrorResponse(APIERR_BADPARS, "selectedNavigatorItemId is corrupt or missing.");
+            }
+            selectedLinks.Push(selectedGuid);
+        }
+
+        if (!selectedLinks.IsEmpty()) {
+            selectedLinksPtr = &selectedLinks;
+        }
+    }
+
+    GSErrCode err = ACAPI_ProjectOperation_Publish(&publishPars, selectedLinksPtr);
     delete publishPars.path;
 
     if (err != NoError) {
@@ -359,13 +383,25 @@ GS::ObjectState GetViewSettingsCommand::Execute (const GS::ObjectState& paramete
         }
 
         GS::UniString graphicOverrideCombinationName (navigatorView.overrideCombination);
-
-        viewSettings (GS::ObjectState (
+        GS::ObjectState viewSetting (
             "modelViewOptions", navigatorView.modelViewOptName,
             "layerCombination", navigatorView.layerCombination,
             "dimensionStyle", navigatorView.dimName,
             "penSetName", navigatorView.penSetName,
-            "graphicOverrideCombination", graphicOverrideCombinationName));
+            "graphicOverrideCombination", graphicOverrideCombinationName,
+            "drawingScale", navigatorView.drawingScale,
+            "saveZoom", navigatorView.saveZoom,
+            "ignoreSavedZoom", navigatorView.ignoreSavedZoom);
+
+        if (navigatorView.saveZoom) {
+            viewSetting.Add ("zoom", GS::ObjectState (
+                "xMin", navigatorView.zoom.xMin,
+                "yMin", navigatorView.zoom.yMin,
+                "xMax", navigatorView.zoom.xMax,
+                "yMax", navigatorView.zoom.yMax));
+        }
+
+        viewSettings (viewSetting);
     }
 
     return response;
@@ -470,6 +506,25 @@ GS::ObjectState SetViewSettingsCommand::Execute (const GS::ObjectState& paramete
         SetCharProperty (viewSettingsOS, "dimensionStyle", navigatorView.dimName);
         SetCharProperty (viewSettingsOS, "penSetName", navigatorView.penSetName);
         SetUCharProperty (viewSettingsOS, "graphicOverrideCombination", navigatorView.overrideCombination);
+        if (viewSettingsOS->Contains ("drawingScale")) {
+            Int32 drawingScale = navigatorView.drawingScale;
+            viewSettingsOS->Get ("drawingScale", drawingScale);
+            navigatorView.drawingScale = drawingScale;
+            navigatorView.saveDScale = true;
+        }
+        if (viewSettingsOS->Contains ("saveZoom")) {
+            viewSettingsOS->Get ("saveZoom", navigatorView.saveZoom);
+        }
+        if (viewSettingsOS->Contains ("ignoreSavedZoom")) {
+            viewSettingsOS->Get ("ignoreSavedZoom", navigatorView.ignoreSavedZoom);
+        }
+        if (const GS::ObjectState* zoomOS = viewSettingsOS->Get ("zoom"); zoomOS != nullptr) {
+            zoomOS->Get ("xMin", navigatorView.zoom.xMin);
+            zoomOS->Get ("yMin", navigatorView.zoom.yMin);
+            zoomOS->Get ("xMax", navigatorView.zoom.xMax);
+            zoomOS->Get ("yMax", navigatorView.zoom.yMax);
+            navigatorView.saveZoom = true;
+        }
 
 
         err = ACAPI_Navigator_ChangeNavigatorView (&navigatorItem, &navigatorView);

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -72,6 +72,9 @@ var gCommands = [{
         "properties": {
             "windowType": {
                 "$ref": "#/WindowType"
+            },
+            "databaseId": {
+                "$ref": "#/DatabaseId"
             }
         },
         "additionalProperties": false,
@@ -1391,6 +1394,15 @@ var gCommands = [{
                                 "y",
                                 "z"
                             ]
+                        },
+                        "height": {
+                            "type": "number",
+                            "description": "Optional column height.",
+                            "exclusiveMinimum": 0.0
+                        },
+                        "axisRotationAngle": {
+                            "type": "number",
+                            "description": "Optional column rotation angle in radians."
                         }
                     },
                     "additionalProperties": false,
@@ -1404,6 +1416,92 @@ var gCommands = [{
         "required": [
             "columnsData"
         ]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/Elements"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "elements"
+        ]
+    }
+            },{
+                "name": "CreateWalls",
+                "version": "1.4.0",
+                "description": "Creates Wall elements based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "wallsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "begCoordinate": { "$ref": "#/Coordinate2D" },
+                        "endCoordinate": { "$ref": "#/Coordinate2D" },
+                        "zCoordinate": { "type": "number" },
+                        "height": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "thickness": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "offset": { "type": "number" },
+                        "structureType": {
+                            "type": "string",
+                            "enum": ["Basic", "Composite", "Profile"]
+                        },
+                        "buildingMaterialId": { "$ref": "#/AttributeId" },
+                        "compositeId": { "$ref": "#/AttributeId" },
+                        "profileId": { "$ref": "#/AttributeId" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["begCoordinate", "endCoordinate", "zCoordinate", "height", "thickness"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["wallsData"]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/Elements"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "elements"
+        ]
+    }
+            },{
+                "name": "CreateBeams",
+                "version": "1.4.0",
+                "description": "Creates Beam elements based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "beamsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "begCoordinate": { "$ref": "#/Coordinate2D" },
+                        "endCoordinate": { "$ref": "#/Coordinate2D" },
+                        "zCoordinate": { "type": "number" },
+                        "offset": { "type": "number" },
+                        "slantAngle": { "type": "number" },
+                        "arcAngle": { "type": "number" },
+                        "verticalCurveHeight": { "type": "number" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["begCoordinate", "endCoordinate", "zCoordinate"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["beamsData"]
     },
                 "outputScheme": {
         "type": "object",
@@ -1434,6 +1532,11 @@ var gCommands = [{
                     "level": {
                         "type": "number",
                         "description" : "The Z coordinate value of the reference line of the slab."	
+                    },
+                    "thickness": {
+                        "type": "number",
+                        "description": "Optional slab thickness.",
+                        "exclusiveMinimum": 0.0
                     },
                     "polygonCoordinates": { 
                         "type": "array",
@@ -1478,6 +1581,352 @@ var gCommands = [{
         "required": [
             "elements"
         ]
+    }
+            },{
+                "name": "CreateWindows",
+                "version": "1.4.0",
+                "description": "Creates Window elements in host walls based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "windowsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "ownerWallId": { "$ref": "#/ElementId" },
+                        "centerOffset": { "type": "number", "minimum": 0.0 },
+                        "sillHeight": { "type": "number" },
+                        "width": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "height": { "type": "number", "exclusiveMinimum": 0.0 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["ownerWallId", "centerOffset"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["windowsData"]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/Elements"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["elements"]
+    }
+            },{
+                "name": "CreateDoors",
+                "version": "1.4.0",
+                "description": "Creates Door elements in host walls based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "doorsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "ownerWallId": { "$ref": "#/ElementId" },
+                        "centerOffset": { "type": "number", "minimum": 0.0 },
+                        "sillHeight": { "type": "number" },
+                        "width": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "height": { "type": "number", "exclusiveMinimum": 0.0 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["ownerWallId", "centerOffset"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["doorsData"]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/Elements"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["elements"]
+    }
+            },{
+                "name": "CreateOpenings",
+                "version": "1.4.0",
+                "description": "Creates Opening elements in the given host elements.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "openingsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "ownerElementId": { "$ref": "#/ElementId" },
+                        "basePoint": { "$ref": "#/Coordinate3D" },
+                        "width": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "height": { "type": "number", "exclusiveMinimum": 0.0 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["ownerElementId", "basePoint"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["openingsData"]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/Elements"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["elements"]
+    }
+            },{
+                "name": "CreateMorphs",
+                "version": "1.4.1",
+                "description": "Creates Morph elements from simple box definitions.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "morphsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "basePoint": { "$ref": "#/Coordinate3D" },
+                        "size": { "$ref": "#/Dimensions3D" },
+                        "buildingMaterialId": { "$ref": "#/AttributeId" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["basePoint", "size"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["morphsData"]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/Elements"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["elements"]
+    }
+            },{
+                "name": "CreateRoofs",
+                "version": "1.4.2",
+                "description": "Creates multi-plane Roof elements based on footprint, level and roof profile data.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "roofsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "level": { "type": "number" },
+                        "thickness": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "polygonCoordinates": {
+                            "type": "array",
+                            "items": { "$ref": "#/Coordinate2D" },
+                            "minItems": 3
+                        },
+                        "polygonArcs": {
+                            "type": "array",
+                            "items": { "$ref": "#/PolyArc" }
+                        },
+                        "holes": { "$ref": "#/Holes2D" },
+                        "eavesOverhang": { "type": "number" },
+                        "levels": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 16,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "levelHeight": { "type": "number" },
+                                    "levelAngle": { "type": "number", "exclusiveMinimum": 0.0 }
+                                },
+                                "additionalProperties": false,
+                                "required": ["levelHeight", "levelAngle"]
+                            }
+                        },
+                        "structureType": {
+                            "type": "string",
+                            "enum": ["Basic", "Composite"]
+                        },
+                        "buildingMaterialId": { "$ref": "#/AttributeId" },
+                        "compositeId": { "$ref": "#/AttributeId" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["level", "polygonCoordinates"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["roofsData"]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/Elements"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["elements"]
+    }
+            },{
+                "name": "CreateAssociativeDimensions",
+                "version": "1.4.3",
+                "description": "Creates associative linear dimensions from explicit witness point references.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "dimensionsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "referencePoint": { "$ref": "#/Coordinate2D" },
+                        "direction": { "$ref": "#/Coordinate2D" },
+                        "floorIndex": { "type": "number" },
+                        "witnessPoints": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "elementId": { "$ref": "#/ElementId" },
+                                    "line": { "type": "boolean" },
+                                    "inIndex": { "type": "integer" },
+                                    "special": { "type": "integer" },
+                                    "nodeType": { "type": "integer" },
+                                    "nodeStatus": { "type": "integer" },
+                                    "nodeId": { "type": "number", "minimum": 0.0 }
+                                },
+                                "additionalProperties": false,
+                                "required": ["elementId"]
+                            },
+                            "minItems": 2
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": ["referencePoint", "direction", "witnessPoints"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["dimensionsData"]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/Elements"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["elements"]
+    }
+            },{
+                "name": "CreateAssociativeDimensionsOnSection",
+                "version": "1.4.3",
+                "description": "Creates associative linear dimensions on section elements using common wall, slab, beam, column and opening presets.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "dimensionsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "sectionElementId": { "$ref": "#/ElementId" },
+                        "referencePoint": { "$ref": "#/Coordinate2D" },
+                        "preset": {
+                            "type": "string",
+                            "enum": [
+                                "WallCompositeFaces",
+                                "WallSkinBorders",
+                                "SlabCompositeFaces",
+                                "SlabSkinBorders",
+                                "BeamOrColumnRefLineEndPoints",
+                                "BeamOrColumnBoundingBoxCorners",
+                                "DoorWindowWallHoleCorners",
+                                "DoorWindowModelHotspots"
+                            ]
+                        },
+                        "direction": { "$ref": "#/Coordinate2D" },
+                        "skinBorderIndices": {
+                            "type": "array",
+                            "items": { "type": "integer" },
+                            "minItems": 1
+                        },
+                        "beginPlane": { "type": "boolean" },
+                        "totalSizePlane": { "type": "boolean" },
+                        "placeOnTop": { "type": "boolean" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["sectionElementId", "referencePoint", "preset"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["dimensionsData"]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/Elements"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["elements"]
+    }
+            },{
+                "name": "CreateWallThicknessDimensions",
+                "version": "1.4.1",
+                "description": "Creates associative wall thickness dimensions for the given walls.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "dimensionsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "wallId": { "$ref": "#/ElementId" },
+                        "referencePoint": { "$ref": "#/Coordinate2D" },
+                        "direction": { "$ref": "#/Coordinate2D" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["wallId", "referencePoint", "direction"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["dimensionsData"]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/Elements"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["elements"]
     }
             },{
                 "name": "CreateZones",
@@ -1796,6 +2245,277 @@ var gCommands = [{
             "elements"
         ]
     }
+            },{
+                "name": "ModifyWalls",
+                "version": "1.4.0",
+                "description": "Modifies Wall elements based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "wallsWithDetails": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": { "$ref": "#/ElementId" },
+                        "begCoordinate": { "$ref": "#/Coordinate2D" },
+                        "endCoordinate": { "$ref": "#/Coordinate2D" },
+                        "height": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "thickness": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "bottomOffset": { "type": "number" },
+                        "offset": { "type": "number" },
+                        "structureType": {
+                            "type": "string",
+                            "enum": ["Basic", "Composite", "Profile"]
+                        },
+                        "buildingMaterialId": { "$ref": "#/AttributeId" },
+                        "compositeId": { "$ref": "#/AttributeId" },
+                        "profileId": { "$ref": "#/AttributeId" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["elementId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["wallsWithDetails"]
+    },
+                "outputScheme": {"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]}
+            },{
+                "name": "ModifyBeams",
+                "version": "1.4.0",
+                "description": "Modifies Beam elements based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "beamsWithDetails": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": { "$ref": "#/ElementId" },
+                        "begCoordinate": { "$ref": "#/Coordinate2D" },
+                        "endCoordinate": { "$ref": "#/Coordinate2D" },
+                        "level": { "type": "number" },
+                        "offset": { "type": "number" },
+                        "slantAngle": { "type": "number" },
+                        "arcAngle": { "type": "number" },
+                        "verticalCurveHeight": { "type": "number" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["elementId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["beamsWithDetails"]
+    },
+                "outputScheme": {"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]}
+            },{
+                "name": "ModifySlabs",
+                "version": "1.4.1",
+                "description": "Modifies Slab elements based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "slabsWithDetails": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": { "$ref": "#/ElementId" },
+                        "zCoordinate": { "type": "number" },
+                        "thickness": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "structureType": {
+                            "type": "string",
+                            "enum": ["Basic", "Composite"]
+                        },
+                        "buildingMaterialId": { "$ref": "#/AttributeId" },
+                        "compositeId": { "$ref": "#/AttributeId" },
+                        "polygonOutline": {
+                            "type": "array",
+                            "items": { "$ref": "#/Coordinate2D" },
+                            "minItems": 3
+                        },
+                        "polygonArcs": {
+                            "type": "array",
+                            "items": { "$ref": "#/PolyArc" }
+                        },
+                        "holes": { "$ref": "#/Holes2D" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["elementId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["slabsWithDetails"]
+    },
+                "outputScheme": {"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]}
+            },{
+                "name": "ModifyColumns",
+                "version": "1.4.1",
+                "description": "Modifies Column elements based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "columnsWithDetails": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": { "$ref": "#/ElementId" },
+                        "origin": { "$ref": "#/Coordinate2D" },
+                        "zCoordinate": { "type": "number" },
+                        "height": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "bottomOffset": { "type": "number" },
+                        "axisRotationAngle": { "type": "number" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["elementId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["columnsWithDetails"]
+    },
+                "outputScheme": {"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]}
+            },{
+                "name": "ModifyWindows",
+                "version": "1.4.0",
+                "description": "Modifies Window elements based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "windowsWithDetails": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": { "$ref": "#/ElementId" },
+                        "width": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "height": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "sillHeight": { "type": "number" },
+                        "centerOffset": { "type": "number", "minimum": 0.0 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["elementId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["windowsWithDetails"]
+    },
+                "outputScheme": {"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]}
+            },{
+                "name": "ModifyDoors",
+                "version": "1.4.0",
+                "description": "Modifies Door elements based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "doorsWithDetails": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": { "$ref": "#/ElementId" },
+                        "width": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "height": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "sillHeight": { "type": "number" },
+                        "centerOffset": { "type": "number", "minimum": 0.0 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["elementId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["doorsWithDetails"]
+    },
+                "outputScheme": {"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]}
+            },{
+                "name": "ModifyMorphs",
+                "version": "1.4.1",
+                "description": "Modifies Morph elements based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "morphsWithDetails": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": { "$ref": "#/ElementId" },
+                        "translation": { "$ref": "#/Coordinate3D" },
+                        "rotationDegreesZ": { "type": "number" },
+                        "buildingMaterialId": { "$ref": "#/AttributeId" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["elementId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["morphsWithDetails"]
+    },
+                "outputScheme": {"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]}
+            },{
+                "name": "ModifyRoofs",
+                "version": "1.4.2",
+                "description": "Modifies multi-plane Roof elements based on the given parameters.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "roofsWithDetails": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": { "$ref": "#/ElementId" },
+                        "level": { "type": "number" },
+                        "thickness": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "eavesOverhang": { "type": "number" },
+                        "levels": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 16,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "levelHeight": { "type": "number" },
+                                    "levelAngle": { "type": "number", "exclusiveMinimum": 0.0 }
+                                },
+                                "additionalProperties": false,
+                                "required": ["levelHeight", "levelAngle"]
+                            }
+                        },
+                        "structureType": {
+                            "type": "string",
+                            "enum": ["Basic", "Composite"]
+                        },
+                        "buildingMaterialId": { "$ref": "#/AttributeId" },
+                        "compositeId": { "$ref": "#/AttributeId" },
+                        "polygonOutline": {
+                            "type": "array",
+                            "items": { "$ref": "#/Coordinate2D" },
+                            "minItems": 3
+                        },
+                        "polygonArcs": {
+                            "type": "array",
+                            "items": { "$ref": "#/PolyArc" }
+                        },
+                        "holes": { "$ref": "#/Holes2D" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["elementId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["roofsWithDetails"]
+    },
+                "outputScheme": {"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]}
             },{
                 "name": "GetElementPreviewImage",
                 "version": "1.2.7",
@@ -3197,6 +3917,131 @@ var gCommands = [{
         "databases"
     ]
 }
+            },{
+                "name": "CreateDetails",
+                "version": "1.4.0",
+                "description": "Creates independent Detail databases.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "detailsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string", "minLength": 1 },
+                        "referenceId": { "type": "string", "minLength": 1 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["name", "referenceId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["detailsData"]
+    },
+                "outputScheme": {"type":"object","properties":{"databases":{"$ref":"#/Databases"}},"additionalProperties":false,"required":["databases"]}
+            },{
+                "name": "CreateWorksheets",
+                "version": "1.4.0",
+                "description": "Creates independent Worksheet databases.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "worksheetsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string", "minLength": 1 },
+                        "referenceId": { "type": "string", "minLength": 1 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["name", "referenceId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["worksheetsData"]
+    },
+                "outputScheme": {"type":"object","properties":{"databases":{"$ref":"#/Databases"}},"additionalProperties":false,"required":["databases"]}
+            },{
+                "name": "CreateLayouts",
+                "version": "1.4.0",
+                "description": "Creates Layouts and their backing master layouts.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "layoutsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "masterLayoutName": { "type": "string", "minLength": 1 },
+                        "layoutName": { "type": "string", "minLength": 1 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["masterLayoutName", "layoutName"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["layoutsData"]
+    },
+                "outputScheme": {"type":"object","properties":{"databases":{"$ref":"#/Databases"}},"additionalProperties":false,"required":["databases"]}
+            },{
+                "name": "CreateSubsets",
+                "version": "1.4.0",
+                "description": "Creates Layout Book subsets.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "subsetsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string", "minLength": 1 },
+                        "parentNavigatorItemId": { "$ref": "#/NavigatorItemId" },
+                        "ownPrefix": { "type": "string" },
+                        "customNumber": { "type": "string" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["name"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["subsetsData"]
+    },
+                "outputScheme": {"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]}
+            },{
+                "name": "CreateDrawings",
+                "version": "1.4.0",
+                "description": "Creates Drawing elements on the specified or active layout from navigator items.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "drawingsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "navigatorItemId": { "$ref": "#/NavigatorItemId" },
+                        "layoutDatabaseId": { "$ref": "#/DatabaseId" },
+                        "name": { "type": "string", "minLength": 1 },
+                        "position": { "$ref": "#/Coordinate2D" },
+                        "scale": { "type": "number", "exclusiveMinimum": 0.0 }
+                    },
+                    "additionalProperties": false,
+                    "required": ["navigatorItemId", "name", "position"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["drawingsData"]
+    },
+                "outputScheme": {"type":"object","properties":{"elements":{"$ref":"#/Elements"}},"additionalProperties":false,"required":["elements"]}
             },{
                 "name": "GetModelViewOptions",
                 "version": "1.1.4",


### PR DESCRIPTION
## Summary

Adds 5 new commands for creating document databases and layout elements, plus enhancements to existing navigator and application commands.

### New document creation commands
- `CreateDetails` (v1.4.0): creates independent Detail databases with name and reference ID
- `CreateWorksheets` (v1.4.0): creates independent Worksheet databases with name and reference ID
- `CreateLayouts` (v1.4.0): creates Layouts and their backing master layouts (looks up or creates master layout as needed)
- `CreateSubsets` (v1.4.0): creates Layout Book subsets with optional parent navigator item and custom numbering style
- `CreateDrawings` (v1.4.0): creates Drawing elements on the specified or active layout from navigator items, with positioning and scale parameters

### Navigator command enhancements
- `PublishPublisherSet`: new optional `selectedNavigatorItemIds` parameter to publish a subset of navigator items instead of the entire publisher set
- `GetViewSettings` / `SetViewSettings`: new fields `drawingScale`, `saveZoom`, `ignoreSavedZoom`, and optional `zoom` object (xMin, yMin, xMax, yMax) for persisting zoom state

### Application command enhancements
- `ChangeWindow`: new optional `databaseId` parameter to switch directly to a specific database window, with validation against the requested window type