### PR TITLE
Add GetDimensionData command for reading witness points

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -349,6 +349,10 @@ GSErrCode Initialize (void)
             elementCommands, "1.4.0",
             "Creates associative wall thickness dimensions for the given walls."
         );
+        err |= RegisterCommand<GetDimensionDataCommand> (
+            elementCommands, "1.5.0",
+            "Gets witness point data (coordinates, measured values) from existing dimension chains."
+        );
         err |= RegisterCommand<CreateZonesCommand> (
             elementCommands, "1.1.8",
             "Creates Zone elements based on the given parameters."

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -3048,7 +3048,7 @@ GS::ObjectState GetDimensionDataCommand::Execute (const GS::ObjectState& paramet
         if (err != NoError) {
             GS::ObjectState errorResult;
             errorResult.Add ("elementId", CreateGuidObjectState (element.header.guid));
-            errorResult.Add ("error", GS::UniString ("Failed to get element. Error code: ") + GS::ValueToUniString (err));
+            errorResult.Add ("error", GS::UniString (GS::UniString ("Failed to get element. Error code: ") + GS::ValueToUniString (err)));
             dimensionsData (errorResult);
             continue;
         }
@@ -3068,7 +3068,7 @@ GS::ObjectState GetDimensionDataCommand::Execute (const GS::ObjectState& paramet
         if (err != NoError) {
             GS::ObjectState errorResult;
             errorResult.Add ("elementId", CreateGuidObjectState (element.header.guid));
-            errorResult.Add ("error", GS::UniString ("Failed to get element memo. Error code: ") + GS::ValueToUniString (err));
+            errorResult.Add ("error", GS::UniString (GS::UniString ("Failed to get element memo. Error code: ") + GS::ValueToUniString (err)));
             dimensionsData (errorResult);
             continue;
         }

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -3048,7 +3048,7 @@ GS::ObjectState GetDimensionDataCommand::Execute (const GS::ObjectState& paramet
         if (err != NoError) {
             GS::ObjectState errorResult;
             errorResult.Add ("elementId", CreateGuidObjectState (element.header.guid));
-            errorResult.Add ("error", GS::UniString (GS::UniString ("Failed to get element. Error code: ") + GS::ValueToUniString (err)));
+            errorResult.Add ("error", GS::UniString::Printf ("Failed to get element. Error code: %d", static_cast<int> (err)));
             dimensionsData (errorResult);
             continue;
         }
@@ -3068,7 +3068,7 @@ GS::ObjectState GetDimensionDataCommand::Execute (const GS::ObjectState& paramet
         if (err != NoError) {
             GS::ObjectState errorResult;
             errorResult.Add ("elementId", CreateGuidObjectState (element.header.guid));
-            errorResult.Add ("error", GS::UniString (GS::UniString ("Failed to get element memo. Error code: ") + GS::ValueToUniString (err)));
+            errorResult.Add ("error", GS::UniString::Printf ("Failed to get element memo. Error code: %d", static_cast<int> (err)));
             dimensionsData (errorResult);
             continue;
         }

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -2932,6 +2932,182 @@ GS::ObjectState ModifyRoofsCommand::Execute (const GS::ObjectState& parameters, 
     });
 }
 
+// ============================================================================
+// GetDimensionData
+// ============================================================================
+
+GetDimensionDataCommand::GetDimensionDataCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String GetDimensionDataCommand::GetName () const
+{
+    return "GetDimensionData";
+}
+
+GS::Optional<GS::UniString> GetDimensionDataCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "elements": {
+                "type": "array",
+                "description": "The identifier of the dimension elements.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": { "$ref": "#/ElementId" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["elementId"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["elements"]
+    })";
+}
+
+GS::Optional<GS::UniString> GetDimensionDataCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "dimensionsData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": { "$ref": "#/ElementId" },
+                        "direction": { "$ref": "#/Coordinate2D" },
+                        "dimensionLinePosition": { "$ref": "#/Coordinate2D" },
+                        "witnessPoints": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "coordinate": { "$ref": "#/Coordinate2D" },
+                                    "coordinate3D": {
+                                        "type": "object",
+                                        "properties": {
+                                            "x": { "type": "number" },
+                                            "y": { "type": "number" },
+                                            "z": { "type": "number" }
+                                        }
+                                    },
+                                    "dimensionPosition": { "$ref": "#/Coordinate2D" },
+                                    "dimensionValue": { "type": "number" },
+                                    "witnessForm": { "type": "string" },
+                                    "witnessVal": { "type": "number" },
+                                    "baseElementId": { "$ref": "#/ElementId" }
+                                }
+                            }
+                        },
+                        "error": { "type": "string" }
+                    }
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["dimensionsData"]
+    })";
+}
+
+static GS::UniString WitnessFormToString (API_WitnessID witnessForm)
+{
+    switch (witnessForm) {
+        case APIWtn_None:   return "None";
+        case APIWtn_Small:  return "Small";
+        case APIWtn_Large:  return "Large";
+        case APIWtn_Fix:    return "Fix";
+        default:            return "Unknown";
+    }
+}
+
+GS::ObjectState GetDimensionDataCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::ObjectState> elements;
+    parameters.Get ("elements", elements);
+
+    GS::ObjectState response;
+    const auto& dimensionsData = response.AddList<GS::ObjectState> ("dimensionsData");
+
+    for (const GS::ObjectState& elementObj : elements) {
+        const GS::ObjectState* elementId = elementObj.Get ("elementId");
+        if (elementId == nullptr) {
+            GS::ObjectState errorResult;
+            errorResult.Add ("error", GS::UniString ("elementId is missing"));
+            dimensionsData (errorResult);
+            continue;
+        }
+
+        API_Element element = {};
+        element.header.guid = GetGuidFromObjectState (*elementId);
+        GSErrCode err = ACAPI_Element_Get (&element);
+        if (err != NoError) {
+            GS::ObjectState errorResult;
+            errorResult.Add ("elementId", CreateGuidObjectState (element.header.guid));
+            errorResult.Add ("error", GS::UniString ("Failed to get element. Error code: ") + GS::ValueToUniString (err));
+            dimensionsData (errorResult);
+            continue;
+        }
+
+        const API_ElemTypeID typeID = GetElemTypeId (element.header);
+        if (typeID != API_DimensionID) {
+            GS::ObjectState errorResult;
+            errorResult.Add ("elementId", CreateGuidObjectState (element.header.guid));
+            errorResult.Add ("error", GS::UniString ("Element is not a Dimension."));
+            dimensionsData (errorResult);
+            continue;
+        }
+
+        API_ElementMemo memo = {};
+        const GS::OnExit guard ([&memo] () { ACAPI_DisposeElemMemoHdls (&memo); });
+        err = ACAPI_Element_GetMemo (element.header.guid, &memo);
+        if (err != NoError) {
+            GS::ObjectState errorResult;
+            errorResult.Add ("elementId", CreateGuidObjectState (element.header.guid));
+            errorResult.Add ("error", GS::UniString ("Failed to get element memo. Error code: ") + GS::ValueToUniString (err));
+            dimensionsData (errorResult);
+            continue;
+        }
+
+        GS::ObjectState dimensionData;
+        dimensionData.Add ("elementId", CreateGuidObjectState (element.header.guid));
+        dimensionData.Add ("direction", Create2DCoordinateObjectState (element.dimension.direction));
+        dimensionData.Add ("dimensionLinePosition", Create2DCoordinateObjectState (element.dimension.refC));
+
+        const auto& witnessPoints = dimensionData.AddList<GS::ObjectState> ("witnessPoints");
+
+        if (memo.dimElems != nullptr && *memo.dimElems != nullptr) {
+            for (Int32 i = 0; i < element.dimension.nDimElem; ++i) {
+                const API_DimElem& dimElem = (*memo.dimElems)[i];
+
+                GS::ObjectState witnessPoint;
+
+                witnessPoint.Add ("coordinate", Create2DCoordinateObjectState (dimElem.base.loc));
+                witnessPoint.Add ("coordinate3D", Create3DCoordinateObjectState (dimElem.base.loc3D));
+                witnessPoint.Add ("dimensionPosition", Create2DCoordinateObjectState (dimElem.pos));
+                witnessPoint.Add ("dimensionValue", dimElem.dimVal);
+                witnessPoint.Add ("witnessForm", WitnessFormToString (dimElem.witnessForm));
+                witnessPoint.Add ("witnessVal", dimElem.witnessVal);
+
+                const API_Guid& baseGuid = dimElem.base.base.guid;
+                if (baseGuid != APINULLGuid) {
+                    witnessPoint.Add ("baseElementId", CreateGuidObjectState (baseGuid));
+                }
+
+                witnessPoints (witnessPoint);
+            }
+        }
+
+        dimensionsData (dimensionData);
+    }
+
+    return response;
+}
+
 ModifyColumnsCommand::ModifyColumnsCommand () :
     CommandBase (CommonSchema::Used)
 {

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -3008,9 +3008,7 @@ GS::ObjectState GetDimensionDataCommand::Execute (const GS::ObjectState& paramet
     for (const GS::ObjectState& elementObj : elements) {
         const GS::ObjectState* elementId = elementObj.Get ("elementId");
         if (elementId == nullptr) {
-            GS::ObjectState errorResult;
-            errorResult.Add ("error", GS::UniString ("elementId is missing"));
-            dimensionsData (errorResult);
+            dimensionsData (CreateErrorResponse (APIERR_BADPARS, "elementId is missing"));
             continue;
         }
 
@@ -3018,19 +3016,13 @@ GS::ObjectState GetDimensionDataCommand::Execute (const GS::ObjectState& paramet
         element.header.guid = GetGuidFromObjectState (*elementId);
         GSErrCode err = ACAPI_Element_Get (&element);
         if (err != NoError) {
-            GS::ObjectState errorResult;
-            errorResult.Add ("elementId", CreateGuidObjectState (element.header.guid));
-            errorResult.Add ("error", GS::UniString::Printf ("Failed to get element. Error code: %d", static_cast<int> (err)));
-            dimensionsData (errorResult);
+            dimensionsData (CreateErrorResponse (err, "Failed to get element"));
             continue;
         }
 
         const API_ElemTypeID typeID = GetElemTypeId (element.header);
         if (typeID != API_DimensionID) {
-            GS::ObjectState errorResult;
-            errorResult.Add ("elementId", CreateGuidObjectState (element.header.guid));
-            errorResult.Add ("error", GS::UniString ("Element is not a Dimension."));
-            dimensionsData (errorResult);
+            dimensionsData (CreateErrorResponse (APIERR_BADID, "Element is not a Dimension"));
             continue;
         }
 
@@ -3038,10 +3030,7 @@ GS::ObjectState GetDimensionDataCommand::Execute (const GS::ObjectState& paramet
         const GS::OnExit guard ([&memo] () { ACAPI_DisposeElemMemoHdls (&memo); });
         err = ACAPI_Element_GetMemo (element.header.guid, &memo);
         if (err != NoError) {
-            GS::ObjectState errorResult;
-            errorResult.Add ("elementId", CreateGuidObjectState (element.header.guid));
-            errorResult.Add ("error", GS::UniString::Printf ("Failed to get element memo. Error code: %d", static_cast<int> (err)));
-            dimensionsData (errorResult);
+            dimensionsData (CreateErrorResponse (err, "Failed to get element memo"));
             continue;
         }
 

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -2977,35 +2977,7 @@ GS::Optional<GS::UniString> GetDimensionDataCommand::GetResponseSchema () const
             "dimensionsData": {
                 "type": "array",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "elementId": { "$ref": "#/ElementId" },
-                        "direction": { "$ref": "#/Coordinate2D" },
-                        "dimensionLinePosition": { "$ref": "#/Coordinate2D" },
-                        "witnessPoints": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "coordinate": { "$ref": "#/Coordinate2D" },
-                                    "coordinate3D": {
-                                        "type": "object",
-                                        "properties": {
-                                            "x": { "type": "number" },
-                                            "y": { "type": "number" },
-                                            "z": { "type": "number" }
-                                        }
-                                    },
-                                    "dimensionPosition": { "$ref": "#/Coordinate2D" },
-                                    "dimensionValue": { "type": "number" },
-                                    "witnessForm": { "type": "string" },
-                                    "witnessVal": { "type": "number" },
-                                    "baseElementId": { "$ref": "#/ElementId" }
-                                }
-                            }
-                        },
-                        "error": { "type": "string" }
-                    }
+                    "$ref": "#/DimensionDataOrError"
                 }
             }
         },

--- a/archicad-addon/Sources/ExtendedElementCommands.hpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.hpp
@@ -178,3 +178,13 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+
+class GetDimensionDataCommand : public CommandBase
+{
+public:
+    GetDimensionDataCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -4044,5 +4044,60 @@
         "required": [
             "elements"
         ]
+    },
+    "DimensionData": {
+        "type": "object",
+        "description": "Dimension element data including witness points and geometry.",
+        "properties": {
+            "elementId": {
+                "$ref": "#/ElementId"
+            },
+            "direction": {
+                "$ref": "#/Coordinate2D"
+            },
+            "dimensionLinePosition": {
+                "$ref": "#/Coordinate2D"
+            },
+            "witnessPoints": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "coordinate": {
+                            "$ref": "#/Coordinate2D"
+                        },
+                        "coordinate3D": {
+                            "$ref": "#/Coordinate3D"
+                        },
+                        "dimensionPosition": {
+                            "$ref": "#/Coordinate2D"
+                        },
+                        "dimensionValue": {
+                            "type": "number"
+                        },
+                        "witnessForm": {
+                            "type": "string"
+                        },
+                        "witnessVal": {
+                            "type": "number"
+                        },
+                        "baseElementId": {
+                            "$ref": "#/ElementId"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "DimensionDataOrError": {
+        "type": "object",
+        "oneOf": [
+            {
+                "$ref": "#/DimensionData"
+            },
+            {
+                "$ref": "#/ErrorItem"
+            }
+        ]
     }
 }

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -4076,7 +4076,8 @@
                             "type": "number"
                         },
                         "witnessForm": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": ["None", "Small", "Large", "Fix", "Unknown"]
                         },
                         "witnessVal": {
                             "type": "number"


### PR DESCRIPTION
## Summary

- Adds new `GetDimensionData` command that reads witness point data from existing dimension chains
- Returns 2D/3D coordinates, measured values (`dimVal`), witness line form, and base element references for each witness point
- Enables automated model verification by comparing dimension values against reference plans

## Motivation

For some workflows, it's essential to verify that modeled elements match the dimensions shown on reference drawings. This command allows reading back the actual measured values from dimension chains placed in the model, enabling easier quality checks.

## Input / Output

**Input:** Array of dimension element GUIDs
```json
{ elements: [{ elementId: { guid: ... } }] }
```

**Output:** For each dimension: direction vector, dimension line position, and array of witness points with:
- `coordinate` / `coordinate3D` — witness point location
- `dimensionValue` — measured distance from previous witness point
- `dimensionPosition` — text position on the dimension line
- `witnessForm` / `witnessVal` — witness line style
- `baseElementId` — GUID of the element the witness point is associated with (if any)

## Test plan

- [ ] CI passes on all platforms (AC25–AC29, Win + Mac)
- [ ] Manual test: create dimension chain in Archicad, call `GetDimensionData`, verify coordinates and values match

🤖 Generated with [Claude Code](https://claude.com/claude-code)