### PR TITLE
fix(stories): SetStories uses array position instead of real story index (breaks with basements)

### DIFF
--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -546,7 +546,7 @@ GS::ObjectState SetStoriesCommand::Execute (const GS::ObjectState& parameters, G
             for (GS::UIndex i = storyCount - 1; i >= stories.GetSize (); --i) {
                 API_StoryCmdType storyCmd = {};
                 storyCmd.action = APIStory_Delete;
-                storyCmd.index  = static_cast<short> (i);
+                storyCmd.index  = (*storyInfo.data)[i].index;
             
                 err = ACAPI_ProjectSetting_ChangeStorySettings (&storyCmd);
                 if (err != NoError) {
@@ -571,7 +571,7 @@ GS::ObjectState SetStoriesCommand::Execute (const GS::ObjectState& parameters, G
         const API_StoryType& story = (*storyInfo.data)[i];
 
         API_StoryCmdType storyCmd = {};
-        storyCmd.index  = static_cast<short> (i);
+        storyCmd.index  = story.index;
 
         stories[i].Get ("dispOnSections", storyCmd.dispOnSections);
 


### PR DESCRIPTION
Fixes #422.

`SetStoriesCommand::Execute` passed the **array position** in `storyInfo.data[]` as `API_StoryCmdType.index`, but that field must be the **actual** (possibly negative) story index. The two coincide only when `firstStory == 0`, so on any project with a story below ground (`firstStory < 0`) the modify and delete loops targeted the wrong / a non-existent story and failed with `-2130313112` (`"Failed to change story level"` / `"Failed to delete story"`). The insert branch was unaffected because it already used `storyInfo.lastStory` (a real index).

**Fix** (2 lines): use the real story index — `(*storyInfo.data)[i].index` in the delete loop and `story.index` in the modify loop.

**Verified live on AC28** with a basement project (`UG -1, EG 0, OG 1`):

| Operation | before | after |
|---|---|---|
| change OG level 3 → 3.25 | `Failed to change story level` | success, OG = 3.25 |
| insert a 4th story | wrong/failed | success, created at requested level |
| delete back to 3 stories | `Failed to delete story` | success |

A project with no basement (`firstStory == 0`) worked before and still works, which is why this went unnoticed since 1.5.0.