### PR TITLE
feat(application): ChangeWindow can target a Navigator view item

### DIFF
--- a/archicad-addon/Examples/change_window_to_view.py
+++ b/archicad-addon/Examples/change_window_to_view.py
@@ -27,7 +27,6 @@ else:
     result = aclib.RunTapirCommand(
         'ChangeWindow',
         {
-            'windowType': 'FloorPlan',
             'navigatorItemId': firstView['navigatorItemId'],
         }
     )

--- a/archicad-addon/Examples/change_window_to_view.py
+++ b/archicad-addon/Examples/change_window_to_view.py
@@ -1,0 +1,34 @@
+import aclib
+
+
+def findFirstLeafView(branch):
+    for entry in branch:
+        navigatorItem = entry['navigatorItem']
+        children = navigatorItem.get('children')
+        if children:
+            found = findFirstLeafView(children)
+            if found is not None:
+                return found
+        else:
+            return navigatorItem
+    return None
+
+
+viewMapTree = aclib.RunCommand('API.GetNavigatorItemTree', {'navigatorTreeId': {'type': 'ViewMap'}})
+firstView = findFirstLeafView(viewMapTree['navigatorTree']['rootItem']['children'])
+
+if firstView is None:
+    print('No saved views found in the View Map; nothing to change to.')
+else:
+    print(f"Changing to view: {firstView.get('name', '<unnamed>')}")
+    # navigatorItemId routes through ACAPI_View_GoToView (AC27+), applying
+    # the view's saved layer combination, scale, MVO, dim, and zoom.
+    # On AC25/26 navigatorItemId returns NOTSUPPORTED; use databaseId there.
+    result = aclib.RunTapirCommand(
+        'ChangeWindow',
+        {
+            'windowType': 'FloorPlan',
+            'navigatorItemId': firstView['navigatorItemId'],
+        }
+    )
+    print(result)

--- a/archicad-addon/Sources/ApplicationCommands.cpp
+++ b/archicad-addon/Sources/ApplicationCommands.cpp
@@ -249,22 +249,7 @@ GS::String ChangeWindowCommand::GetName () const
 GS::Optional<GS::UniString> ChangeWindowCommand::GetInputParametersSchema () const
 {
     return R"({
-        "type": "object",
-        "properties": {
-            "windowType": {
-                "$ref": "#/WindowType"
-            },
-            "databaseId": {
-                "$ref": "#/DatabaseId"
-            },
-            "navigatorItemId": {
-                "$ref": "#/NavigatorItemId"
-            }
-        },
-        "additionalProperties": false,
-        "required": [
-            "windowType"
-        ]
+        "$ref": "#/NavigatorItemIdOrDatabaseIdAndWindowType"
     })";
 }
 
@@ -277,24 +262,7 @@ GS::Optional<GS::UniString> ChangeWindowCommand::GetResponseSchema () const
 
 GS::ObjectState ChangeWindowCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
-    GS::UniString windowTypeStr;
-    if (!parameters.Get ("windowType", windowTypeStr)) {
-        return CreateFailedExecutionResult (APIERR_BADPARS, "Missing parameter: windowType.");
-    }
-
-    API_WindowInfo windowInfo = {};
-    windowInfo.typeID = ConvertWindowTypeToString (windowTypeStr);
-    if (windowInfo.typeID == API_ZombieWindowID) {
-        return CreateFailedExecutionResult (APIERR_BADPARS, "Invalid parameter: windowType.");
-    }
-
-    const GS::ObjectState* databaseId = parameters.Get ("databaseId");
     const GS::ObjectState* navigatorItemId = parameters.Get ("navigatorItemId");
-
-    if (databaseId != nullptr && navigatorItemId != nullptr) {
-        return CreateFailedExecutionResult (APIERR_BADPARS, "Specify either databaseId or navigatorItemId, not both.");
-    }
-
     if (navigatorItemId != nullptr) {
 #if defined (ServerMainVers_2700)
         API_Guid navGuid = GetGuidFromObjectState (*navigatorItemId);
@@ -323,10 +291,6 @@ GS::ObjectState ChangeWindowCommand::Execute (const GS::ObjectState& parameters,
                 break;
         }
 
-        if (navigatorItem.db.typeID != windowInfo.typeID) {
-            return CreateFailedExecutionResult (APIERR_BADPARS, "navigatorItemId's database does not belong to the requested windowType.");
-        }
-
         // ACAPI_View_GoToView applies the view's saved settings (layer combo,
         // scale, MVO, dim, zoom). The whole point of accepting navigatorItemId
         // is to apply those settings, so AC25/26 (without GoToView) rejects
@@ -339,7 +303,21 @@ GS::ObjectState ChangeWindowCommand::Execute (const GS::ObjectState& parameters,
 #else
         return CreateFailedExecutionResult (APIERR_NOTSUPPORTED, "navigatorItemId requires Archicad 27 or later; use databaseId instead.");
 #endif
-    } else if (databaseId != nullptr) {
+    }
+
+    GS::UniString windowTypeStr;
+    if (!parameters.Get ("windowType", windowTypeStr)) {
+        return CreateFailedExecutionResult (APIERR_BADPARS, "Missing parameter: windowType.");
+    }
+
+    API_WindowInfo windowInfo = {};
+    windowInfo.typeID = ConvertWindowTypeToString (windowTypeStr);
+    if (windowInfo.typeID == API_ZombieWindowID) {
+        return CreateFailedExecutionResult (APIERR_BADPARS, "Invalid parameter: windowType.");
+    }
+
+    const GS::ObjectState* databaseId = parameters.Get ("databaseId");
+    if (databaseId != nullptr) {
         API_DatabaseInfo targetDatabase = DatabaseIdResolver::Instance ().GetDatabaseWithId (GetGuidFromObjectState (*databaseId));
         GSErrCode err = ACAPI_Window_GetDatabaseInfo (&targetDatabase);
         if (err != NoError) {

--- a/archicad-addon/Sources/ApplicationCommands.cpp
+++ b/archicad-addon/Sources/ApplicationCommands.cpp
@@ -256,6 +256,9 @@ GS::Optional<GS::UniString> ChangeWindowCommand::GetInputParametersSchema () con
             },
             "databaseId": {
                 "$ref": "#/DatabaseId"
+            },
+            "navigatorItemId": {
+                "$ref": "#/NavigatorItemId"
             }
         },
         "additionalProperties": false,
@@ -286,7 +289,57 @@ GS::ObjectState ChangeWindowCommand::Execute (const GS::ObjectState& parameters,
     }
 
     const GS::ObjectState* databaseId = parameters.Get ("databaseId");
-    if (databaseId != nullptr) {
+    const GS::ObjectState* navigatorItemId = parameters.Get ("navigatorItemId");
+
+    if (databaseId != nullptr && navigatorItemId != nullptr) {
+        return CreateFailedExecutionResult (APIERR_BADPARS, "Specify either databaseId or navigatorItemId, not both.");
+    }
+
+    if (navigatorItemId != nullptr) {
+#if defined (ServerMainVers_2700)
+        API_Guid navGuid = GetGuidFromObjectState (*navigatorItemId);
+        if (navGuid == APINULLGuid) {
+            return CreateFailedExecutionResult (APIERR_BADPARS, "navigatorItemId is corrupt or missing");
+        }
+
+        API_NavigatorItem navigatorItem = {};
+        GSErrCode err = ACAPI_Navigator_GetNavigatorItem (&navGuid, &navigatorItem);
+        if (err != NoError) {
+            return CreateFailedExecutionResult (err, "Failed to get navigator item from guid");
+        }
+
+        switch (navigatorItem.itemType) {
+            case API_UndefinedNavItem:
+            case API_ProjectNavItem:
+            case API_CameraSetNavItem:
+            case API_InfoNavItem:
+            case API_HelpNavItem:
+            case API_BookNavItem:
+            case API_MasterFolderNavItem:
+            case API_SubSetNavItem:
+            case API_FolderNavItem:
+                return CreateFailedExecutionResult (APIERR_BADPARS, "navigatorItemId must be a view or viewpoint; got a container or folder");
+            default:
+                break;
+        }
+
+        if (navigatorItem.db.typeID != windowInfo.typeID) {
+            return CreateFailedExecutionResult (APIERR_BADPARS, "navigatorItemId's database does not belong to the requested windowType.");
+        }
+
+        // ACAPI_View_GoToView applies the view's saved settings (layer combo,
+        // scale, MVO, dim, zoom). The whole point of accepting navigatorItemId
+        // is to apply those settings, so AC25/26 (without GoToView) rejects
+        // rather than silently falling back to a plain database/window switch.
+        const GS::UniString guidStr = APIGuidToString (navGuid);
+        err = ACAPI_View_GoToView (guidStr.ToCStr ().Get ());
+        return err == NoError
+            ? CreateSuccessfulExecutionResult ()
+            : CreateErrorResponse (err, "Failed to activate the view");
+#else
+        return CreateFailedExecutionResult (APIERR_NOTSUPPORTED, "navigatorItemId requires Archicad 27 or later; use databaseId instead.");
+#endif
+    } else if (databaseId != nullptr) {
         API_DatabaseInfo targetDatabase = DatabaseIdResolver::Instance ().GetDatabaseWithId (GetGuidFromObjectState (*databaseId));
         GSErrCode err = ACAPI_Window_GetDatabaseInfo (&targetDatabase);
         if (err != NoError) {

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -813,6 +813,29 @@
             "Unknown"
         ]
     },
+    "NavigatorItemIdOrDatabaseIdAndWindowType": {
+        "description": "Identifies the window to change to. Either a navigatorItemId on its own (the navigator item's saved view settings are applied), or a windowType optionally narrowed to a specific databaseId.",
+        "oneOf": [
+            {
+                "$ref": "#/NavigatorItemIdArrayItem"
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "windowType": {
+                        "$ref": "#/WindowType"
+                    },
+                    "databaseId": {
+                        "$ref": "#/DatabaseId"
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "windowType"
+                ]
+            }
+        ]
+    },
     "LengthType": {
         "type": "string",
         "description": "The type of the length measurement unit.",


### PR DESCRIPTION
Extend `ChangeWindow` with `navigatorItemId` so you can use Views. 

Extends the existing `ChangeWindow` command with an optional `navigatorItemId` parameter. When given, the navigator item is resolved and (on AC27+) routed through `ACAPI_View_GoToView` so the View's saved settings (layer  scale, zoom) etc. are applied. The existing `databaseId` path is unchanged.

This is an alternative to #394 which provides higher level features on top of the lower level ACAPI calls, we will abandon 394 if we like this approach.


## Schema change

```diff
 {
   "windowType":      { "$ref": "#/WindowType" },
   "databaseId":      { "$ref": "#/DatabaseId" },
+  "navigatorItemId": { "$ref": "#/NavigatorItemId" }
 }
 required: ["windowType"]
```

- Existing callers continue to work unchanged.
- `databaseId` and `navigatorItemId` are mutually exclusive (clear error if both given).
- `windowType` remains required and is validated against the navigator item's database type 

## Behavior

| Input | AC27+ | AC25 / AC26 |
|---|---|---|
| `windowType` only | existing | existing |
| `windowType` + `databaseId` | existing | existing |
| `windowType` + `navigatorItemId` (view) | **`ACAPI_View_GoToView` — view settings applied** | rejected with `NOTSUPPORTED` (use `databaseId` instead) |
| `windowType` + `navigatorItemId` (viewpoint) | `GoToView` (functionally equivalent to a window switch) | rejected with `NOTSUPPORTED` (use `databaseId` instead) |
| `windowType` + `navigatorItemId` (container/folder) | rejected with `BADPARS` | rejected with `NOTSUPPORTED` (version check happens before item-type check) |

## Example

`archicad-addon/Examples/change_window_to_view.py` — enumerates the View Map via `API.GetNavigatorItemTree`, finds the first leaf view, and activates it via `ChangeWindow` with `navigatorItemId`.

## Test plan

- [x] Builds locally on AC29.
- [x] AC25-29 × Win+Mac matrix green on the fork.
- [x] AC29 manual: activating saved views with distinct layer combinations via `navigatorItemId` applies each view's saved layer combo.
- [x] Regression: `windowType` only and `windowType` + `databaseId` paths still succeed.
- [x] Validation: both-ids, container/folder, and invalid guid all rejected with appropriate errors.
