### PR TITLE
feat(walls,columns,beams,slabs): add reference line / anchor placement parameters

### DIFF
--- a/archicad-addon/Sources/CommandBase.cpp
+++ b/archicad-addon/Sources/CommandBase.cpp
@@ -527,6 +527,20 @@ API_ElemTypeID GetElementTypeFromNonLocalizedName (const GS::UniString& typeStr)
     return API_ZombieElemID;
 }
 
+short ParseAnchorPointString (const GS::UniString& anchorPoint)
+{
+    if (anchorPoint == "TopLeft")      return 0;
+    if (anchorPoint == "TopCenter")    return 1;
+    if (anchorPoint == "TopRight")     return 2;
+    if (anchorPoint == "MiddleLeft")   return 3;
+    if (anchorPoint == "Center")       return 4;
+    if (anchorPoint == "MiddleRight")  return 5;
+    if (anchorPoint == "BottomLeft")   return 6;
+    if (anchorPoint == "BottomCenter") return 7;
+    if (anchorPoint == "BottomRight")  return 8;
+    return 4;
+}
+
 API_Guid GetAttributeGuidFromIndex (API_AttrTypeID typeID, API_AttributeIndex index)
 {
     API_Attribute attr = {};

--- a/archicad-addon/Sources/CommandBase.hpp
+++ b/archicad-addon/Sources/CommandBase.hpp
@@ -91,6 +91,7 @@ GS::Pair<short, double> GetFloorIndexAndOffset (const double zPos, const Stories
 double GetZPos (const short floorIndex, const double offset, const Stories& stories);
 GS::UniString GetElementTypeNonLocalizedName (API_ElemTypeID typeID);
 API_ElemTypeID GetElementTypeFromNonLocalizedName (const GS::UniString& typeStr);
+short ParseAnchorPointString (const GS::UniString& anchorPoint);
 
 API_Guid GetAttributeGuidFromIndex (API_AttrTypeID typeID, API_AttributeIndex index);
 API_Attr_Head GetAttributeHeadFromGuid (API_Guid guid);

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -156,6 +156,11 @@ GS::Optional<GS::UniString> CreateColumnsCommand::GetInputParametersSchema () co
                             "type": "number",
                             "description": "Cross section depth (height) of the column. Applied to all segments. Only effective for rectangular columns.",
                             "exclusiveMinimum": 0.0
+                        },
+                        "coreAnchor": {
+                            "type": "string",
+                            "description": "Optional anchor point of the column core on a 3x3 grid.",
+                            "enum": ["TopLeft", "TopCenter", "TopRight", "MiddleLeft", "Center", "MiddleRight", "BottomLeft", "BottomCenter", "BottomRight"]
                         }
                     },
                     "additionalProperties": false,
@@ -185,6 +190,11 @@ GS::Optional<GS::ObjectState> CreateColumnsCommand::SetTypeSpecificParameters (A
     element.column.origoPos.y = apiCoordinate.y;
     parameters.Get ("height", element.column.height);
     parameters.Get ("axisRotationAngle", element.column.axisRotationAngle);
+
+    GS::UniString coreAnchor;
+    if (parameters.Get ("coreAnchor", coreAnchor)) {
+        element.column.coreAnchor = ParseAnchorPointString (coreAnchor);
+    }
 
     double width = 0.0;
     double depth = 0.0;
@@ -231,6 +241,11 @@ GS::Optional<GS::UniString> CreateSlabsCommand::GetInputParametersSchema () cons
                         "type": "number",
                         "description": "Optional slab thickness.",
                         "exclusiveMinimum": 0.0
+                    },
+                    "referencePlaneLocation": {
+                        "type": "string",
+                        "description": "Optional location of the slab reference plane. For a basic (homogeneous) slab only 'Top' or 'Bottom' are valid.",
+                        "enum": ["Top", "CoreTop", "CoreBottom", "Bottom"]
                     },
                     "polygonCoordinates": { 
                         "type": "array",

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -353,6 +353,19 @@ GS::Optional<GS::ObjectState> CreateSlabsCommand::SetTypeSpecificParameters (API
     element.slab.level = floorIndexAndOffset.second;
     parameters.Get ("thickness", element.slab.thickness);
 
+    GS::UniString referencePlaneLocation;
+    if (parameters.Get ("referencePlaneLocation", referencePlaneLocation)) {
+        if (referencePlaneLocation == "Top") {
+            element.slab.referencePlaneLocation = APISlabRefPlane_Top;
+        } else if (referencePlaneLocation == "CoreTop") {
+            element.slab.referencePlaneLocation = APISlabRefPlane_CoreTop;
+        } else if (referencePlaneLocation == "CoreBottom") {
+            element.slab.referencePlaneLocation = APISlabRefPlane_CoreBottom;
+        } else if (referencePlaneLocation == "Bottom") {
+            element.slab.referencePlaneLocation = APISlabRefPlane_Bottom;
+        }
+    }
+
     GS::Array<GS::ObjectState> polygonCoordinates;
     GS::Array<GS::ObjectState> polygonArcs;
     GS::Array<GS::ObjectState> holes;

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -1528,6 +1528,10 @@ GS::Optional<GS::UniString> CreateWallsCommand::GetInputParametersSchema () cons
                         "height": { "type": "number", "exclusiveMinimum": 0.0 },
                         "thickness": { "type": "number", "exclusiveMinimum": 0.0 },
                         "offset": { "type": "number" },
+                        "referenceLineLocation": {
+                            "type": "string",
+                            "enum": ["Outside", "Center", "Inside", "CoreOutside", "CoreCenter", "CoreInside"]
+                        },
                         "structureType": {
                             "type": "string",
                             "enum": ["Basic", "Composite", "Profile"]
@@ -1570,6 +1574,22 @@ GS::Optional<GS::ObjectState> CreateWallsCommand::SetTypeSpecificParameters (API
     element.wall.height = height;
     element.wall.thickness = thickness;
     element.wall.referenceLineLocation = APIWallRefLine_Center;
+    GS::UniString referenceLineLocation;
+    if (parameters.Get ("referenceLineLocation", referenceLineLocation)) {
+        if (referenceLineLocation == "Outside") {
+            element.wall.referenceLineLocation = APIWallRefLine_Outside;
+        } else if (referenceLineLocation == "Center") {
+            element.wall.referenceLineLocation = APIWallRefLine_Center;
+        } else if (referenceLineLocation == "Inside") {
+            element.wall.referenceLineLocation = APIWallRefLine_Inside;
+        } else if (referenceLineLocation == "CoreOutside") {
+            element.wall.referenceLineLocation = APIWallRefLine_CoreOutside;
+        } else if (referenceLineLocation == "CoreCenter") {
+            element.wall.referenceLineLocation = APIWallRefLine_CoreCenter;
+        } else if (referenceLineLocation == "CoreInside") {
+            element.wall.referenceLineLocation = APIWallRefLine_CoreInside;
+        }
+    }
     element.wall.modelElemStructureType = API_BasicStructure;
     element.wall.offset = 0.0;
 
@@ -1623,6 +1643,11 @@ GS::Optional<GS::UniString> CreateBeamsCommand::GetInputParametersSchema () cons
                             "type": "number",
                             "description": "Cross section height of the beam. Applied to all segments.",
                             "exclusiveMinimum": 0.0
+                        },
+                        "anchorPoint": {
+                            "type": "string",
+                            "description": "Optional anchor point of the beam cross section on a 3x3 grid.",
+                            "enum": ["TopLeft", "TopCenter", "TopRight", "MiddleLeft", "Center", "MiddleRight", "BottomLeft", "BottomCenter", "BottomRight"]
                         }
                     },
                     "additionalProperties": false,
@@ -1668,6 +1693,11 @@ GS::Optional<GS::ObjectState> CreateBeamsCommand::SetTypeSpecificParameters (API
     auto curveHeight = GetOptionalDouble (parameters, "verticalCurveHeight");
     if (curveHeight.HasValue ()) {
         element.beam.verticalCurveHeight = curveHeight.Get ();
+    }
+
+    GS::UniString anchorPoint;
+    if (parameters.Get ("anchorPoint", anchorPoint)) {
+        element.beam.anchorPoint = ParseAnchorPointString (anchorPoint);
     }
 
     auto width = GetOptionalDouble (parameters, "width");


### PR DESCRIPTION
Adds optional placement-reference parameters to element creation, so callers can match plan dimensioning (drawings reference faces/corners, not element centers):

- **CreateWalls** — `referenceLineLocation` (`Outside`/`Center`/`Inside`/`CoreOutside`/`CoreCenter`/`CoreInside`)
- **CreateColumns** — `coreAnchor` (3×3 grid)
- **CreateBeams** — `anchorPoint` (3×3 grid)
- **CreateSlabs** — `referencePlaneLocation` (`Top`/`CoreTop`/`CoreBottom`/`Bottom`)

Columns and beams share the same 3×3 anchor grid, so the string→index mapping lives in a shared `ParseAnchorPointString` helper in `CommandBase`. Walls and slabs use the existing inline enum pattern. The wall default stays `APIWallRefLine_Center`, so behavior is unchanged when the field is omitted. Built clean on AC28.