### PR TITLE
feat(meshes): add line-display fields to CreateMeshes

### DIFF
--- a/archicad-addon/Examples/create_mesh.py
+++ b/archicad-addon/Examples/create_mesh.py
@@ -43,3 +43,32 @@ aclib.RunTapirCommand(
             } for x in range(0, nX*(width+gap), (width+gap)) for y in range(0, nY*(height+gap), (height+gap))
         ]
     })
+
+# Demonstrate the line-display fields: ridges/showLines control which edges Archicad
+# draws on a mesh, contourPen/levelPen/lineTypeIndex control how those lines look.
+# Pen 2 is conventionally red; line type 2 is dashed in the standard set.
+aclib.RunTapirCommand(
+    'CreateMeshes', {
+        'meshesData': [
+            {
+                'floorIndex': 2,
+                'level': 0.0,
+                'polygonCoordinates': [
+                    {'x': -20.0, 'y': -20.0, 'z': 0.0},
+                    {'x':  -5.0, 'y': -20.0, 'z': 0.0},
+                    {'x':  -5.0, 'y':  -5.0, 'z': 2.0},
+                    {'x': -20.0, 'y':  -5.0, 'z': 2.0},
+                ],
+                'sublines': [
+                    {'coordinates': [
+                        {'x': -20.0, 'y': y, 'z': 1.0} for y in range(-19, -5, 2)
+                    ]}
+                ],
+                'ridges':        'UserDefined',
+                'showLines':     False,
+                'contourPen':    2,
+                'levelPen':      4,
+                'lineTypeIndex': 2,
+            }
+        ]
+    })

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -1013,14 +1013,14 @@ GS::Optional<GS::ObjectState> CreateMeshesCommand::SetTypeSpecificParameters (AP
         element.mesh.showLines = showLines ? 1 : 0;
     }
 
-    Int32 contourPen = 0;
+    short contourPen = 0;
     if (parameters.Get ("contourPen", contourPen) && contourPen > 0) {
-        element.mesh.contPen = static_cast<short> (contourPen);
+        element.mesh.contPen = contourPen;
     }
 
-    Int32 levelPen = 0;
+    short levelPen = 0;
     if (parameters.Get ("levelPen", levelPen) && levelPen > 0) {
-        element.mesh.levelPen = static_cast<short> (levelPen);
+        element.mesh.levelPen = levelPen;
     }
 
     Int32 lineTypeIndex = 0;

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -915,7 +915,28 @@ GS::Optional<GS::UniString> CreateMeshesCommand::GetInputParametersSchema () con
                         "type": "number",
                         "description": "The height of the skirt."
                     },
-                    "polygonCoordinates": { 
+                    "ridges": {
+                        "type": "string",
+                        "description": "How ridges between mesh facets are displayed in 3D: 'AllSharp' shows all ridges, 'AllSmooth' hides them, 'UserDefined' shows only ridges along user-defined level lines (the drawing-set look for contour-line topography).",
+                        "enum": ["AllSharp", "AllSmooth", "UserDefined"]
+                    },
+                    "showLines": {
+                        "type": "boolean",
+                        "description": "Whether to show secondary mesh lines (level lines other than the user-defined ones) on plan."
+                    },
+                    "contourPen": {
+                        "type": "integer",
+                        "description": "Optional pen attribute index for the mesh's contour line."
+                    },
+                    "levelPen": {
+                        "type": "integer",
+                        "description": "Optional pen attribute index for the mesh's level lines."
+                    },
+                    "lineTypeIndex": {
+                        "type": "integer",
+                        "description": "Optional line type attribute index for the mesh's contour."
+                    },
+                    "polygonCoordinates": {
                         "type": "array",
                         "description": "The 3D coordinates of the outline polygon of the mesh.",
                         "items": {
@@ -976,6 +997,37 @@ GS::Optional<GS::ObjectState> CreateMeshesCommand::SetTypeSpecificParameters (AP
     parameters.Get ("skirtLevel", element.mesh.skirtLevel);
     GS::UniString skirtType;
     parameters.Get ("skirtType", skirtType);
+    GS::UniString ridges;
+    if (parameters.Get ("ridges", ridges)) {
+        if (ridges == "AllSharp") {
+            element.mesh.smoothRidges = APIRidge_AllSharp;
+        } else if (ridges == "AllSmooth") {
+            element.mesh.smoothRidges = APIRidge_AllSmooth;
+        } else if (ridges == "UserDefined") {
+            element.mesh.smoothRidges = APIRidge_UserSharp;
+        }
+    }
+
+    bool showLines = false;
+    if (parameters.Get ("showLines", showLines)) {
+        element.mesh.showLines = showLines ? 1 : 0;
+    }
+
+    Int32 contourPen = 0;
+    if (parameters.Get ("contourPen", contourPen) && contourPen > 0) {
+        element.mesh.contPen = static_cast<short> (contourPen);
+    }
+
+    Int32 levelPen = 0;
+    if (parameters.Get ("levelPen", levelPen) && levelPen > 0) {
+        element.mesh.levelPen = static_cast<short> (levelPen);
+    }
+
+    Int32 lineTypeIndex = 0;
+    if (parameters.Get ("lineTypeIndex", lineTypeIndex) && lineTypeIndex > 0) {
+        element.mesh.ltypeInd = ACAPI_CreateAttributeIndex (lineTypeIndex);
+    }
+
     if (skirtType == "SurfaceOnlyWithoutSkirt") {
         element.mesh.skirt = 3;
     } else if (skirtType == "WithSkirt") {


### PR DESCRIPTION
## Summary

Extends `CreateMeshes` with five optional fields for mesh line display — `ridges`, `showLines`, `contourPen`, `levelPen`, `lineTypeIndex` — each mapping to an existing [`API_MeshType`](https://archicadapi.graphisoft.com/documentation/api_meshtype) member (`smoothRidges`, `showLines`, `contPen`, `levelPen`, `ltypeInd`).

- `ridges`: `AllSharp` / `AllSmooth` / `UserDefined` — controls which mesh edges are shown in 3D. `UserDefined` gives the documentation/contour-line look (only user-defined level lines visible, all other ridges suppressed).
- `showLines`: visibility of secondary mesh lines on plan.
- `contourPen` / `levelPen`: pen attribute indices for the mesh contour and level lines.
- `lineTypeIndex`: line type attribute index for the contour.

All five fields are optional; omitting them preserves existing `CreateMeshes` default behavior.

## Conventions

Pen and line-type input shape matches the existing precedent in `CreatePolyLines` (`ElementCreationCommands.cpp` for `polyLine`): pen as plain integer, `lineTypeIndex` wrapped via `ACAPI_CreateAttributeIndex`. No new schema patterns introduced.

## Example

`archicad-addon/Examples/create_mesh.py` is extended with a styled mesh appended after the existing grid stress test, demonstrating all five new fields together.

## Test plan

- [x] Builds locally on AC29
- [x] Pre-verified the full AC25-29 × Win+Mac build matrix on my fork before opening
- [x] Manual visual test in AC29: side-by-side default vs styled mesh — styled mesh renders with the requested pen colors and line type, default mesh is unchanged.
- [x] Regression: omitting all new fields preserves existing default behavior (the existing grid stress test in `create_mesh.py` continues to work without modification).
