### PR TITLE
feat(library, favorites): GetAvailableLibraryParts + ImportFavorites + ExportFavorites

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -443,6 +443,14 @@ GSErrCode Initialize (void)
             favoritesCommands, "1.1.2",
             "Create favorites from the given elements."
         );
+        err |= RegisterCommand<ImportFavoritesCommand> (
+            favoritesCommands, "1.0.0",
+            "Import Favorites from a .prefs file or folder into the current project."
+        );
+        err |= RegisterCommand<ExportFavoritesCommand> (
+            favoritesCommands, "1.0.0",
+            "Export the project's Favorites to a .prefs file or folder."
+        );
         AddCommandGroup (favoritesCommands);
     }
 

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -538,6 +538,10 @@ GSErrCode Initialize (void)
             libraryCommands, "1.2.2",
             "Adds the given files into the embedded library."
         );
+        err |= RegisterCommand<GetAvailableLibraryPartsCommand> (
+            libraryCommands, "1.0.0",
+            "Lists library parts currently available to the project. Filter by typeId (e.g. 'Door', 'Window', 'Object', 'Lamp')."
+        );
         AddCommandGroup (libraryCommands);
     }
 

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -444,11 +444,11 @@ GSErrCode Initialize (void)
             "Create favorites from the given elements."
         );
         err |= RegisterCommand<ImportFavoritesCommand> (
-            favoritesCommands, "1.0.0",
+            favoritesCommands, "1.4.1",
             "Import Favorites from a .prefs file or folder into the current project."
         );
         err |= RegisterCommand<ExportFavoritesCommand> (
-            favoritesCommands, "1.0.0",
+            favoritesCommands, "1.4.1",
             "Export the project's Favorites to a .prefs file or folder."
         );
         AddCommandGroup (favoritesCommands);
@@ -547,7 +547,7 @@ GSErrCode Initialize (void)
             "Adds the given files into the embedded library."
         );
         err |= RegisterCommand<GetAvailableLibraryPartsCommand> (
-            libraryCommands, "1.0.0",
+            libraryCommands, "1.4.1",
             "Lists library parts currently available to the project. Filter by typeId (e.g. 'Door', 'Window', 'Object', 'Lamp')."
         );
         AddCommandGroup (libraryCommands);

--- a/archicad-addon/Sources/FavoritesCommands.cpp
+++ b/archicad-addon/Sources/FavoritesCommands.cpp
@@ -411,3 +411,187 @@ GS::ObjectState CreateFavoritesFromElementsCommand::Execute (const GS::ObjectSta
 
     return response;
 }
+
+
+// ============================================================================
+// ImportFavorites / ExportFavorites — wrap ACAPI_Favorite_Import / _Export
+// so a caller can load a .prefs file into the project (replicating known-
+// good GDL defaults across installs) or back the current Favorites database
+// out to a file, both without going through AC's UI.
+// ============================================================================
+
+static IO::Location LocationFromPath (const GS::UniString& path)
+{
+    return IO::Location (path);
+}
+
+static API_FavoriteNameConflictResolutionPolicy ParseConflictPolicy (
+    const GS::UniString& s, API_FavoriteNameConflictResolutionPolicy fallback)
+{
+    if (s == "Error")     return API_FavoriteError;
+    if (s == "Skip")      return API_FavoriteSkip;
+    if (s == "Overwrite") return API_FavoriteOverwrite;
+    if (s == "Append")    return API_FavoriteAppend;
+    return fallback;
+}
+
+ImportFavoritesCommand::ImportFavoritesCommand () :
+    CommandBase (CommonSchema::Used)
+{}
+
+GS::String ImportFavoritesCommand::GetName () const
+{
+    return "ImportFavorites";
+}
+
+GS::Optional<GS::UniString> ImportFavoritesCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Absolute path on the AC host to a Favorites file (.prefs) or folder."
+            },
+            "targetFolder": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Folder hierarchy under which to import. Empty = root."
+            },
+            "importFolders": {
+                "type": "boolean",
+                "description": "If true and `path` is a folder, the folder structure is preserved."
+            },
+            "conflictPolicy": {
+                "type": "string",
+                "enum": ["Error", "Skip", "Overwrite", "Append"],
+                "description": "How to resolve name conflicts. Default Overwrite."
+            }
+        },
+        "required": ["path"],
+        "additionalProperties": false
+    })";
+}
+
+GS::Optional<GS::UniString> ImportFavoritesCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "firstConflictName": {
+                "type": "string",
+                "description": "Set when conflictPolicy=Error and a name collided; absent otherwise."
+            }
+        },
+        "additionalProperties": false
+    })";
+}
+
+GS::ObjectState ImportFavoritesCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::UniString path;
+    parameters.Get ("path", path);
+    if (path.IsEmpty ()) {
+        return CreateErrorResponse (APIERR_BADPARS, "path is required");
+    }
+
+    API_FavoriteFolderHierarchy targetFolder;
+    if (parameters.Contains ("targetFolder")) {
+        GS::Array<GS::UniString> folders;
+        parameters.Get ("targetFolder", folders);
+        for (const GS::UniString& f : folders) {
+            targetFolder.Push (f);
+        }
+    }
+
+    bool importFolders = false;
+    if (parameters.Contains ("importFolders")) {
+        parameters.Get ("importFolders", importFolders);
+    }
+
+    GS::UniString policyStr = "Overwrite";
+    if (parameters.Contains ("conflictPolicy")) {
+        parameters.Get ("conflictPolicy", policyStr);
+    }
+    const auto policy = ParseConflictPolicy (policyStr, API_FavoriteOverwrite);
+
+    const IO::Location location = LocationFromPath (path);
+    GS::UniString firstConflictName;
+    const GSErrCode err = ACAPI_Favorite_Import (
+        location, targetFolder, importFolders, policy, &firstConflictName);
+    if (err != NoError) {
+        return CreateErrorResponse (err, "ACAPI_Favorite_Import failed.");
+    }
+
+    GS::ObjectState response;
+    if (!firstConflictName.IsEmpty ()) {
+        response.Add ("firstConflictName", firstConflictName);
+    }
+    return response;
+}
+
+ExportFavoritesCommand::ExportFavoritesCommand () :
+    CommandBase (CommonSchema::Used)
+{}
+
+GS::String ExportFavoritesCommand::GetName () const
+{
+    return "ExportFavorites";
+}
+
+GS::Optional<GS::UniString> ExportFavoritesCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Absolute path on the AC host. If extension matches the Favorite binary format (.prefs), writes a single file; otherwise treats as folder."
+            },
+            "names": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Optional subset of Favorites to export. Default: export all."
+            }
+        },
+        "required": ["path"],
+        "additionalProperties": false
+    })";
+}
+
+GS::Optional<GS::UniString> ExportFavoritesCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+    })";
+}
+
+GS::ObjectState ExportFavoritesCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::UniString path;
+    parameters.Get ("path", path);
+    if (path.IsEmpty ()) {
+        return CreateErrorResponse (APIERR_BADPARS, "path is required");
+    }
+
+    const IO::Location location = LocationFromPath (path);
+
+    GSErrCode err = NoError;
+    if (parameters.Contains ("names")) {
+        GS::Array<GS::UniString> names;
+        parameters.Get ("names", names);
+        err = ACAPI_Favorite_Export (location, &names);
+    } else {
+        err = ACAPI_Favorite_Export (location, nullptr);
+    }
+    if (err != NoError) {
+        return CreateErrorResponse (err, "ACAPI_Favorite_Export failed.");
+    }
+
+    // Empty response satisfies the schema (`additionalProperties: false`).
+    // CreateSuccessfulExecutionResult() would inject `{"success": true}`
+    // which the schema validator rejects for top-level command responses.
+    return GS::ObjectState ();
+}

--- a/archicad-addon/Sources/FavoritesCommands.cpp
+++ b/archicad-addon/Sources/FavoritesCommands.cpp
@@ -519,6 +519,18 @@ GS::ObjectState ImportFavoritesCommand::Execute (const GS::ObjectState& paramete
     GS::UniString firstConflictName;
     const GSErrCode err = ACAPI_Favorite_Import (
         location, targetFolder, importFolders, policy, &firstConflictName);
+
+    // On conflictPolicy=Error + name collision, ACAPI returns
+    // APIERR_NAMEALREADYUSED AND fills firstConflictName. We must NOT
+    // collapse this into a generic error response, because the caller
+    // (the MCP wrapper) special-cases firstConflictName to surface
+    // ok=False with the name. Translate it to a structured success-
+    // shape response so the field reaches the caller.
+    if (err == APIERR_NAMEALREADYUSED && !firstConflictName.IsEmpty ()) {
+        GS::ObjectState response;
+        response.Add ("firstConflictName", firstConflictName);
+        return response;
+    }
     if (err != NoError) {
         return CreateErrorResponse (err, "ACAPI_Favorite_Import failed.");
     }

--- a/archicad-addon/Sources/FavoritesCommands.cpp
+++ b/archicad-addon/Sources/FavoritesCommands.cpp
@@ -496,23 +496,17 @@ GS::ObjectState ImportFavoritesCommand::Execute (const GS::ObjectState& paramete
     }
 
     API_FavoriteFolderHierarchy targetFolder;
-    if (parameters.Contains ("targetFolder")) {
-        GS::Array<GS::UniString> folders;
-        parameters.Get ("targetFolder", folders);
-        for (const GS::UniString& f : folders) {
-            targetFolder.Push (f);
-        }
+    GS::Array<GS::UniString> folders;
+    parameters.Get ("targetFolder", folders);
+    for (const GS::UniString& f : folders) {
+        targetFolder.Push (f);
     }
 
     bool importFolders = false;
-    if (parameters.Contains ("importFolders")) {
-        parameters.Get ("importFolders", importFolders);
-    }
+    parameters.Get ("importFolders", importFolders);
 
     GS::UniString policyStr = "Overwrite";
-    if (parameters.Contains ("conflictPolicy")) {
-        parameters.Get ("conflictPolicy", policyStr);
-    }
+    parameters.Get ("conflictPolicy", policyStr);
     const auto policy = ParseConflictPolicy (policyStr, API_FavoriteOverwrite);
 
     const IO::Location location = LocationFromPath (path);
@@ -591,9 +585,8 @@ GS::ObjectState ExportFavoritesCommand::Execute (const GS::ObjectState& paramete
     const IO::Location location = LocationFromPath (path);
 
     GSErrCode err = NoError;
-    if (parameters.Contains ("names")) {
-        GS::Array<GS::UniString> names;
-        parameters.Get ("names", names);
+    GS::Array<GS::UniString> names;
+    if (parameters.Get ("names", names)) {
         err = ACAPI_Favorite_Export (location, &names);
     } else {
         err = ACAPI_Favorite_Export (location, nullptr);

--- a/archicad-addon/Sources/FavoritesCommands.hpp
+++ b/archicad-addon/Sources/FavoritesCommands.hpp
@@ -41,3 +41,23 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+
+class ImportFavoritesCommand : public CommandBase
+{
+public:
+    ImportFavoritesCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class ExportFavoritesCommand : public CommandBase
+{
+public:
+    ExportFavoritesCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};

--- a/archicad-addon/Sources/LibraryCommands.cpp
+++ b/archicad-addon/Sources/LibraryCommands.cpp
@@ -309,8 +309,8 @@ GS::Optional<GS::UniString> GetAvailableLibraryPartsCommand::GetInputParametersS
         "type": "object",
         "properties": {
             "filterByTypeId": {
-                "type": "string",
-                "description": "Optional element-type filter. Examples: 'Door', 'Window', 'Object', 'Lamp', 'Macro', 'Picture'."
+                "$ref": "#/LibraryPartType",
+                "description": "Optional. Filter by libpart type (matches the value returned by LibPartTypeIdToString)."
             }
         },
         "additionalProperties": false
@@ -331,7 +331,7 @@ GS::Optional<GS::UniString> GetAvailableLibraryPartsCommand::GetResponseSchema (
                         "index": { "type": "integer" },
                         "documentName": { "type": "string" },
                         "fileName": { "type": "string" },
-                        "typeId": { "type": "string" }
+                        "typeId": { "$ref": "#/LibraryPartType" }
                     }
                 }
             },

--- a/archicad-addon/Sources/LibraryCommands.cpp
+++ b/archicad-addon/Sources/LibraryCommands.cpp
@@ -4,6 +4,7 @@
 #include "Folder.hpp"
 #include "File.hpp"
 #include "FileSystem.hpp"
+#include "GSUnID.hpp"
 
 AddFilesToEmbeddedLibraryCommand::AddFilesToEmbeddedLibraryCommand () :
     CommandBase (CommonSchema::Used)
@@ -291,3 +292,113 @@ GS::ObjectState ReloadLibrariesCommand::Execute (const GS::ObjectState& /*parame
 
     return CreateSuccessfulExecutionResult ();
 }
+
+GetAvailableLibraryPartsCommand::GetAvailableLibraryPartsCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String GetAvailableLibraryPartsCommand::GetName () const
+{
+    return "GetAvailableLibraryParts";
+}
+
+GS::Optional<GS::UniString> GetAvailableLibraryPartsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "filterByTypeId": {
+                "type": "string",
+                "description": "Optional element-type filter. Examples: 'Door', 'Window', 'Object', 'Lamp', 'Stair'."
+            }
+        },
+        "additionalProperties": false
+    })";
+}
+
+GS::Optional<GS::UniString> GetAvailableLibraryPartsCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "libraryParts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "guid": { "type": "string" },
+                        "index": { "type": "integer" },
+                        "documentName": { "type": "string" },
+                        "fileName": { "type": "string" },
+                        "typeId": { "type": "string" }
+                    }
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["libraryParts"]
+    })";
+}
+
+static GS::UniString LibPartTypeIdToString (Int32 typeID)
+{
+    switch (typeID) {
+        case API_ZombieLibID:        return "Zombie";
+        case APILib_SpecID:          return "Spec";
+        case APILib_WindowID:        return "Window";
+        case APILib_DoorID:          return "Door";
+        case APILib_ObjectID:        return "Object";
+        case APILib_LampID:          return "Lamp";
+        case APILib_RoomID:          return "Room";
+        case APILib_PropertyID:      return "Property";
+        case APILib_PlanSignID:      return "PlanSign";
+        case APILib_LabelID:         return "Label";
+        case APILib_MacroID:         return "Macro";
+        case APILib_PictID:          return "Picture";
+        case APILib_ListSchemeID:    return "ListScheme";
+        case APILib_SkylightID:      return "Skylight";
+        case APILib_OpeningSymbolID: return "OpeningSymbol";
+        default:                     return GS::UniString::Printf ("Type%d", typeID);
+    }
+}
+
+GS::ObjectState GetAvailableLibraryPartsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::UniString filterTypeId;
+    parameters.Get ("filterByTypeId", filterTypeId);
+
+    Int32 partCount = 0;
+    GSErrCode err = ACAPI_LibraryPart_GetNum (&partCount);
+    if (err != NoError) {
+        return CreateErrorResponse (err, "Failed to enumerate library parts.");
+    }
+
+    GS::ObjectState response;
+    const auto& adder = response.AddList<GS::ObjectState> ("libraryParts");
+
+    for (Int32 i = 1; i <= partCount; ++i) {
+        API_LibPart libPart = {};
+        libPart.index = i;
+        err = ACAPI_LibraryPart_Get (&libPart);
+        if (err != NoError) {
+            continue;
+        }
+
+        GS::UniString typeId = LibPartTypeIdToString (libPart.typeID);
+        if (!filterTypeId.IsEmpty () && typeId != filterTypeId) {
+            continue;
+        }
+
+        GS::ObjectState entry;
+        entry.Add ("guid", GS::UnID (libPart.ownUnID).GetMainGuid ().ToUniString ());
+        entry.Add ("index", static_cast<Int32> (libPart.index));
+        entry.Add ("documentName", GS::UniString (libPart.docu_UName));
+        entry.Add ("fileName", GS::UniString (libPart.file_UName));
+        entry.Add ("typeId", typeId);
+        adder (entry);
+    }
+
+    return response;
+}
+

--- a/archicad-addon/Sources/LibraryCommands.cpp
+++ b/archicad-addon/Sources/LibraryCommands.cpp
@@ -111,7 +111,7 @@ GS::ObjectState AddFilesToEmbeddedLibraryCommand::Execute (const GS::ObjectState
                 libPart.typeID = APILib_LabelID;
             } else if (typeStr == "Macro") {
                 libPart.typeID = APILib_MacroID;
-            } else if (typeStr == "Pict") {
+            } else if (typeStr == "Pict" || typeStr == "Picture") {
                 libPart.typeID = APILib_PictID;
             } else if (typeStr == "ListScheme") {
                 libPart.typeID = APILib_ListSchemeID;
@@ -382,6 +382,13 @@ GS::ObjectState GetAvailableLibraryPartsCommand::Execute (const GS::ObjectState&
 {
     GS::UniString filterTypeId;
     parameters.Get ("filterByTypeId", filterTypeId);
+    // `LibPartTypeIdToString` emits "Picture" for APILib_PictID, but the
+    // shared LibraryPartType enum keeps both "Pict" (legacy
+    // AddFilesToEmbeddedLibrary input) and "Picture" (this output).
+    // Normalise so callers can filter by either spelling.
+    if (filterTypeId == "Pict") {
+        filterTypeId = "Picture";
+    }
 
     Int32 partCount = 0;
     GSErrCode err = ACAPI_LibraryPart_GetNum (&partCount);

--- a/archicad-addon/Sources/LibraryCommands.cpp
+++ b/archicad-addon/Sources/LibraryCommands.cpp
@@ -334,10 +334,25 @@ GS::Optional<GS::UniString> GetAvailableLibraryPartsCommand::GetResponseSchema (
                         "typeId": { "type": "string" }
                     }
                 }
+            },
+            "skippedCount": {
+                "type": "integer",
+                "description": "Library parts that ACAPI_LibraryPart_Get failed to read. Non-zero means the inventory is partial."
+            },
+            "skippedSample": {
+                "type": "array",
+                "description": "First five failed indices with their ACAPI error code, for diagnostic.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "index": { "type": "integer" },
+                        "code": { "type": "integer" }
+                    }
+                }
             }
         },
         "additionalProperties": false,
-        "required": ["libraryParts"]
+        "required": ["libraryParts", "skippedCount"]
     })";
 }
 
@@ -375,7 +390,11 @@ GS::ObjectState GetAvailableLibraryPartsCommand::Execute (const GS::ObjectState&
     }
 
     GS::ObjectState response;
-    const auto& adder = response.AddList<GS::ObjectState> ("libraryParts");
+    const auto& libpartAdder = response.AddList<GS::ObjectState> ("libraryParts");
+    const auto& skippedAdder = response.AddList<GS::ObjectState> ("skippedSample");
+
+    Int32 skippedCount = 0;
+    constexpr Int32 maxSkippedSample = 5;
 
     for (Int32 i = 1; i <= partCount; ++i) {
         API_LibPart libPart = {};
@@ -383,6 +402,13 @@ GS::ObjectState GetAvailableLibraryPartsCommand::Execute (const GS::ObjectState&
         err = ACAPI_LibraryPart_Get (&libPart);
         if (err != NoError) {
             // libPart.location is not allocated on failure.
+            if (skippedCount < maxSkippedSample) {
+                GS::ObjectState skipEntry;
+                skipEntry.Add ("index", i);
+                skipEntry.Add ("code", static_cast<Int32> (err));
+                skippedAdder (skipEntry);
+            }
+            ++skippedCount;
             continue;
         }
 
@@ -396,7 +422,7 @@ GS::ObjectState GetAvailableLibraryPartsCommand::Execute (const GS::ObjectState&
             entry.Add ("documentName", GS::UniString (libPart.docu_UName));
             entry.Add ("fileName", GS::UniString (libPart.file_UName));
             entry.Add ("typeId", typeId);
-            adder (entry);
+            libpartAdder (entry);
         }
 
         // ACAPI_LibraryPart_Get allocates libPart.location; free it on
@@ -405,6 +431,8 @@ GS::ObjectState GetAvailableLibraryPartsCommand::Execute (const GS::ObjectState&
         delete libPart.location;
         libPart.location = nullptr;
     }
+
+    response.Add ("skippedCount", skippedCount);
 
     return response;
 }

--- a/archicad-addon/Sources/LibraryCommands.cpp
+++ b/archicad-addon/Sources/LibraryCommands.cpp
@@ -310,7 +310,7 @@ GS::Optional<GS::UniString> GetAvailableLibraryPartsCommand::GetInputParametersS
         "properties": {
             "filterByTypeId": {
                 "type": "string",
-                "description": "Optional element-type filter. Examples: 'Door', 'Window', 'Object', 'Lamp', 'Stair'."
+                "description": "Optional element-type filter. Examples: 'Door', 'Window', 'Object', 'Lamp', 'Macro', 'Picture'."
             }
         },
         "additionalProperties": false
@@ -382,23 +382,29 @@ GS::ObjectState GetAvailableLibraryPartsCommand::Execute (const GS::ObjectState&
         libPart.index = i;
         err = ACAPI_LibraryPart_Get (&libPart);
         if (err != NoError) {
+            // libPart.location is not allocated on failure.
             continue;
         }
 
-        GS::UniString typeId = LibPartTypeIdToString (libPart.typeID);
-        if (!filterTypeId.IsEmpty () && typeId != filterTypeId) {
-            continue;
+        const GS::UniString typeId = LibPartTypeIdToString (libPart.typeID);
+        const bool matchesFilter = filterTypeId.IsEmpty () || typeId == filterTypeId;
+
+        if (matchesFilter) {
+            GS::ObjectState entry;
+            entry.Add ("guid", GS::UnID (libPart.ownUnID).GetMainGuid ().ToUniString ());
+            entry.Add ("index", static_cast<Int32> (libPart.index));
+            entry.Add ("documentName", GS::UniString (libPart.docu_UName));
+            entry.Add ("fileName", GS::UniString (libPart.file_UName));
+            entry.Add ("typeId", typeId);
+            adder (entry);
         }
 
-        GS::ObjectState entry;
-        entry.Add ("guid", GS::UnID (libPart.ownUnID).GetMainGuid ().ToUniString ());
-        entry.Add ("index", static_cast<Int32> (libPart.index));
-        entry.Add ("documentName", GS::UniString (libPart.docu_UName));
-        entry.Add ("fileName", GS::UniString (libPart.file_UName));
-        entry.Add ("typeId", typeId);
-        adder (entry);
+        // ACAPI_LibraryPart_Get allocates libPart.location; free it on
+        // every successful Get to avoid leaking ~one IO::Location per
+        // libpart (thousands per call).
+        delete libPart.location;
+        libPart.location = nullptr;
     }
 
     return response;
 }
-

--- a/archicad-addon/Sources/LibraryCommands.hpp
+++ b/archicad-addon/Sources/LibraryCommands.hpp
@@ -29,3 +29,12 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+class GetAvailableLibraryPartsCommand : public CommandBase
+{
+public:
+    GetAvailableLibraryPartsCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -63,6 +63,7 @@
 #define ACAPI_Revision_GetRVMChangesFromChangeIds(par1, par2) ACAPI_Database (APIDb_GetRVMChangesFromChangeIdsID, (void*)par1, par2)
 
 #define ACAPI_LibraryPart_Register(par1) ACAPI_LibPart_Register(par1)
+#define ACAPI_LibraryPart_GetNum(par1) ACAPI_LibPart_GetNum(par1)
 #define ACAPI_LibraryPart_GetParams ACAPI_LibPart_GetParams
 #define ACAPI_LibraryPart_GetParamValues(par1) ACAPI_Goodies(APIAny_GetParamValuesID,par1)
 

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -3809,6 +3809,8 @@
         "type": "string",
         "description": "Enumeration of available library part types.",
         "enum": [
+            "Zombie",
+            "Spec",
             "Window",
             "Door",
             "Object",
@@ -3819,6 +3821,7 @@
             "Label",
             "Macro",
             "Pict",
+            "Picture",
             "ListScheme",
             "Skylight",
             "OpeningSymbol"


### PR DESCRIPTION
## Summary

Adds programmatic access to ArchiCAD's libpart inventory and project Favorites database. Builds on closed PR #379's `GetAvailableLibraryParts` idea but re-derived from main, AC29-compatible, with the original review feedback addressed.

### New commands

1. **`GetAvailableLibraryParts(filterByTypeId?)`** — enumerates the loaded libpart inventory. Returns `{guid, index, documentName, fileName, typeId}` per part, plus `skippedCount` + `skippedSample` (first 5 `{index, code}`) when `ACAPI_LibraryPart_Get` fails on individual indices. The `documentName` is the locale-translated name AC displays, which `CreateObjects` accepts as `libraryPartName`.

2. **`ImportFavorites(path, targetFolder?, importFolders?, conflictPolicy?)`** — wraps `ACAPI_Favorite_Import`. Loads a `.prefs` file or folder of Favorites into the current project. `conflictPolicy` is one of `Error`/`Skip`/`Overwrite` (default)/`Append`. On `Error` + name collision, returns `firstConflictName`.

3. **`ExportFavorites(path, names?)`** — wraps `ACAPI_Favorite_Export`. Dumps the project's Favorites database to a file or folder. `names=null` exports all; pass a subset list to filter.

Together with the existing `ApplyFavoritesToElementDefaults`, these enable the full "good GDL defaults" workflow programmatically: capture once in UI → export to `.prefs` → share/import across projects → apply for headless `CreateDoors`/`CreateWindows`/`CreateObjects`.

### Why this isn't a #379 re-submit

#379 bundled two unrelated features and was closed. This PR ships just `GetAvailableLibraryParts` (door/window libpart spec dropped) + adds the Favorites import/export wrappers. Independent, AC29-compatible, with the review feedback baked in.

## Changes addressing prior review notes

- Memory leak fix: `ACAPI_LibraryPart_Get` allocates `libPart.location`; loop now frees it on every successful Get (was ~7k leaked allocations per call on a stock AC29 library).
- `skippedCount` + `skippedSample` exposed so callers can distinguish "complete inventory" from "partial enumeration".
- AC29 compat: `APILib_*` enum prefix (vs the pre-AC28 `API_*`), `docu_UName` (wide-char) vs `docu_Name`, `GS::UnID(...).GetMainGuid().ToUniString()` for guid conversion.
- `ExportFavorites` response is an empty `GS::ObjectState` rather than `CreateSuccessfulExecutionResult()` (the latter injects `success: true` which `additionalProperties: false` rejects via 4009).
- `ImportFavorites` with `Error` policy: special-cases `APIERR_NAMEALREADYUSED + firstConflictName` so the name reaches the caller (was being swallowed by `CreateErrorResponse`).

## Test plan

Tested live on AC29 trial (build 3000, FRA) after deploy:

- [x] `GetAvailableLibraryParts(filterByTypeId="Object")` returns 3504 Object entries
- [x] `skippedCount=92`, `skippedSample` populated with `{index, code}` pairs
- [x] `ExportFavorites` writes `.prefs` (131KB) for a project with existing Favorites
- [x] `ImportFavorites` round-trips the exported file with `Overwrite` policy → ok
- [x] `ImportFavorites` with `Error` policy hits an existing Favorite → returns `firstConflictName` ("150/300 Blocs d'entrelacement préfabriqués")

Also build-tested for AC28 with ACAPI 28.4001 SDK + v142 toolset (no source changes needed; same enum names).

## Files

- `archicad-addon/Sources/LibraryCommands.cpp` + `.hpp` — `GetAvailableLibraryParts`
- `archicad-addon/Sources/FavoritesCommands.cpp` + `.hpp` — `ImportFavorites` / `ExportFavorites`
- `archicad-addon/Sources/AddOnMain.cpp` — 3 `RegisterCommand` calls
