### PR TITLE
feat(stairs): add CreateStairs command

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -313,6 +313,10 @@ GSErrCode Initialize (void)
             elementCommands, "1.4.0",
             "Creates Beam elements based on the given parameters."
         );
+        err |= RegisterCommand<CreateStairsCommand> (
+            elementCommands, "1.5.0",
+            "Creates Stair elements based on the given baseline and parameters."
+        );
         err |= RegisterCommand<CreateSlabsCommand> (
             elementCommands, "1.0.3",
             "Creates Slab elements based on the given parameters."

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -1497,6 +1497,158 @@ GS::Optional<GS::ObjectState> CreateBeamsCommand::SetTypeSpecificParameters (API
     return {};
 }
 
+CreateStairsCommand::CreateStairsCommand () :
+    CreateElementsCommandBase ("CreateStairs", API_StairID, "stairsData")
+{
+}
+
+GS::Optional<GS::UniString> CreateStairsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "stairsData": {
+                "type": "array",
+                "description": "Array of data to create Stair elements.",
+                "items": {
+                    "type": "object",
+                    "description": "The parameters of the new Stair.",
+                    "properties": {
+                        "baseLinePoints": {
+                            "type": "array",
+                            "description": "2D coordinates defining the stair baseline polyline. Minimum 2 points for a straight stair, 3+ for L-shaped or U-shaped stairs.",
+                            "items": { "$ref": "#/Coordinate2D" },
+                            "minItems": 2
+                        },
+                        "zCoordinate": {
+                            "type": "number",
+                            "description": "The Z coordinate (absolute elevation) of the stair base."
+                        },
+                        "totalHeight": {
+                            "type": "number",
+                            "description": "Total height of the stair.",
+                            "exclusiveMinimum": 0.0
+                        },
+                        "flightWidth": {
+                            "type": "number",
+                            "description": "Width of the stair flight.",
+                            "exclusiveMinimum": 0.0
+                        },
+                        "stepNum": {
+                            "type": "integer",
+                            "description": "Number of risers (steps).",
+                            "minimum": 1
+                        },
+                        "riserHeight": {
+                            "type": "number",
+                            "description": "Height of each riser.",
+                            "exclusiveMinimum": 0.0
+                        },
+                        "treadDepth": {
+                            "type": "number",
+                            "description": "Depth (going) of each tread.",
+                            "exclusiveMinimum": 0.0
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": ["baseLinePoints", "zCoordinate"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["stairsData"]
+    })";
+}
+
+GS::Optional<GS::ObjectState> CreateStairsCommand::SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const
+{
+    GS::Array<GS::ObjectState> baseLinePoints;
+    parameters.Get ("baseLinePoints", baseLinePoints);
+    if (baseLinePoints.GetSize () < 2) {
+        return CreateErrorResponse (APIERR_BADPARS, "baseLinePoints must have at least 2 points.");
+    }
+
+    double zCoordinate = 0.0;
+    parameters.Get ("zCoordinate", zCoordinate);
+    const auto floorIndexAndOffset = GetFloorIndexAndOffset (zCoordinate, stories);
+    element.header.floorInd = floorIndexAndOffset.first;
+
+    auto totalHeight = GetOptionalDouble (parameters, "totalHeight");
+    if (totalHeight.HasValue ()) {
+        element.stair.totalHeight = totalHeight.Get ();
+    }
+    auto flightWidth = GetOptionalDouble (parameters, "flightWidth");
+    if (flightWidth.HasValue ()) {
+        element.stair.flightWidth = flightWidth.Get ();
+    }
+
+    Int32 stepNum = 0;
+    if (parameters.Get ("stepNum", stepNum)) {
+        element.stair.stepNum = static_cast<UInt32> (stepNum);
+    }
+
+    auto riserHeight = GetOptionalDouble (parameters, "riserHeight");
+    if (riserHeight.HasValue ()) {
+        element.stair.riserHeight = riserHeight.Get ();
+    }
+    auto treadDepth = GetOptionalDouble (parameters, "treadDepth");
+    if (treadDepth.HasValue ()) {
+        element.stair.treadDepth = treadDepth.Get ();
+    }
+
+    // Build the baseline polyline in the memo
+    const Int32 nCoords = static_cast<Int32> (baseLinePoints.GetSize ());
+
+    // Free existing baseline handles from defaults
+    if (memo.stairBaseLine.coords != nullptr) {
+        BMKillHandle (reinterpret_cast<GSHandle*>(&memo.stairBaseLine.coords));
+    }
+    if (memo.stairBaseLine.pends != nullptr) {
+        BMKillHandle (reinterpret_cast<GSHandle*>(&memo.stairBaseLine.pends));
+    }
+    if (memo.stairBaseLine.parcs != nullptr) {
+        BMKillHandle (reinterpret_cast<GSHandle*>(&memo.stairBaseLine.parcs));
+    }
+    if (memo.stairBaseLine.edgeData != nullptr) {
+        BMKillPtr (reinterpret_cast<GSPtr*>(&memo.stairBaseLine.edgeData));
+    }
+    if (memo.stairBaseLine.vertexData != nullptr) {
+        BMKillPtr (reinterpret_cast<GSPtr*>(&memo.stairBaseLine.vertexData));
+    }
+
+    // Allocate new baseline: polyline (not polygon), so no closing vertex needed
+    // Coords: index 1..nCoords (1-based), index 0 unused
+    memo.stairBaseLine.coords = reinterpret_cast<API_Coord**> (BMAllocateHandle ((nCoords + 1) * sizeof (API_Coord), ALLOCATE_CLEAR, 0));
+    memo.stairBaseLine.pends = reinterpret_cast<Int32**> (BMAllocateHandle (2 * sizeof (Int32), ALLOCATE_CLEAR, 0));
+    memo.stairBaseLine.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (0, ALLOCATE_CLEAR, 0));
+    memo.stairBaseLine.edgeData = reinterpret_cast<API_StairPolylineEdgeData*> (BMAllocatePtr (nCoords * sizeof (API_StairPolylineEdgeData), ALLOCATE_CLEAR, 0));
+    memo.stairBaseLine.vertexData = reinterpret_cast<API_StairPolylineVertexData*> (BMAllocatePtr ((nCoords + 1) * sizeof (API_StairPolylineVertexData), ALLOCATE_CLEAR, 0));
+
+    for (Int32 i = 0; i < nCoords; ++i) {
+        (*memo.stairBaseLine.coords)[i + 1] = Get2DCoordinateFromObjectState (baseLinePoints[i]);
+
+        // Set vertex data
+        memo.stairBaseLine.vertexData[i + 1].type = APISP_BaseLine;
+        memo.stairBaseLine.vertexData[i + 1].geometryType = APISG_Vertex;
+        memo.stairBaseLine.vertexData[i + 1].subElemId = 0;
+
+        // Set edge data (between vertices, so nCoords-1 edges)
+        if (i < nCoords - 1) {
+            memo.stairBaseLine.edgeData[i].type = APISP_BaseLine;
+            memo.stairBaseLine.edgeData[i].geometryType = APISG_Edge;
+            memo.stairBaseLine.edgeData[i].subElemId = 0;
+        }
+    }
+
+    (*memo.stairBaseLine.pends)[1] = nCoords;
+
+    memo.stairBaseLine.polygon.nCoords = nCoords;
+    memo.stairBaseLine.polygon.nSubPolys = 1;
+    memo.stairBaseLine.polygon.nArcs = 0;
+
+    return {};
+}
+
 CreateWindowsCommand::CreateWindowsCommand () :
     CommandBase (CommonSchema::Used)
 {

--- a/archicad-addon/Sources/ExtendedElementCommands.hpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.hpp
@@ -19,6 +19,14 @@ public:
     virtual GS::Optional<GS::ObjectState> SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const override;
 };
 
+class CreateStairsCommand : public CreateElementsCommandBase
+{
+public:
+    CreateStairsCommand ();
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::ObjectState> SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const override;
+};
+
 class CreateWindowsCommand : public CommandBase
 {
 public:


### PR DESCRIPTION
## Summary

Adds a new `CreateStairs` command that creates Stair elements from a baseline polyline and optional dimensional parameters.

This is a first implementation covering straight and multi-segment stairs (L-shaped, U-shaped). Subelements (risers, treads, structures) are generated automatically by Archicad from the main parameters.

## Parameters

| Parameter | Type | Required | Description |
|---|---|---|---|
| `baseLinePoints` | `Coordinate2D[]` | yes | 2D coordinates defining the stair baseline. Min 2 points. |
| `zCoordinate` | `number` | yes | Absolute elevation of the stair base |
| `totalHeight` | `number` | no | Total height of the stair |
| `flightWidth` | `number` | no | Width of the stair flight |
| `stepNum` | `integer` | no | Number of risers (steps) |
| `riserHeight` | `number` | no | Height of each riser |
| `treadDepth` | `number` | no | Depth (going) of each tread |

## Example

```json
{
  stairsData: [{
    baseLinePoints: [
      {x: 0.0, y: 0.0},
      {x: 3.0, y: 0.0}
    ],
    zCoordinate: 0.0,
    totalHeight: 2.80,
    flightWidth: 1.20,
    stepNum: 16,
    riserHeight: 0.175,
    treadDepth: 0.29
  }]
}
```

## Implementation

- Inherits from `CreateElementsCommandBase` (same pattern as CreateWalls, CreateBeams, etc.)
- Builds the baseline polyline in `memo.stairBaseLine` with proper `API_StairPolylineData` allocation (coords, pends, parcs, edgeData, vertexData)
- Frees default baseline handles before allocating new ones
- Edge/vertex data typed as `APISP_BaseLine` with proper geometry types

## Notes

- This is a minimal but functional first version — additional parameters (walking line position, baseline offset, stair rules, structure types) can be added in follow-up PRs
- No version guards needed — `API_StairType` and `API_StairPolylineData` are stable across AC25-AC29