### PR TITLE
feat(doors): allow explicit libraryPart for CreateDoors/CreateWindows + new GetAvailableLibraryParts

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -314,12 +314,12 @@ GSErrCode Initialize (void)
             "Creates Slab elements based on the given parameters."
         );
         err |= RegisterCommand<CreateWindowsCommand> (
-            elementCommands, "1.4.0",
-            "Creates Window elements in host walls based on the given parameters."
+            elementCommands, "1.5.0",
+            "Creates Window elements in host walls. Accepts optional libraryPart {guid} to bypass AC defaults."
         );
         err |= RegisterCommand<CreateDoorsCommand> (
-            elementCommands, "1.4.0",
-            "Creates Door elements in host walls based on the given parameters."
+            elementCommands, "1.5.0",
+            "Creates Door elements in host walls. Accepts optional libraryPart {guid} to bypass AC defaults."
         );
         err |= RegisterCommand<CreateOpeningsCommand> (
             elementCommands, "1.4.0",
@@ -537,6 +537,10 @@ GSErrCode Initialize (void)
         err |= RegisterCommand<AddFilesToEmbeddedLibraryCommand> (
             libraryCommands, "1.2.2",
             "Adds the given files into the embedded library."
+        );
+        err |= RegisterCommand<GetAvailableLibraryPartsCommand> (
+            libraryCommands, "1.0.0",
+            "Lists library parts currently available to the project. Filter by typeId (e.g. 'Door', 'Window')."
         );
         AddCommandGroup (libraryCommands);
     }

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -238,7 +238,7 @@ bool DoesWallExist (const API_Guid& wallGuid)
     return GetElemTypeId (header) == API_WallID;
 }
 
-GSErrCode PrepareWindowOrDoorDefaults (API_ElemTypeID elemTypeId, API_Element& element, API_ElementMemo& memo, API_SubElement& marker)
+GSErrCode PrepareWindowOrDoorDefaults (API_ElemTypeID elemTypeId, API_Element& element, API_ElementMemo& memo, API_SubElement& marker, const GS::Optional<API_Guid>& explicitLibPartGuid = GS::NoValue)
 {
     element = {};
     marker = {};
@@ -255,21 +255,32 @@ GSErrCode PrepareWindowOrDoorDefaults (API_ElemTypeID elemTypeId, API_Element& e
     }
 
     API_LibPart libPart = {};
+    if (explicitLibPartGuid.HasValue ()) {
+        libPart.ownUnID = explicitLibPartGuid.Get ();
+        err = ACAPI_LibraryPart_Search (&libPart, false, true);
+        delete libPart.location;
+        if (err != NoError) {
+            return err;
+        }
+        // Bind the requested GDL to the element so ACAPI_Element_CreateExt
+        // can instantiate the right panel.
+        element.window.openingBase.libInd = libPart.index;
+    } else {
 #ifdef ServerMainVers_2700
-    err = ACAPI_LibraryPart_GetMarkerParent (element.header.type, libPart);
+        err = ACAPI_LibraryPart_GetMarkerParent (element.header.type, libPart);
 #elif ServerMainVers_2600
-    err = ACAPI_Goodies_GetMarkerParent (element.header.type, libPart);
+        err = ACAPI_Goodies_GetMarkerParent (element.header.type, libPart);
 #else
-    err = ACAPI_Goodies (APIAny_GetMarkerParentID, (void*)&element.header.typeID, (void*)&libPart);
+        err = ACAPI_Goodies (APIAny_GetMarkerParentID, (void*)&element.header.typeID, (void*)&libPart);
 #endif
-    if (err != NoError) {
-        return NoError;
-    }
-
-    err = ACAPI_LibraryPart_Search (&libPart, false, true);
-    delete libPart.location;
-    if (err != NoError) {
-        return err;
+        if (err != NoError) {
+            return NoError;
+        }
+        err = ACAPI_LibraryPart_Search (&libPart, false, true);
+        delete libPart.location;
+        if (err != NoError) {
+            return err;
+        }
     }
 
     double a = 0.0;
@@ -1521,7 +1532,23 @@ GS::Optional<GS::UniString> CreateWindowsCommand::GetInputParametersSchema () co
                         "centerOffset": { "type": "number", "minimum": 0.0 },
                         "sillHeight": { "type": "number" },
                         "width": { "type": "number", "exclusiveMinimum": 0.0 },
-                        "height": { "type": "number", "exclusiveMinimum": 0.0 }
+                        "height": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "libraryPart": {
+                            "type": "object",
+                            "description": "Optional explicit library part to instantiate. Required when AC has no default for this element type.",
+                            "properties": {
+                                "guid": { "type": "string", "description": "GUID of the GDL library part." }
+                            },
+                            "required": ["guid"]
+                        },
+                        "libraryPart": {
+                            "type": "object",
+                            "description": "Optional explicit library part to instantiate. Required when AC has no default for this element type.",
+                            "properties": {
+                                "guid": { "type": "string", "description": "GUID of the GDL library part." }
+                            },
+                            "required": ["guid"]
+                        }
                     },
                     "additionalProperties": false,
                     "required": ["ownerWallId", "centerOffset"]
@@ -1571,7 +1598,15 @@ GS::ObjectState CreateWindowsCommand::Execute (const GS::ObjectState& parameters
                 ACAPI_DisposeElemMemoHdls (&marker.memo);
             });
 
-            GSErrCode err = PrepareWindowOrDoorDefaults (API_WindowID, element, memo, marker);
+            GS::Optional<API_Guid> libPartGuid;
+            const GS::ObjectState* libPart = data.Get ("libraryPart");
+            if (libPart != nullptr) {
+                GS::UniString guidStr;
+                if (libPart->Get ("guid", guidStr)) {
+                    libPartGuid = APIGuidFromString (guidStr.ToCStr ());
+                }
+            }
+            GSErrCode err = PrepareWindowOrDoorDefaults (API_WindowID, element, memo, marker, libPartGuid);
             if (err != NoError) {
                 elements.Push (CreateErrorResponse (err, "Failed to prepare window defaults."));
                 continue;
@@ -1678,7 +1713,15 @@ GS::ObjectState CreateDoorsCommand::Execute (const GS::ObjectState& parameters, 
                 ACAPI_DisposeElemMemoHdls (&marker.memo);
             });
 
-            GSErrCode err = PrepareWindowOrDoorDefaults (API_DoorID, element, memo, marker);
+            GS::Optional<API_Guid> libPartGuid;
+            const GS::ObjectState* libPart = data.Get ("libraryPart");
+            if (libPart != nullptr) {
+                GS::UniString guidStr;
+                if (libPart->Get ("guid", guidStr)) {
+                    libPartGuid = APIGuidFromString (guidStr.ToCStr ());
+                }
+            }
+            GSErrCode err = PrepareWindowOrDoorDefaults (API_DoorID, element, memo, marker, libPartGuid);
             if (err != NoError) {
                 elements.Push (CreateErrorResponse (err, "Failed to prepare door defaults."));
                 continue;

--- a/archicad-addon/Sources/LibraryCommands.cpp
+++ b/archicad-addon/Sources/LibraryCommands.cpp
@@ -291,3 +291,108 @@ GS::ObjectState ReloadLibrariesCommand::Execute (const GS::ObjectState& /*parame
 
     return CreateSuccessfulExecutionResult ();
 }
+
+GetAvailableLibraryPartsCommand::GetAvailableLibraryPartsCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String GetAvailableLibraryPartsCommand::GetName () const
+{
+    return "GetAvailableLibraryParts";
+}
+
+GS::Optional<GS::UniString> GetAvailableLibraryPartsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "filterByTypeId": {
+                "type": "string",
+                "description": "Optional element-type filter. Examples: 'Door', 'Window', 'Object', 'Lamp', 'Stair'."
+            }
+        },
+        "additionalProperties": false
+    })";
+}
+
+GS::Optional<GS::UniString> GetAvailableLibraryPartsCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "libraryParts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "guid": { "type": "string" },
+                        "index": { "type": "integer" },
+                        "documentName": { "type": "string" },
+                        "fileName": { "type": "string" },
+                        "typeId": { "type": "string" }
+                    }
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["libraryParts"]
+    })";
+}
+
+static GS::UniString LibPartTypeIdToString (Int32 typeID)
+{
+    switch (typeID) {
+        case API_ZombieLibID:    return "Zombie";
+        case API_WindowID:       return "Window";
+        case API_DoorID:         return "Door";
+        case API_ObjectID:       return "Object";
+        case API_LampID:         return "Lamp";
+        case API_RoomID:         return "Room";
+        case API_LabelID:        return "Label";
+        case API_MacroID:        return "Macro";
+        case API_PictID:         return "Picture";
+        case API_ListSchemeID:   return "ListScheme";
+        default:                 return GS::UniString::Printf ("Type%d", typeID);
+    }
+}
+
+GS::ObjectState GetAvailableLibraryPartsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::UniString filterTypeId;
+    parameters.Get ("filterByTypeId", filterTypeId);
+
+    Int32 partCount = 0;
+    GSErrCode err = ACAPI_LibraryPart_GetNum (&partCount);
+    if (err != NoError) {
+        return CreateErrorResponse (err, "Failed to enumerate library parts.");
+    }
+
+    GS::ObjectState response;
+    const auto& adder = response.AddList<GS::ObjectState> ("libraryParts");
+
+    for (Int32 i = 1; i <= partCount; ++i) {
+        API_LibPart libPart = {};
+        libPart.index = i;
+        err = ACAPI_LibraryPart_Get (&libPart);
+        if (err != NoError) {
+            continue;
+        }
+
+        GS::UniString typeId = LibPartTypeIdToString (libPart.typeID);
+        if (!filterTypeId.IsEmpty () && typeId != filterTypeId) {
+            continue;
+        }
+
+        GS::ObjectState entry;
+        entry.Add ("guid", APIGuidToString (libPart.ownUnID));
+        entry.Add ("index", static_cast<Int32> (libPart.index));
+        entry.Add ("documentName", GS::UniString (libPart.docu_Name));
+        entry.Add ("fileName", GS::UniString (libPart.file_UName));
+        entry.Add ("typeId", typeId);
+        adder (entry);
+    }
+
+    return response;
+}
+

--- a/archicad-addon/Sources/LibraryCommands.hpp
+++ b/archicad-addon/Sources/LibraryCommands.hpp
@@ -29,3 +29,13 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+
+class GetAvailableLibraryPartsCommand : public CommandBase
+{
+public:
+    GetAvailableLibraryPartsCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};


### PR DESCRIPTION
## Motivation

`CreateDoors` and `CreateWindows` currently rely on AC's *door tool defaults* being configured via the UI. On a fresh project where the user has never opened **Options → Door Settings**, the underlying `ACAPI_Element_GetDefaultsExt` returns a partially-initialised element whose `libInd` is invalid. `ACAPI_Element_CreateExt` then fails silently with `\"Failed to create door.\"`.

This is a real blocker for headless / scripted workflows (LLM-driven, batch-processing pipelines, CI for generative design, etc.) where there's no opportunity for the user to interact with the door dialog beforehand.

## What this PR adds

1. A new optional `libraryPart` field in the `doorsData` / `windowsData` schemas:

   ```json
   {
     \"doorsData\": [{
       \"ownerWallId\": {\"guid\": \"...\"},
       \"centerOffset\": 1.0,
       \"width\": 0.90,
       \"height\": 2.10,
       \"libraryPart\": { \"guid\": \"<GDL-GUID>\" }
     }]
   }
   ```

   `PrepareWindowOrDoorDefaults` now accepts a `GS::Optional<API_Guid>`. When provided, it bypasses the default-marker-parent lookup and resolves the explicit GDL via `ACAPI_LibraryPart_Search (ownUnID)`, binding `libInd` to the element so `ACAPI_Element_CreateExt` has a valid template to instantiate.

2. A new `GetAvailableLibraryParts` command so clients can discover the GUIDs of installed library parts:

   ```json
   { \"filterByTypeId\": \"Door\" }
   ```

   Returns:

   ```json
   {
     \"libraryParts\": [
       {\"guid\": \"...\", \"index\": 42, \"documentName\": \"Door 28\",
        \"fileName\": \"Door 28.gsm\", \"typeId\": \"Door\"}
     ]
   }
   ```

## Backward compatibility

100% — omitting `libraryPart` keeps the existing behaviour. All current callers continue to work unchanged.

## Versions

- `CreateDoors`: 1.4.0 → 1.5.0
- `CreateWindows`: 1.4.0 → 1.5.0
- `GetAvailableLibraryParts`: new 1.0.0

## Tested against

Not yet build-tested locally — the contributor lacks an AC SDK build environment. The patch follows the existing patterns in \`ExtendedElementCommands.cpp\` and \`LibraryCommands.cpp\` closely. **Please verify the build before merging.**

The patterns I followed:
- \`ACAPI_LibraryPart_Search\` with \`ownUnID\` populated (matches the convention used in marker-parent fallback)
- \`element.window.openingBase.libInd\` (the field set when AC's defaults are valid — same path as the default flow)
- New command modelled on \`GetLibrariesCommand\` (no input, single-pass result list)

## Why we need this

I'm building [\`archicad-mcp\`](https://github.com/akunia/archicad-mcp) — a Model Context Protocol server that lets an LLM (Claude, GPT-4o, …) drive ArchiCAD via Tapir. The MCP currently falls back to \`CreateOpenings\` (plain rectangular voids) whenever \`CreateDoors\` fails, because we can't realistically ask end-users to pre-configure their door defaults via the GUI before every script run. This PR lets us emit *real* doors with panels without that UX dependency.

Happy to iterate on the API surface (param naming, additional fields like \`gdlParameters\` to pass arbitrary GDL params) if you'd prefer a different shape.