### PR TITLE
feat(navigator): add GoToView command to activate a saved view

### DIFF
--- a/archicad-addon/Examples/go_to_view.py
+++ b/archicad-addon/Examples/go_to_view.py
@@ -16,8 +16,8 @@ viewMapTree = aclib.RunCommand('API.GetNavigatorItemTree', {'navigatorTreeId': {
 firstView = findFirstLeafView(viewMapTree['navigatorTree']['rootItem']['children'])
 
 if firstView is None:
-    print('No saved views found in the View Map; nothing to open.')
+    print('No saved views found in the View Map; nothing to go to.')
 else:
-    print(f"Opening view: {firstView.get('name', '<unnamed>')}")
-    result = aclib.RunTapirCommand('OpenView', {'navigatorItemId': firstView['navigatorItemId']})
+    print(f"Going to view: {firstView.get('name', '<unnamed>')}")
+    result = aclib.RunTapirCommand('GoToView', {'navigatorItemId': firstView['navigatorItemId']})
     print(result)

--- a/archicad-addon/Examples/open_view.py
+++ b/archicad-addon/Examples/open_view.py
@@ -1,0 +1,23 @@
+import aclib
+
+def findFirstLeafView(branch):
+    for entry in branch:
+        navigatorItem = entry['navigatorItem']
+        children = navigatorItem.get('children')
+        if children:
+            found = findFirstLeafView(children)
+            if found is not None:
+                return found
+        else:
+            return navigatorItem
+    return None
+
+viewMapTree = aclib.RunCommand('API.GetNavigatorItemTree', {'navigatorTreeId': {'type': 'ViewMap'}})
+firstView = findFirstLeafView(viewMapTree['navigatorTree']['rootItem']['children'])
+
+if firstView is None:
+    print('No saved views found in the View Map; nothing to open.')
+else:
+    print(f"Opening view: {firstView.get('name', '<unnamed>')}")
+    result = aclib.RunTapirCommand('OpenView', {'navigatorItemId': firstView['navigatorItemId']})
+    print(result)

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -648,7 +648,7 @@ GSErrCode Initialize (void)
             navigatorCommands, "1.3.1",
             "Zooms to the given elements or fits everything in the window."
         );
-        err |= RegisterCommand<OpenViewCommand> (
+        err |= RegisterCommand<GoToViewCommand> (
             navigatorCommands, "1.4.2",
             "Activates a saved view by its navigator item id."
         );

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -648,6 +648,10 @@ GSErrCode Initialize (void)
             navigatorCommands, "1.3.1",
             "Zooms to the given elements or fits everything in the window."
         );
+        err |= RegisterCommand<OpenViewCommand> (
+            navigatorCommands, "1.4.2",
+            "Activates a saved view by its navigator item id."
+        );
         AddCommandGroup (navigatorCommands);
     }
 

--- a/archicad-addon/Sources/NavigatorCommands.cpp
+++ b/archicad-addon/Sources/NavigatorCommands.cpp
@@ -688,16 +688,16 @@ GS::ObjectState FitInWindowCommand::Execute (const GS::ObjectState& parameters, 
     return CreateSuccessfulExecutionResult ();
 }
 
-OpenViewCommand::OpenViewCommand () :
+GoToViewCommand::GoToViewCommand () :
     CommandBase (CommonSchema::Used)
 {}
 
-GS::String OpenViewCommand::GetName () const
+GS::String GoToViewCommand::GetName () const
 {
-    return "OpenView";
+    return "GoToView";
 }
 
-GS::Optional<GS::UniString> OpenViewCommand::GetInputParametersSchema () const
+GS::Optional<GS::UniString> GoToViewCommand::GetInputParametersSchema () const
 {
     return R"({
         "type": "object",
@@ -713,17 +713,16 @@ GS::Optional<GS::UniString> OpenViewCommand::GetInputParametersSchema () const
     })";
 }
 
-GS::Optional<GS::UniString> OpenViewCommand::GetResponseSchema () const
+GS::Optional<GS::UniString> GoToViewCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
     })";
 }
 
-GS::ObjectState OpenViewCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+GS::ObjectState GoToViewCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
-    // ACAPI_View_GoToView is absent from the AC25 and AC26 API DevKits.
-    // Guard at 2700 so the all-versions CI matrix compiles.
+    // ACAPI_View_GoToView is AC27+.
 #if defined (ServerMainVers_2700)
     const GS::ObjectState* navigatorItemIdOS = parameters.Get ("navigatorItemId");
     if (navigatorItemIdOS == nullptr) {
@@ -751,7 +750,7 @@ GS::ObjectState OpenViewCommand::Execute (const GS::ObjectState& parameters, GS:
         case API_MasterFolderNavItem:
         case API_SubSetNavItem:
         case API_FolderNavItem:
-            return CreateFailedExecutionResult (APIERR_BADPARS, "OpenView requires a savable view item; the given navigator item is a container or folder");
+            return CreateFailedExecutionResult (APIERR_BADPARS, "GoToView requires a savable view item; the given navigator item is a container or folder");
         default:
             break;
     }
@@ -765,6 +764,6 @@ GS::ObjectState OpenViewCommand::Execute (const GS::ObjectState& parameters, GS:
     return CreateSuccessfulExecutionResult ();
 #else
     (void) parameters;
-    return CreateFailedExecutionResult (APIERR_GENERAL, "OpenView requires Archicad 27 or later.");
+    return CreateFailedExecutionResult (APIERR_GENERAL, "GoToView requires Archicad 27 or later.");
 #endif
 }

--- a/archicad-addon/Sources/NavigatorCommands.cpp
+++ b/archicad-addon/Sources/NavigatorCommands.cpp
@@ -687,3 +687,84 @@ GS::ObjectState FitInWindowCommand::Execute (const GS::ObjectState& parameters, 
 
     return CreateSuccessfulExecutionResult ();
 }
+
+OpenViewCommand::OpenViewCommand () :
+    CommandBase (CommonSchema::Used)
+{}
+
+GS::String OpenViewCommand::GetName () const
+{
+    return "OpenView";
+}
+
+GS::Optional<GS::UniString> OpenViewCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "navigatorItemId": {
+                "$ref": "#/NavigatorItemId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "navigatorItemId"
+        ]
+    })";
+}
+
+GS::Optional<GS::UniString> OpenViewCommand::GetResponseSchema () const
+{
+    return R"({
+        "$ref": "#/ExecutionResult"
+    })";
+}
+
+GS::ObjectState OpenViewCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    // ACAPI_View_GoToView is absent from the AC25 and AC26 API DevKits.
+    // Guard at 2700 so the all-versions CI matrix compiles.
+#if defined (ServerMainVers_2700)
+    const GS::ObjectState* navigatorItemIdOS = parameters.Get ("navigatorItemId");
+    if (navigatorItemIdOS == nullptr) {
+        return CreateFailedExecutionResult (APIERR_BADPARS, "navigatorItemId is missing");
+    }
+
+    API_Guid navGuid = GetGuidFromObjectState (*navigatorItemIdOS);
+    if (navGuid == APINULLGuid) {
+        return CreateFailedExecutionResult (APIERR_BADPARS, "navigatorItemId is corrupt or missing");
+    }
+
+    API_NavigatorItem navigatorItem = {};
+    GSErrCode err = ACAPI_Navigator_GetNavigatorItem (&navGuid, &navigatorItem);
+    if (err != NoError) {
+        return CreateFailedExecutionResult (err, "Failed to get navigator item from guid");
+    }
+
+    switch (navigatorItem.itemType) {
+        case API_UndefinedNavItem:
+        case API_ProjectNavItem:
+        case API_CameraSetNavItem:
+        case API_InfoNavItem:
+        case API_HelpNavItem:
+        case API_BookNavItem:
+        case API_MasterFolderNavItem:
+        case API_SubSetNavItem:
+        case API_FolderNavItem:
+            return CreateFailedExecutionResult (APIERR_BADPARS, "OpenView requires a savable view item; the given navigator item is a container or folder");
+        default:
+            break;
+    }
+
+    const GS::UniString guidStr = APIGuidToString (navGuid);
+    err = ACAPI_View_GoToView (guidStr.ToCStr ().Get ());
+    if (err != NoError) {
+        return CreateFailedExecutionResult (err, "Failed to activate the view");
+    }
+
+    return CreateSuccessfulExecutionResult ();
+#else
+    (void) parameters;
+    return CreateFailedExecutionResult (APIERR_GENERAL, "OpenView requires Archicad 27 or later.");
+#endif
+}

--- a/archicad-addon/Sources/NavigatorCommands.hpp
+++ b/archicad-addon/Sources/NavigatorCommands.hpp
@@ -80,10 +80,10 @@ public:
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
-class OpenViewCommand : public CommandBase
+class GoToViewCommand : public CommandBase
 {
 public:
-    OpenViewCommand ();
+    GoToViewCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;

--- a/archicad-addon/Sources/NavigatorCommands.hpp
+++ b/archicad-addon/Sources/NavigatorCommands.hpp
@@ -79,3 +79,13 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+
+class OpenViewCommand : public CommandBase
+{
+public:
+    OpenViewCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};


### PR DESCRIPTION
## Summary

Adds an `OpenView` JSON command that activates a saved View Map item by its navigator item id. Complements the existing `GetViewSettings` / `SetViewSettings` commands by activating the view itself rather than reading or mutating its settings.

Implementation uses `ACAPI_View_GoToView` (available from AC27+), guarded with `#if defined (ServerMainVers_2700)` and a "requires Archicad 27 or later" fallback for the older matrix cells.

Input-type validation rejects container items (folders, subsets, camera sets, master folders, book/root items) with a clear `APIERR_BADPARS` message.

## Example

`archicad-addon/Examples/open_view.py` walks `API.GetNavigatorItemTree` for the View Map and opens the first leaf view it finds, degrading gracefully if no views exist.

## Test plan

- [x] Builds locally on AC29
- [x] Pre-verified the full AC25-29 × Win+Mac build matrix on my fork before opening
- [x] Manual tests in AC29: opens 2D StoryItem, 3D Perspective, ElevationItem, AxonometryItem — all visibly switch the active view
- [x] Manual tests for failure modes: malformed GUID → `APIERR_BADPARS`; well-formed unknown GUID → mapped error; FolderItem and UndefinedItem containers → input-type validation rejection
