### PR TITLE
feat(lamps): add CreateLamps for API_LampID-classified library parts

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -358,7 +358,7 @@ GSErrCode Initialize (void)
             "Creates Object elements based on the given parameters."
         );
         err |= RegisterCommand<CreateLampsCommand> (
-            elementCommands, "1.0.0",
+            elementCommands, "1.4.1",
             "Creates Lamp elements (e.g. ceiling lights, wall sconces, table lamps) based on the given parameters. Parallel to CreateObjects but uses AC subtype API_LampID, which is required for libparts that AC classifies as Lamp rather than Object (Lampe, Lampe de chevet, Lustre, Applique murale, etc.)."
         );
         err |= RegisterCommand<CreateMeshesCommand> (

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -359,7 +359,7 @@ GSErrCode Initialize (void)
         );
         err |= RegisterCommand<CreateLampsCommand> (
             elementCommands, "1.4.1",
-            "Creates Lamp elements (e.g. ceiling lights, wall sconces, table lamps) based on the given parameters. Parallel to CreateObjects but uses AC subtype API_LampID, which is required for libparts that AC classifies as Lamp rather than Object (Lampe, Lampe de chevet, Lustre, Applique murale, etc.)."
+            "Creates Lamp elements based on the given parameters."
         );
         err |= RegisterCommand<CreateMeshesCommand> (
             elementCommands, "1.1.9",

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -357,6 +357,10 @@ GSErrCode Initialize (void)
             elementCommands, "1.0.3",
             "Creates Object elements based on the given parameters."
         );
+        err |= RegisterCommand<CreateLampsCommand> (
+            elementCommands, "1.0.0",
+            "Creates Lamp elements (e.g. ceiling lights, wall sconces, table lamps) based on the given parameters. Parallel to CreateObjects but uses AC subtype API_LampID, which is required for libparts that AC classifies as Lamp rather than Object (Lampe, Lampe de chevet, Lustre, Applique murale, etc.)."
+        );
         err |= RegisterCommand<CreateMeshesCommand> (
             elementCommands, "1.1.9",
             "Creates Mesh elements based on the given parameters."

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -645,26 +645,29 @@ GS::Optional<GS::ObjectState> CreatePolylinesCommand::SetTypeSpecificParameters 
     return {};
 }
 
-CreateObjectsCommand::CreateObjectsCommand () :
-    CreateElementsCommandBase ("CreateObjects", API_ObjectID, "objectsData")
+// Shared schema builder for CreateObjects and CreateLamps.
+//
+// API_LampType is a typedef alias of API_ObjectType in APIdefs_Elements.h
+// (verified across AC25..29), so the two commands differ only in name,
+// elemTypeID, JSON array field name, and the singular noun / description
+// used in the schema.
+static GS::UniString BuildLibraryPartBasedSchema (const char* arrayFieldName,
+                                                  const char* elementSingularName,
+                                                  const char* libraryPartNameDescription)
 {
-}
-
-GS::Optional<GS::UniString> CreateObjectsCommand::GetInputParametersSchema () const
-{
-    return R"({
+    return GS::UniString::Printf (R"({
         "type": "object",
         "properties": {
-            "objectsData": {
+            "%s": {
                 "type": "array",
-                "description": "Array of data to create Objects.",
+                "description": "Array of data to create %ss.",
                 "items": {
                     "type": "object",
-                    "description": "The parameters of the new Object.",
+                    "description": "The parameters of the new %s.",
                     "properties": {
                         "libraryPartName": {
                             "type": "string",
-                            "description" : "The name of the library part to use."	
+                            "description" : "%s"
                         },
                         "coordinates": {
                             "$ref": "#/Coordinate3D"
@@ -683,9 +686,22 @@ GS::Optional<GS::UniString> CreateObjectsCommand::GetInputParametersSchema () co
         },
         "additionalProperties": false,
         "required": [
-            "objectsData"
+            "%s"
         ]
-    })";
+    })",
+    arrayFieldName, elementSingularName, elementSingularName,
+    libraryPartNameDescription, arrayFieldName);
+}
+
+CreateObjectsCommand::CreateObjectsCommand () :
+    CreateElementsCommandBase ("CreateObjects", API_ObjectID, "objectsData")
+{
+}
+
+GS::Optional<GS::UniString> CreateObjectsCommand::GetInputParametersSchema () const
+{
+    return BuildLibraryPartBasedSchema ("objectsData", "Object",
+                                        "The name of the library part to use.");
 }
 
 constexpr const char* ParameterValueFieldName = "value";
@@ -767,7 +783,15 @@ static void ChangeParams (API_AddParType**& params, const GS::HashTable<GS::Stri
 	}
 }
 
-GS::Optional<GS::ObjectState> CreateObjectsCommand::SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const
+// Shared placement logic for CreateObjects and CreateLamps.
+//
+// element.object and element.lamp alias the same union storage in
+// API_Element (API_LampType is a typedef of API_ObjectType across the
+// AC25..29 SDKs we target), so writing through element.object.* is
+// correct for both API_ObjectID and API_LampID code paths.
+static GS::Optional<GS::ObjectState> SetLibraryPartElementParameters (
+    API_Element& element, API_ElementMemo& memo,
+    const Stories& stories, const GS::ObjectState& parameters)
 {
     GS::UniString uName;
     parameters.Get ("libraryPartName", uName);
@@ -779,7 +803,7 @@ GS::Optional<GS::ObjectState> CreateObjectsCommand::SetTypeSpecificParameters (A
     delete libPart.location;
 
     if (err != NoError) {
-        return CreateErrorResponse (err, GS::UniString::Printf ("Not found library part with name '%T'", uName.ToPrintf()));
+        return CreateErrorResponse (err, GS::UniString::Printf ("Not found library part with name '%T'", uName.ToPrintf ()));
     }
 
     element.object.libInd = libPart.index;
@@ -802,19 +826,22 @@ GS::Optional<GS::ObjectState> CreateObjectsCommand::SetTypeSpecificParameters (A
         element.object.xRatio = dimensions.x;
         element.object.yRatio = dimensions.y;
         GS::ObjectState os (ParameterValueFieldName, dimensions.z);
-        ChangeParams(memo.params, {{"ZZYZX", os}});
+        ChangeParams (memo.params, {{"ZZYZX", os}});
     }
 
     return {};
 }
 
+GS::Optional<GS::ObjectState> CreateObjectsCommand::SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const
+{
+    return SetLibraryPartElementParameters (element, memo, stories, parameters);
+}
+
 // CreateLamps — parallel to CreateObjects but for AC subtype Lamp.
-// `API_LampType` is a typedef alias of `API_ObjectType` in
-// `APIdefs_Elements.h`, so the field layout and per-element placement
-// logic are identical. The only difference is the element typeID
-// (`API_LampID`), which routes AC through the lamp-specific create
-// path. Without this command, lamp libparts cannot be placed via
-// Tapir — `CreateObjects` rejects them with `APIERR_NOTSUPPORTED`.
+// Without this command, lamp libparts cannot be placed via Tapir —
+// CreateObjects rejects them with APIERR_NOTSUPPORTED. The schema and
+// placement logic are shared via BuildLibraryPartBasedSchema and
+// SetLibraryPartElementParameters above.
 CreateLampsCommand::CreateLampsCommand () :
     CreateElementsCommandBase ("CreateLamps", API_LampID, "lampsData")
 {
@@ -822,84 +849,13 @@ CreateLampsCommand::CreateLampsCommand () :
 
 GS::Optional<GS::UniString> CreateLampsCommand::GetInputParametersSchema () const
 {
-    return R"({
-        "type": "object",
-        "properties": {
-            "lampsData": {
-                "type": "array",
-                "description": "Array of data to create Lamps.",
-                "items": {
-                    "type": "object",
-                    "description": "The parameters of the new Lamp.",
-                    "properties": {
-                        "libraryPartName": {
-                            "type": "string",
-                            "description" : "The name of the lamp library part to use."
-                        },
-                        "coordinates": {
-                            "$ref": "#/Coordinate3D"
-                        },
-                        "dimensions": {
-                            "$ref": "#/Dimensions3D"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required" : [
-                        "libraryPartName",
-                        "coordinates"
-                    ]
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "lampsData"
-        ]
-    })";
+    return BuildLibraryPartBasedSchema ("lampsData", "Lamp",
+                                        "The name of the lamp library part to use.");
 }
 
 GS::Optional<GS::ObjectState> CreateLampsCommand::SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const
 {
-    // Identical logic to CreateObjects since API_LampType == API_ObjectType.
-    // We access via `element.lamp.*` to make the intent explicit at the
-    // call site, but the underlying memory and field offsets are the same.
-    GS::UniString uName;
-    parameters.Get ("libraryPartName", uName);
-
-    API_LibPart libPart = {};
-    GS::ucscpy (libPart.docu_UName, uName.ToUStr ());
-
-    GSErrCode err = ACAPI_LibraryPart_Search (&libPart, false, true);
-    delete libPart.location;
-
-    if (err != NoError) {
-        return CreateErrorResponse (err, GS::UniString::Printf ("Not found library part with name '%T'", uName.ToPrintf ()));
-    }
-
-    element.lamp.libInd = libPart.index;
-
-    GS::ObjectState coordinates;
-    if (parameters.Get ("coordinates", coordinates)) {
-        const API_Coord3D apiCoordinate = Get3DCoordinateFromObjectState (coordinates);
-
-        element.lamp.pos.x = apiCoordinate.x;
-        element.lamp.pos.y = apiCoordinate.y;
-
-        const auto floorIndexAndOffset = GetFloorIndexAndOffset (apiCoordinate.z, stories);
-        element.header.floorInd = floorIndexAndOffset.first;
-        element.lamp.level = floorIndexAndOffset.second;
-    }
-
-    if (parameters.Get ("dimensions", coordinates)) {
-        const API_Coord3D dimensions = Get3DCoordinateFromObjectState (coordinates);
-
-        element.lamp.xRatio = dimensions.x;
-        element.lamp.yRatio = dimensions.y;
-        GS::ObjectState os (ParameterValueFieldName, dimensions.z);
-        ChangeParams (memo.params, {{"ZZYZX", os}});
-    }
-
-    return {};
+    return SetLibraryPartElementParameters (element, memo, stories, parameters);
 }
 
 CreateMeshesCommand::CreateMeshesCommand () :

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -809,14 +809,12 @@ GS::Optional<GS::ObjectState> CreateObjectsCommand::SetTypeSpecificParameters (A
 }
 
 // CreateLamps — parallel to CreateObjects but for AC subtype Lamp.
-// API_LampType is a typedef alias of API_ObjectType in APIdefs_Elements.h
-// (line 5713), so the field layout and per-element placement logic are
-// identical. The only difference is the element typeID — `API_LampID` —
-// which routes AC's element-create code through the lamp-specific path
-// instead of the generic object path. Without this command, lamp
-// libparts (Lampe, Lampe de chevet, Lustre, Applique murale, …) cannot
-// be placed via Tapir — `CreateObjects` rejects them with
-// `-2130313112 Failed to create new Object`.
+// `API_LampType` is a typedef alias of `API_ObjectType` in
+// `APIdefs_Elements.h`, so the field layout and per-element placement
+// logic are identical. The only difference is the element typeID
+// (`API_LampID`), which routes AC through the lamp-specific create
+// path. Without this command, lamp libparts cannot be placed via
+// Tapir — `CreateObjects` rejects them with `APIERR_NOTSUPPORTED`.
 CreateLampsCommand::CreateLampsCommand () :
     CreateElementsCommandBase ("CreateLamps", API_LampID, "lampsData")
 {

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -808,6 +808,102 @@ GS::Optional<GS::ObjectState> CreateObjectsCommand::SetTypeSpecificParameters (A
     return {};
 }
 
+// CreateLamps — parallel to CreateObjects but for AC subtype Lamp.
+// API_LampType is a typedef alias of API_ObjectType in APIdefs_Elements.h
+// (line 5713), so the field layout and per-element placement logic are
+// identical. The only difference is the element typeID — `API_LampID` —
+// which routes AC's element-create code through the lamp-specific path
+// instead of the generic object path. Without this command, lamp
+// libparts (Lampe, Lampe de chevet, Lustre, Applique murale, …) cannot
+// be placed via Tapir — `CreateObjects` rejects them with
+// `-2130313112 Failed to create new Object`.
+CreateLampsCommand::CreateLampsCommand () :
+    CreateElementsCommandBase ("CreateLamps", API_LampID, "lampsData")
+{
+}
+
+GS::Optional<GS::UniString> CreateLampsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "lampsData": {
+                "type": "array",
+                "description": "Array of data to create Lamps.",
+                "items": {
+                    "type": "object",
+                    "description": "The parameters of the new Lamp.",
+                    "properties": {
+                        "libraryPartName": {
+                            "type": "string",
+                            "description" : "The name of the lamp library part to use."
+                        },
+                        "coordinates": {
+                            "$ref": "#/Coordinate3D"
+                        },
+                        "dimensions": {
+                            "$ref": "#/Dimensions3D"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required" : [
+                        "libraryPartName",
+                        "coordinates"
+                    ]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "lampsData"
+        ]
+    })";
+}
+
+GS::Optional<GS::ObjectState> CreateLampsCommand::SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const
+{
+    // Identical logic to CreateObjects since API_LampType == API_ObjectType.
+    // We access via `element.lamp.*` to make the intent explicit at the
+    // call site, but the underlying memory and field offsets are the same.
+    GS::UniString uName;
+    parameters.Get ("libraryPartName", uName);
+
+    API_LibPart libPart = {};
+    GS::ucscpy (libPart.docu_UName, uName.ToUStr ());
+
+    GSErrCode err = ACAPI_LibraryPart_Search (&libPart, false, true);
+    delete libPart.location;
+
+    if (err != NoError) {
+        return CreateErrorResponse (err, GS::UniString::Printf ("Not found library part with name '%T'", uName.ToPrintf ()));
+    }
+
+    element.lamp.libInd = libPart.index;
+
+    GS::ObjectState coordinates;
+    if (parameters.Get ("coordinates", coordinates)) {
+        const API_Coord3D apiCoordinate = Get3DCoordinateFromObjectState (coordinates);
+
+        element.lamp.pos.x = apiCoordinate.x;
+        element.lamp.pos.y = apiCoordinate.y;
+
+        const auto floorIndexAndOffset = GetFloorIndexAndOffset (apiCoordinate.z, stories);
+        element.header.floorInd = floorIndexAndOffset.first;
+        element.lamp.level = floorIndexAndOffset.second;
+    }
+
+    if (parameters.Get ("dimensions", coordinates)) {
+        const API_Coord3D dimensions = Get3DCoordinateFromObjectState (coordinates);
+
+        element.lamp.xRatio = dimensions.x;
+        element.lamp.yRatio = dimensions.y;
+        GS::ObjectState os (ParameterValueFieldName, dimensions.z);
+        ChangeParams (memo.params, {{"ZZYZX", os}});
+    }
+
+    return {};
+}
+
 CreateMeshesCommand::CreateMeshesCommand () :
     CreateElementsCommandBase ("CreateMeshes", API_MeshID, "meshesData")
 {}

--- a/archicad-addon/Sources/ElementCreationCommands.hpp
+++ b/archicad-addon/Sources/ElementCreationCommands.hpp
@@ -57,6 +57,14 @@ public:
     virtual GS::Optional<GS::ObjectState> SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const override;
 };
 
+class CreateLampsCommand : public CreateElementsCommandBase
+{
+public:
+    CreateLampsCommand ();
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::ObjectState> SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const override;
+};
+
 class CreateMeshesCommand : public CreateElementsCommandBase
 {
 public:


### PR DESCRIPTION
## Summary

Adds `CreateLamps`, a sibling to the existing `CreateObjects` command that places library parts Archicad classifies as `API_LampID` rather than `API_ObjectID`. Without this command, Lamp-subtype libparts cannot be placed via Tapir because `CreateObjects` rejects them with `APIERR_NOTSUPPORTED`.

Implementation mirrors `CreateObjects` via the `API_LampType == API_ObjectType` typedef. Field layout and placement logic are identical; the only difference is the element typeID (`API_LampID`), which routes Archicad through the lamp-specific create path.

## Schema

Same shape as `CreateObjects`:

```json
{
  "lampsData": [
    {
      "libraryPartName": "Lustre",
      "coordinates": { "x": 0, "y": 0, "z": 0 }
    }
  ]
}
```

`libraryPartName` is the libpart's `docu_UName` (free-form string, looked up via `ACAPI_LibraryPart_Search`).

## Why

Tapir already routes `API_LampID` through several read paths (`GetTypesOfElements`, `GetElementsByType("Lamp")`, GDL parameter queries). Creation was the missing capability.

Targets Tapir 1.4.1. Independent of #381.

## Test Plan

- `CreateLamps` with `libraryPartName: "Lustre"` places the lamp at the given coordinates on AC29 trial (FRA library).
- 25 FR lamp libparts smoke-tested, including `Applique murale`, `Lustre`, `Plafonnier 01`, `Suspension`, `Lampadaire 01`, `Spot 01`.
- AC29 Win Release build OK.
