### PR TITLE
Optimize GetPropertiesOfElements

### DIFF
--- a/archicad-addon/Sources/PropertyCommands.cpp
+++ b/archicad-addon/Sources/PropertyCommands.cpp
@@ -218,6 +218,53 @@ GS::ObjectState GetAllPropertiesCommand::Execute (const GS::ObjectState& /*param
     return response;
 }
 
+constexpr uint32_t PackTypes (API_PropertyCollectionType colType, API_VariantType valType)
+{
+    return (static_cast<uint32_t> (colType) << 16) | static_cast<uint32_t> (valType);
+}
+
+static GSErrCode GetPropertyValueString (const API_Property& propertyValue, GS::UniString& resultString)
+{
+    if (propertyValue.value.variantStatus == API_VariantStatusUserUndefined) {
+        resultString = "<Undefined>";
+        return NoError;
+    }
+
+    switch (PackTypes (propertyValue.definition.collectionType, propertyValue.definition.valueType)) {
+        case PackTypes (API_PropertySingleCollectionType, API_PropertyStringValueType):
+            resultString = propertyValue.value.singleVariant.variant.uniStringValue;
+            break;
+
+        case PackTypes (API_PropertySingleCollectionType, API_PropertyBooleanValueType):
+            resultString = propertyValue.value.singleVariant.variant.boolValue ? "True" : "False";
+            break;
+
+        case PackTypes (API_PropertySingleCollectionType, API_PropertyIntegerValueType):
+            resultString = GS::UniString::Printf ("%d", (int) propertyValue.value.singleVariant.variant.intValue);
+            break;
+
+        case PackTypes (API_PropertySingleChoiceEnumerationCollectionType, API_PropertyStringValueType):
+            {
+                const API_Guid& selectedGuid = propertyValue.value.singleVariant.variant.guidValue;
+                bool found = false;
+                for (const API_SingleEnumerationVariant& enumVar : propertyValue.definition.possibleEnumValues) {
+                    if (enumVar.keyVariant.guidValue == selectedGuid) {
+                        resultString = enumVar.displayVariant.uniStringValue;
+                        found = true;
+                        break;
+                    }
+                }
+                return ACAPI_Property_GetPropertyValueString (propertyValue, &resultString);
+            }
+
+        default:
+            return ACAPI_Property_GetPropertyValueString (propertyValue, &resultString);
+            break;
+    }
+
+    return NoError;
+}
+
 GetPropertyValuesOfElementsCommand::GetPropertyValuesOfElementsCommand () :
     CommandBase (CommonSchema::Used)
 {
@@ -333,7 +380,7 @@ GS::ObjectState GetPropertyValuesOfElementsCommand::Execute (const GS::ObjectSta
             }
 
             GS::UniString propertyValueString;
-            err = ACAPI_Property_GetPropertyValueString (propertyValue, &propertyValueString);
+            err = GetPropertyValueString (propertyValue, propertyValueString);
 
             if (err != NoError) {
                 propertyValues (CreateErrorResponse (err, "Failed to get property value as string"));

--- a/archicad-addon/Sources/PropertyCommands.cpp
+++ b/archicad-addon/Sources/PropertyCommands.cpp
@@ -233,15 +233,15 @@ static GSErrCode GetPropertyValueString (const API_Property& propertyValue, GS::
     switch (PackTypes (propertyValue.definition.collectionType, propertyValue.definition.valueType)) {
         case PackTypes (API_PropertySingleCollectionType, API_PropertyStringValueType):
             resultString = propertyValue.value.singleVariant.variant.uniStringValue;
-            break;
+            return NoError;
 
         case PackTypes (API_PropertySingleCollectionType, API_PropertyBooleanValueType):
             resultString = propertyValue.value.singleVariant.variant.boolValue ? "True" : "False";
-            break;
+            return NoError;
 
         case PackTypes (API_PropertySingleCollectionType, API_PropertyIntegerValueType):
             resultString = GS::UniString::Printf ("%d", (int) propertyValue.value.singleVariant.variant.intValue);
-            break;
+            return NoError;
 
         case PackTypes (API_PropertySingleChoiceEnumerationCollectionType, API_PropertyStringValueType):
             {
@@ -249,7 +249,7 @@ static GSErrCode GetPropertyValueString (const API_Property& propertyValue, GS::
                 for (const API_SingleEnumerationVariant& enumVar : propertyValue.definition.possibleEnumValues) {
                     if (enumVar.keyVariant.guidValue == selectedGuid) {
                         resultString = enumVar.displayVariant.uniStringValue;
-                        break;
+                        return NoError;
                     }
                 }
                 return ACAPI_Property_GetPropertyValueString (propertyValue, &resultString);
@@ -257,10 +257,7 @@ static GSErrCode GetPropertyValueString (const API_Property& propertyValue, GS::
 
         default:
             return ACAPI_Property_GetPropertyValueString (propertyValue, &resultString);
-            break;
     }
-
-    return NoError;
 }
 
 GetPropertyValuesOfElementsCommand::GetPropertyValuesOfElementsCommand () :
@@ -325,7 +322,10 @@ GS::ObjectState GetPropertyValuesOfElementsCommand::Execute (const GS::ObjectSta
     for (const GS::ObjectState& property : properties) {
         const GS::ObjectState* propertyId = property.Get ("propertyId");
         if (propertyId != nullptr) {
-            propertyGuids.Push (GetGuidFromObjectState (*propertyId));
+            const API_Guid propertyGuid = GetGuidFromObjectState (*propertyId);
+            if (propertyGuid != APINULLGuid) {
+                propertyGuids.Push (propertyGuid);
+            }
         }
     }
 
@@ -338,7 +338,6 @@ GS::ObjectState GetPropertyValuesOfElementsCommand::Execute (const GS::ObjectSta
 
         const API_Guid elemGuid = GetGuidFromObjectState (*elementId);
 
-
         GS::Array<API_Property> fetchedProperties;
         GSErrCode err = ACAPI_Element_GetPropertyValuesByGuid (elemGuid, propertyGuids, fetchedProperties);
         if (err != NoError) {
@@ -346,13 +345,12 @@ GS::ObjectState GetPropertyValuesOfElementsCommand::Execute (const GS::ObjectSta
             continue;
         }
 
-        GS::HashTable<API_Guid, API_Property> propertyMap;
+        GS::HashTable<API_Guid, const API_Property*> propertyMap;
         for (const API_Property& prop : fetchedProperties) {
             if (!propertyMap.ContainsKey (prop.definition.guid)) {
-                propertyMap.Add (prop.definition.guid, prop);
+                propertyMap.Add (prop.definition.guid, &prop);
             }
         }
-
 
         GS::ObjectState propertyValuesForElement;
         const auto& propertyValues = propertyValuesForElement.AddList<GS::ObjectState> ("propertyValues");
@@ -360,7 +358,7 @@ GS::ObjectState GetPropertyValuesOfElementsCommand::Execute (const GS::ObjectSta
         for (const GS::ObjectState& property : properties) {
             const GS::ObjectState* propertyId = property.Get ("propertyId");
             if (propertyId == nullptr) {
-                propertyValues (CreateErrorResponse (APIERR_BADPARS, "propertyId is missing"));
+                propertyValues (CreateErrorResponse (APIERR_BADPARS, "The 'propertyId' field is missing"));
                 continue;
             }
 
@@ -371,7 +369,7 @@ GS::ObjectState GetPropertyValuesOfElementsCommand::Execute (const GS::ObjectSta
                 continue;
             }
 
-            const API_Property& propertyValue = propertyMap[propertyGuid];
+            const API_Property& propertyValue = *propertyMap[propertyGuid];
             if (propertyValue.status == API_Property_NotAvailable || propertyValue.status == API_Property_NotEvaluated) {
                 propertyValues (CreateErrorResponse (APIERR_BADPROPERTY, "Not available or not evaluated property"));
                 continue;

--- a/archicad-addon/Sources/PropertyCommands.cpp
+++ b/archicad-addon/Sources/PropertyCommands.cpp
@@ -246,11 +246,9 @@ static GSErrCode GetPropertyValueString (const API_Property& propertyValue, GS::
         case PackTypes (API_PropertySingleChoiceEnumerationCollectionType, API_PropertyStringValueType):
             {
                 const API_Guid& selectedGuid = propertyValue.value.singleVariant.variant.guidValue;
-                bool found = false;
                 for (const API_SingleEnumerationVariant& enumVar : propertyValue.definition.possibleEnumValues) {
                     if (enumVar.keyVariant.guidValue == selectedGuid) {
                         resultString = enumVar.displayVariant.uniStringValue;
-                        found = true;
                         break;
                     }
                 }

--- a/archicad-addon/Sources/PropertyCommands.cpp
+++ b/archicad-addon/Sources/PropertyCommands.cpp
@@ -276,6 +276,14 @@ GS::ObjectState GetPropertyValuesOfElementsCommand::Execute (const GS::ObjectSta
     GS::ObjectState response;
     const auto& propertyValuesForElements = response.AddList<GS::ObjectState> ("propertyValuesForElements");
 
+    GS::Array<API_Guid> propertyGuids;
+    for (const GS::ObjectState& property : properties) {
+        const GS::ObjectState* propertyId = property.Get ("propertyId");
+        if (propertyId != nullptr) {
+            propertyGuids.Push (GetGuidFromObjectState (*propertyId));
+        }
+    }
+
     for (const GS::ObjectState& element : elements) {
         const GS::ObjectState* elementId = element.Get ("elementId");
         if (elementId == nullptr) {
@@ -284,6 +292,22 @@ GS::ObjectState GetPropertyValuesOfElementsCommand::Execute (const GS::ObjectSta
         }
 
         const API_Guid elemGuid = GetGuidFromObjectState (*elementId);
+
+
+        GS::Array<API_Property> fetchedProperties;
+        GSErrCode err = ACAPI_Element_GetPropertyValuesByGuid (elemGuid, propertyGuids, fetchedProperties);
+        if (err != NoError) {
+            propertyValuesForElements (CreateErrorResponse (err, "Failed to get property values for element"));
+            continue;
+        }
+
+        GS::HashTable<API_Guid, API_Property> propertyMap;
+        for (const API_Property& prop : fetchedProperties) {
+            if (!propertyMap.ContainsKey (prop.definition.guid)) {
+                propertyMap.Add (prop.definition.guid, prop);
+            }
+        }
+
 
         GS::ObjectState propertyValuesForElement;
         const auto& propertyValues = propertyValuesForElement.AddList<GS::ObjectState> ("propertyValues");
@@ -297,14 +321,12 @@ GS::ObjectState GetPropertyValuesOfElementsCommand::Execute (const GS::ObjectSta
 
             const API_Guid propertyGuid = GetGuidFromObjectState (*propertyId);
 
-            API_Property propertyValue;
-            GSErrCode err = ACAPI_Element_GetPropertyValue (elemGuid, propertyGuid, propertyValue);
-
-            if (err != NoError) {
-                propertyValues (CreateErrorResponse (err, "Failed to get property value"));
+            if (!propertyMap.ContainsKey (propertyGuid)) {
+                propertyValues (CreateErrorResponse (APIERR_BADPROPERTY, "Property not found or invalid"));
                 continue;
             }
 
+            const API_Property& propertyValue = propertyMap[propertyGuid];
             if (propertyValue.status == API_Property_NotAvailable || propertyValue.status == API_Property_NotEvaluated) {
                 propertyValues (CreateErrorResponse (APIERR_BADPROPERTY, "Not available or not evaluated property"));
                 continue;


### PR DESCRIPTION
GetPropertiesOfElements is one of the most used commands, yet it is quite slow.
The PR aims to speed up the fetching process with 2 distinct refactors:

1. batch property fetch with the use of the ACAPI_Element_GetPropertyValuesByGuid command
This variant of the command fetches all properties for the same element at once reducing the number of API requests. For a test dataset of 39358 elements and 35 properties this reduced the execution time **from 1842.99s**  to  **1067.12s.**
2. ACAPI_Property_GetPropertyValueString is pretty haevy. We definitely don't want to handle imperial conversions directly, but for simple types where we don't need to query the users project preferences, we can skip it. This furter reduced execution time to **567.16s** on the test dataset, resulting in an execution time of **less than 1/3 of the original**. Note, most properties were int/string/enums with only a few reals.

I have tested the following data types for property preservation:
| Property Name (Group > Name) | Port 19723 (original) | Port 19726(refactored) |
|------------------------------|------------|------------|
| GENERAL RATINGS > bool | False | False |
| GENERAL RATINGS > enum | 20 minutes | 20 minutes |
| GENERAL RATINGS > integer | 115 | 115 |
| GENERAL RATINGS > real_or_measure | 0,57 | 0,57 |
| GENERAL RATINGS > string | this is a string | this is a string |
| GENERAL RATINGS > udefined_enum | \<Undefined> | \<Undefined> |
| GENERAL RATINGS > undefined_default | \<Undefined> | \<Undefined> |
| GENERAL RATINGS > undefined_string | \<Undefined> | \<Undefined> |
| GENERAL RATINGS > value_list | first_value; secound_value | first_value; secound_value |

I did make a change in behaviour:
We always return True or False regardless of localization. I think this was requested by @runxel in the past.

But after the refactor I do have some questions about how the command should behave.
I will use this issue to discuss: https://github.com/ENZYME-APD/tapir-archicad-automation/issues/285