### PR TITLE
chore(library): replace "Zombie" with "Unknown" catch-all in LibraryPartType (#381 review follow-up)

### DIFF
--- a/archicad-addon/Sources/LibraryCommands.cpp
+++ b/archicad-addon/Sources/LibraryCommands.cpp
@@ -359,7 +359,6 @@ GS::Optional<GS::UniString> GetAvailableLibraryPartsCommand::GetResponseSchema (
 static GS::UniString LibPartTypeIdToString (Int32 typeID)
 {
     switch (typeID) {
-        case API_ZombieLibID:        return "Zombie";
         case APILib_SpecID:          return "Spec";
         case APILib_WindowID:        return "Window";
         case APILib_DoorID:          return "Door";
@@ -374,7 +373,12 @@ static GS::UniString LibPartTypeIdToString (Int32 typeID)
         case APILib_ListSchemeID:    return "ListScheme";
         case APILib_SkylightID:      return "Skylight";
         case APILib_OpeningSymbolID: return "OpeningSymbol";
-        default:                     return GS::UniString::Printf ("Type%d", typeID);
+        // API_ZombieLibID (ACAPI's uninitialized / General-Object
+        // sentinel) and any future ACAPI subtype fall through here.
+        // We return the schema-valid catch-all "Unknown" rather than a
+        // dynamic "TypeN" value so callers can validate the response
+        // against the LibraryPartType enum without surprises.
+        default:                     return "Unknown";
     }
 }
 

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -3807,9 +3807,8 @@
     },
     "LibraryPartType": {
         "type": "string",
-        "description": "Enumeration of available library part types.",
+        "description": "Enumeration of available library part types. 'Unknown' is the schema-valid catch-all returned for any libpart whose typeID is not one of the named values (rare ACAPI sentinels and any future SDK subtype).",
         "enum": [
-            "Zombie",
             "Spec",
             "Window",
             "Door",
@@ -3824,7 +3823,8 @@
             "Picture",
             "ListScheme",
             "Skylight",
-            "OpeningSymbol"
+            "OpeningSymbol",
+            "Unknown"
         ]
     },
     "ElementsWithExecutionResults": {

--- a/docs/archicad-addon/common_schema_definitions.js
+++ b/docs/archicad-addon/common_schema_definitions.js
@@ -3807,8 +3807,9 @@ var gSchemaDefinitions = {
     },
     "LibraryPartType": {
         "type": "string",
-        "description": "Enumeration of available library part types.",
+        "description": "Enumeration of available library part types. 'Unknown' is the schema-valid catch-all returned for any libpart whose typeID is not one of the named values (rare ACAPI sentinels and any future SDK subtype).",
         "enum": [
+            "Spec",
             "Window",
             "Door",
             "Object",
@@ -3819,9 +3820,11 @@ var gSchemaDefinitions = {
             "Label",
             "Macro",
             "Pict",
+            "Picture",
             "ListScheme",
             "Skylight",
-            "OpeningSymbol"
+            "OpeningSymbol",
+            "Unknown"
         ]
     },
     "ElementsWithExecutionResults": {


### PR DESCRIPTION
## Summary

Address @tlorantfy's review feedback on the merged PR #381 (left 5 minutes before merge, not actioned in time):

> Probably using "All" instead of Zombie would make the usage, the documentation more clear

The `"Zombie"` token in `LibraryPartType` exposes ACAPI's `API_ZombieLibID` sentinel to API consumers — meaningless / confusing in user-facing docs. Renaming to `"All"` literally would mislead too, since omission of `filterByTypeId` already means "no filter" (`LibraryCommands.cpp:392`, `filterTypeId.IsEmpty()`).

## Changes

- Remove `"Zombie"` from the `LibraryPartType` enum.
- Add `"Unknown"` as a schema-valid catch-all so `LibPartTypeIdToString`'s `default:` branch can return a value that callers can validate against the enum, instead of the previous dynamic `"Type%d"` output (which silently violated the enum contract for any unmapped typeID).
- Update the enum description to document the catch-all semantics.
- Regenerate `docs/archicad-addon/common_schema_definitions.js` so it mirrors the full RFIX schema (the checked-in JS was already stale vs RFIX, missing `"Spec"` and `"Picture"`).

## Compatibility

- No behavioural change for callers that omit `filterByTypeId` — that path still means "no filter" via `filterTypeId.IsEmpty()`.
- Callers who passed `"Zombie"` explicitly (rare; the value was meaningless) now either omit the filter or use the explicit `"Unknown"` catch-all.

## Test plan

- [ ] Build add-on against AC25/26/27/28/29 — no compilation regression.
- [ ] `GetAvailableLibraryParts` returns `"Unknown"` (not `"TypeN"`) for any unmapped `typeID`, and `"Zombie"` no longer appears anywhere in the response.
- [ ] `LibraryPartType` enum used by `AddFilesToEmbeddedLibrary` (input filter) still accepts all real libpart types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
