### PR TITLE
feat(texts): add CreateTexts command for standalone Text elements

### DIFF
--- a/archicad-addon/Examples/create_texts.py
+++ b/archicad-addon/Examples/create_texts.py
@@ -1,0 +1,30 @@
+import aclib
+
+# Place a few standalone Text elements, then read them back to confirm.
+result = aclib.RunTapirCommand (
+    'CreateTexts', {
+        'textsData': [
+            {
+                'coordinate': {'x': 0.0, 'y': 0.0, 'z': 0.0},
+                'text': '100',
+                'height': 2.5
+            },
+            {
+                'coordinate': {'x': 5.0, 'y': 2.0, 'z': 0.0},
+                'text': '102',
+                'height': 2.5,
+                'justification': 'Center'
+            },
+            {
+                'coordinate': {'x': 10.0, 'y': 4.0, 'z': 0.0},
+                'text': 'multi\nline',
+                'height': 2.5,
+                'angle': 0.0
+            }
+        ]
+    })
+
+# Round-trip check: the created elements should be retrievable.
+elements = result['elements']
+details = aclib.RunTapirCommand ('GetDetailsOfElements', {'elements': elements})
+print(details)

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -373,6 +373,10 @@ GSErrCode Initialize (void)
             elementCommands, "1.2.5",
             "Creates Label elements based on the given parameters."
         );
+        err |= RegisterCommand<CreateTextsCommand> (
+            elementCommands, "1.4.2",
+            "Creates standalone Text elements based on the given parameters."
+        );
         err |= RegisterCommand<ModifyWallsCommand> (
             elementCommands, "1.4.0",
             "Modifies Wall elements based on the given parameters."

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -1221,3 +1221,136 @@ GS::Optional<GS::ObjectState> CreateLabelsCommand::SetTypeSpecificParameters (AP
 
     return {};
 }
+
+CreateTextsCommand::CreateTextsCommand () :
+    CreateElementsCommandBase ("CreateTexts", API_TextID, "textsData")
+{
+}
+
+GS::Optional<GS::UniString> CreateTextsCommand::GetInputParametersSchema () const
+{
+    return R"({
+    "type": "object",
+    "properties": {
+        "textsData": {
+            "type": "array",
+            "description": "Array of data to create Texts.",
+            "items": {
+                "type": "object",
+                "description": "The parameters of the new Text element.",
+                "properties": {
+                    "coordinate": {
+                        "$ref": "#/Coordinate3D",
+                        "description": "The placement position of the text. The z value is used to determine the floor when floorIndex is omitted."
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "The text content. Newlines create multiple lines."
+                    },
+                    "height": {
+                        "type": "number",
+                        "description": "The character height in millimeters. Optional; defaults to the Text tool default."
+                    },
+                    "pen": {
+                        "type": "integer",
+                        "description": "Optional pen attribute index."
+                    },
+                    "angle": {
+                        "type": "number",
+                        "description": "Optional rotation angle in radians."
+                    },
+                    "justification": {
+                        "type": "string",
+                        "description": "Optional text justification.",
+                        "enum": ["Left", "Center", "Right", "Full"]
+                    },
+                    "floorIndex": {
+                        "type": "integer",
+                        "description": "Optional floor index. If omitted, derived from the coordinate's z value."
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "coordinate",
+                    "text"
+                ]
+            }
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "textsData"
+    ]
+})";
+}
+
+GS::Optional<GS::ObjectState> CreateTextsCommand::SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const
+{
+    const GS::ObjectState* coordinateOS = parameters.Get ("coordinate");
+    if (coordinateOS == nullptr) {
+        return CreateErrorResponse (APIERR_BADPARS, "Missing 'coordinate' parameter");
+    }
+    API_Coord3D apiCoordinate = Get3DCoordinateFromObjectState (*coordinateOS);
+
+    short floorIndex = 0;
+    if (parameters.Get ("floorIndex", floorIndex)) {
+        element.header.floorInd = floorIndex;
+    } else {
+        const auto floorIndexAndOffset = GetFloorIndexAndOffset (apiCoordinate.z, stories);
+        element.header.floorInd = floorIndexAndOffset.first;
+    }
+
+    element.text.loc.x = apiCoordinate.x;
+    element.text.loc.y = apiCoordinate.y;
+
+    parameters.Get ("height", element.text.size);
+    parameters.Get ("pen", element.text.pen);
+    parameters.Get ("angle", element.text.angle);
+
+    GS::UniString justification;
+    if (parameters.Get ("justification", justification)) {
+        if (justification == "Left") {
+            element.text.just = APIJust_Left;
+        } else if (justification == "Center") {
+            element.text.just = APIJust_Center;
+        } else if (justification == "Right") {
+            element.text.just = APIJust_Right;
+        } else if (justification == "Full") {
+            element.text.just = APIJust_Full;
+        }
+    }
+
+    GS::UniString text;
+    if (!parameters.Get ("text", text)) {
+        return CreateErrorResponse (APIERR_BADPARS, "Missing 'text' parameter");
+    }
+
+#ifdef ServerMainVers_2800
+    delete memo.textContent;
+    memo.textContent = new GS::UniString { text };
+#else
+    memo.textContent = BMhAllClear ((text.GetLength () + 1) * sizeof (GS::uchar_t));
+    GS::ucscpy (reinterpret_cast<GS::uchar_t*> (*memo.textContent), text.ToUStr ());
+#endif
+
+    const GS::UniChar newlineChar = GS::UniChar (char ('\n'));
+    element.text.nLine = text.Count (newlineChar) + 1;
+    const Int32 numOfParagraphs = 1;
+    memo.paragraphs = reinterpret_cast<API_ParagraphType**> (BMhAll (numOfParagraphs * sizeof (API_ParagraphType)));
+    SetParagraph (memo.paragraphs, 0, 0, text.GetLength (), 1, 1, element.text.nLine);
+    SetRun (memo.paragraphs, 0, 0, 0, text.GetLength (), element.text.pen, element.text.faceBits, element.text.font, element.text.effectsBits, element.text.size);
+    Int32 lastEolPos = 0;
+    for (Int32 eolIndex = 0; eolIndex < element.text.nLine; ++eolIndex) {
+        Int32 eolPos = text.FindFirst (newlineChar, eolIndex == 0 ? 0 : lastEolPos + 1);
+        Int32 offset = (eolPos != MaxUIndex ? eolPos : text.GetLength ()) - lastEolPos - 1;
+        lastEolPos = eolPos;
+        SetEOL (memo.paragraphs, 0, eolIndex, offset);
+    }
+
+    element.text.width = 0;
+    element.text.height = 0;
+    element.text.nonBreaking = true;
+    element.text.useEolPos = true;
+
+    return {};
+}

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -1151,6 +1151,48 @@ static GSErrCode SetEOL (API_ParagraphType** paragraph, UInt32 parNum, UInt32 eo
 	return NoError;
 }
 
+static API_JustID ParseJustificationString (const GS::UniString& justification)
+{
+    if (justification == "Center") {
+        return APIJust_Center;
+    } else if (justification == "Right") {
+        return APIJust_Right;
+    } else if (justification == "Full") {
+        return APIJust_Full;
+    }
+    return APIJust_Left;
+}
+
+static void SetTextContentAndParagraphs (API_ElementMemo& memo, API_TextType& textData, const GS::UniString& text)
+{
+#ifdef ServerMainVers_2800
+    delete memo.textContent;
+    memo.textContent = new GS::UniString { text };
+#else
+    memo.textContent = BMhAllClear ((text.GetLength () + 1) * sizeof (GS::uchar_t));
+    GS::ucscpy (reinterpret_cast<GS::uchar_t*> (*memo.textContent), text.ToUStr ());
+#endif
+
+    const GS::UniChar newlineChar = GS::UniChar (char ('\n'));
+    textData.nLine = text.Count (newlineChar) + 1;
+    const Int32 numOfParagraphs = 1;
+    memo.paragraphs = reinterpret_cast<API_ParagraphType**> (BMhAll (numOfParagraphs * sizeof (API_ParagraphType)));
+    SetParagraph (memo.paragraphs, 0, 0, text.GetLength (), 1, 1, textData.nLine);
+    SetRun (memo.paragraphs, 0, 0, 0, text.GetLength (), textData.pen, textData.faceBits, textData.font, textData.effectsBits, textData.size);
+    Int32 lastEolPos = 0;
+    for (Int32 eolIndex = 0; eolIndex < textData.nLine; ++eolIndex) {
+        Int32 eolPos = text.FindFirst (newlineChar, eolIndex == 0 ? 0 : lastEolPos + 1);
+        Int32 offset = (eolPos != MaxUIndex ? eolPos : text.GetLength ()) - lastEolPos - 1;
+        lastEolPos = eolPos;
+        SetEOL (memo.paragraphs, 0, eolIndex, offset);
+    }
+
+    textData.width = 0;
+    textData.height = 0;
+    textData.nonBreaking = true;
+    textData.useEolPos = true;
+}
+
 GS::Optional<GS::ObjectState> CreateLabelsCommand::SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories&, const GS::ObjectState& parameters) const
 {
     parameters.Get ("floorInd", element.header.floorInd);
@@ -1191,32 +1233,7 @@ GS::Optional<GS::ObjectState> CreateLabelsCommand::SetTypeSpecificParameters (AP
         if (!parameters.Get ("text", text)) {
             return CreateErrorResponse (APIERR_BADPARS, "Missing 'text' parameter for text label");
         }
-#ifdef ServerMainVers_2800
-        delete memo.textContent;
-        memo.textContent = new GS::UniString { text };
-#else
-        memo.textContent = BMhAllClear ((text.GetLength () + 1) * sizeof (GS::uchar_t));
-        GS::ucscpy (reinterpret_cast<GS::uchar_t*> (*memo.textContent), text.ToUStr ());
-#endif
-
-        const GS::UniChar newlineChar = GS::UniChar (char ('\n'));
-        element.label.u.text.nLine = text.Count(newlineChar) + 1;
-	    const Int32 numOfParagraphs = 1;
-	    memo.paragraphs = reinterpret_cast<API_ParagraphType**> (BMhAll (numOfParagraphs * sizeof (API_ParagraphType)));
-        SetParagraph (memo.paragraphs, 0, 0, text.GetLength (), 1, 1, element.label.u.text.nLine);
-        SetRun (memo.paragraphs, 0, 0, 0, text.GetLength (), element.label.u.text.pen, element.label.u.text.faceBits, element.label.u.text.font, element.label.u.text.effectsBits, element.label.u.text.size);
-        Int32 lastEolPos = 0;
-        for (Int32 eolIndex = 0; eolIndex < element.label.u.text.nLine; ++eolIndex) {
-            Int32 eolPos = text.FindFirst (newlineChar, eolIndex == 0 ? 0 : lastEolPos + 1);
-            Int32 offset = (eolPos != MaxUIndex ? eolPos : text.GetLength ()) - lastEolPos - 1;
-            lastEolPos = eolPos;
-            SetEOL (memo.paragraphs, 0, eolIndex, offset);
-        }
-
-        element.label.u.text.width  = 0;
-        element.label.u.text.height = 0;
-        element.label.u.text.nonBreaking = true;
-        element.label.u.text.useEolPos = true;
+        SetTextContentAndParagraphs (memo, element.label.u.text, text);
     }
 
     return {};
@@ -1309,15 +1326,7 @@ GS::Optional<GS::ObjectState> CreateTextsCommand::SetTypeSpecificParameters (API
 
     GS::UniString justification;
     if (parameters.Get ("justification", justification)) {
-        if (justification == "Left") {
-            element.text.just = APIJust_Left;
-        } else if (justification == "Center") {
-            element.text.just = APIJust_Center;
-        } else if (justification == "Right") {
-            element.text.just = APIJust_Right;
-        } else if (justification == "Full") {
-            element.text.just = APIJust_Full;
-        }
+        element.text.just = ParseJustificationString (justification);
     }
 
     GS::UniString text;
@@ -1325,32 +1334,7 @@ GS::Optional<GS::ObjectState> CreateTextsCommand::SetTypeSpecificParameters (API
         return CreateErrorResponse (APIERR_BADPARS, "Missing 'text' parameter");
     }
 
-#ifdef ServerMainVers_2800
-    delete memo.textContent;
-    memo.textContent = new GS::UniString { text };
-#else
-    memo.textContent = BMhAllClear ((text.GetLength () + 1) * sizeof (GS::uchar_t));
-    GS::ucscpy (reinterpret_cast<GS::uchar_t*> (*memo.textContent), text.ToUStr ());
-#endif
-
-    const GS::UniChar newlineChar = GS::UniChar (char ('\n'));
-    element.text.nLine = text.Count (newlineChar) + 1;
-    const Int32 numOfParagraphs = 1;
-    memo.paragraphs = reinterpret_cast<API_ParagraphType**> (BMhAll (numOfParagraphs * sizeof (API_ParagraphType)));
-    SetParagraph (memo.paragraphs, 0, 0, text.GetLength (), 1, 1, element.text.nLine);
-    SetRun (memo.paragraphs, 0, 0, 0, text.GetLength (), element.text.pen, element.text.faceBits, element.text.font, element.text.effectsBits, element.text.size);
-    Int32 lastEolPos = 0;
-    for (Int32 eolIndex = 0; eolIndex < element.text.nLine; ++eolIndex) {
-        Int32 eolPos = text.FindFirst (newlineChar, eolIndex == 0 ? 0 : lastEolPos + 1);
-        Int32 offset = (eolPos != MaxUIndex ? eolPos : text.GetLength ()) - lastEolPos - 1;
-        lastEolPos = eolPos;
-        SetEOL (memo.paragraphs, 0, eolIndex, offset);
-    }
-
-    element.text.width = 0;
-    element.text.height = 0;
-    element.text.nonBreaking = true;
-    element.text.useEolPos = true;
+    SetTextContentAndParagraphs (memo, element.text, text);
 
     return {};
 }

--- a/archicad-addon/Sources/ElementCreationCommands.hpp
+++ b/archicad-addon/Sources/ElementCreationCommands.hpp
@@ -80,3 +80,11 @@ public:
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
     virtual GS::Optional<GS::ObjectState> SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const override;
 };
+
+class CreateTextsCommand : public CreateElementsCommandBase
+{
+public:
+    CreateTextsCommand ();
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::ObjectState> SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const override;
+};


### PR DESCRIPTION
## Summary

Adds a `CreateTexts` command for placing standalone **Text** elements (`API_TextID`), parallel to the existing `CreateLabels`.

Per-text parameters:
- `coordinate` (required) — placement position; the `z` value selects the floor when `floorIndex` is omitted
- `text` (required) — content; newlines produce multiple lines
- `height`, `pen`, `angle`, `justification` (`Left`/`Center`/`Right`/`Full`), `floorIndex` — all optional

Multi-line text is handled by building paragraph/run/EOL records from the newline-split content, reusing the same text-memo path as `CreateLabels` (`textContent` guarded for `ServerMainVers_2800`).

## Example

See `archicad-addon/Examples/create_texts.py`.

## Notes

- Compiles unchanged across the supported Archicad API versions (no version guard needed).
- Verified building locally against the AC29 DevKit; opened as draft so the full CI matrix can run.