### PR TITLE
feat(beams,columns): add cross section width/height parameters

### DIFF
--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -146,6 +146,16 @@ GS::Optional<GS::UniString> CreateColumnsCommand::GetInputParametersSchema () co
                         "axisRotationAngle": {
                             "type": "number",
                             "description": "Optional column rotation angle in radians."
+                        },
+                        "width": {
+                            "type": "number",
+                            "description": "Cross section width of the column. Applied to all segments.",
+                            "exclusiveMinimum": 0.0
+                        },
+                        "depth": {
+                            "type": "number",
+                            "description": "Cross section depth (height) of the column. Applied to all segments. Only effective for rectangular columns.",
+                            "exclusiveMinimum": 0.0
                         }
                     },
                     "additionalProperties": false,
@@ -162,7 +172,7 @@ GS::Optional<GS::UniString> CreateColumnsCommand::GetInputParametersSchema () co
     })";
 }
 
-GS::Optional<GS::ObjectState> CreateColumnsCommand::SetTypeSpecificParameters (API_Element& element, API_ElementMemo&, const Stories& stories, const GS::ObjectState& parameters) const
+GS::Optional<GS::ObjectState> CreateColumnsCommand::SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const
 {
     GS::ObjectState coordinates;
     parameters.Get ("coordinates", coordinates);
@@ -175,6 +185,23 @@ GS::Optional<GS::ObjectState> CreateColumnsCommand::SetTypeSpecificParameters (A
     element.column.origoPos.y = apiCoordinate.y;
     parameters.Get ("height", element.column.height);
     parameters.Get ("axisRotationAngle", element.column.axisRotationAngle);
+
+    double width = 0.0;
+    double depth = 0.0;
+    bool hasWidth = parameters.Get ("width", width);
+    bool hasDepth = parameters.Get ("depth", depth);
+
+    if ((hasWidth || hasDepth) && memo.columnSegments != nullptr) {
+        GSSize nSegments = BMGetPtrSize (reinterpret_cast<GSPtr>(memo.columnSegments)) / sizeof (API_ColumnSegmentType);
+        for (GSSize i = 0; i < nSegments; ++i) {
+            if (hasWidth) {
+                memo.columnSegments[i].assemblySegmentData.nominalWidth = width;
+            }
+            if (hasDepth) {
+                memo.columnSegments[i].assemblySegmentData.nominalHeight = depth;
+            }
+        }
+    }
 
     return {};
 }

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -1453,7 +1453,17 @@ GS::Optional<GS::UniString> CreateBeamsCommand::GetInputParametersSchema () cons
                         "offset": { "type": "number" },
                         "slantAngle": { "type": "number" },
                         "arcAngle": { "type": "number" },
-                        "verticalCurveHeight": { "type": "number" }
+                        "verticalCurveHeight": { "type": "number" },
+                        "width": {
+                            "type": "number",
+                            "description": "Cross section width of the beam. Applied to all segments.",
+                            "exclusiveMinimum": 0.0
+                        },
+                        "height": {
+                            "type": "number",
+                            "description": "Cross section height of the beam. Applied to all segments.",
+                            "exclusiveMinimum": 0.0
+                        }
                     },
                     "additionalProperties": false,
                     "required": ["begCoordinate", "endCoordinate", "zCoordinate"]
@@ -1465,7 +1475,7 @@ GS::Optional<GS::UniString> CreateBeamsCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::ObjectState> CreateBeamsCommand::SetTypeSpecificParameters (API_Element& element, API_ElementMemo&, const Stories& stories, const GS::ObjectState& parameters) const
+GS::Optional<GS::ObjectState> CreateBeamsCommand::SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const
 {
     element.beam.begC = Get2DCoordinateFromObjectState (*parameters.Get ("begCoordinate"));
     element.beam.endC = Get2DCoordinateFromObjectState (*parameters.Get ("endCoordinate"));
@@ -1492,6 +1502,21 @@ GS::Optional<GS::ObjectState> CreateBeamsCommand::SetTypeSpecificParameters (API
     auto curveHeight = GetOptionalDouble (parameters, "verticalCurveHeight");
     if (curveHeight.HasValue ()) {
         element.beam.verticalCurveHeight = curveHeight.Get ();
+    }
+
+    auto width = GetOptionalDouble (parameters, "width");
+    auto height = GetOptionalDouble (parameters, "height");
+
+    if ((width.HasValue () || height.HasValue ()) && memo.beamSegments != nullptr) {
+        GSSize nSegments = BMGetPtrSize (reinterpret_cast<GSPtr>(memo.beamSegments)) / sizeof (API_BeamSegmentType);
+        for (GSSize i = 0; i < nSegments; ++i) {
+            if (width.HasValue ()) {
+                memo.beamSegments[i].assemblySegmentData.nominalWidth = width.Get ();
+            }
+            if (height.HasValue ()) {
+                memo.beamSegments[i].assemblySegmentData.nominalHeight = height.Get ();
+            }
+        }
     }
 
     return {};


### PR DESCRIPTION
## Summary

Adds optional cross section dimension parameters:
- **CreateBeams**: `width` and `height` — sets the beam's cross section dimensions
- **CreateColumns**: `width` and `depth` — sets the column's cross section dimensions

Values are applied to **all segments** of the element via `assemblySegmentData.nominalWidth` / `nominalHeight` in the element memo, following the approach discussed in #382.

## Changes

- `ExtendedElementCommands.cpp`: Extended `CreateBeamsCommand` schema and `SetTypeSpecificParameters` to iterate over `memo.beamSegments` and set `nominalWidth`/`nominalHeight`
- `ElementCreationCommands.cpp`: Extended `CreateColumnsCommand` schema and `SetTypeSpecificParameters` to iterate over `memo.columnSegments` and set `nominalWidth`/`nominalHeight`

Both parameters are optional with `exclusiveMinimum: 0.0`. When omitted, the Archicad defaults are used (unchanged behavior).

## Notes

- Per @tlorantfy's guidance, width/height are applied to all segments when the default beam/column has multiple segments
- Modify commands (`ModifyBeams`/`ModifyColumns`) are not yet covered — they use `ACAPI_Element_Change` with a mask which doesn't touch memo segments. Segment modification would need a different approach (follow-up PR)

Closes #382