### PR TITLE
Add Attributes to GetDetailsOfElements and CreateLabels

### DIFF
--- a/archicad-addon/Sources/CommandBase.cpp
+++ b/archicad-addon/Sources/CommandBase.cpp
@@ -246,11 +246,11 @@ void AddPolygonWithHolesFromMemoCoords (const API_Guid& elemGuid, GS::ObjectStat
         GS::ObjectState hole;
         const auto& holeCoords = hole.AddList<GS::ObjectState> (holeCoordsFieldName);
         if (includeZCoords) {
-            for (size_t i = 0; i < polygons[i].coords.size (); ++i) {
+            for (size_t j = 0; j < polygons[i].coords.size (); ++j) {
                 holeCoords (Create3DCoordinateObjectState (API_Coord3D {
-                    polygons[i].coords[i].x,
-                    polygons[i].coords[i].y,
-                    polygons[i].zCoords[i]
+                    polygons[i].coords[j].x,
+                    polygons[i].coords[j].y,
+                    polygons[i].zCoords[j]
                 }));
             }
         } else {

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -435,8 +435,6 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                         break;
                     case APIWtyp_Trapez:
                         typeSpecificDetails.Add ("geometryType", "Trapezoid");
-                        typeSpecificDetails.Add ("begThickness", elem.wall.thickness);
-                        typeSpecificDetails.Add ("endThickness", elem.wall.thickness1);
                         break;
                     case APIWtyp_Poly:
                         {
@@ -453,8 +451,13 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                 typeSpecificDetails.Add ("bottomOffset", elem.wall.bottomOffset);
                 typeSpecificDetails.Add ("offset", elem.wall.offset);
                 typeSpecificDetails.Add ("flipped", elem.wall.flipped);
-                typeSpecificDetails.Add ("begThickness", elem.wall.thickness);
-                typeSpecificDetails.Add ("endThickness", elem.wall.thickness1);
+                if (elem.wall.type == APIWtyp_Poly) {
+                    typeSpecificDetails.Add ("begThickness", 0);
+                    typeSpecificDetails.Add ("endThickness", 0);
+                } else {
+                    typeSpecificDetails.Add ("begThickness", elem.wall.thickness);
+                    typeSpecificDetails.Add ("endThickness", elem.wall.thickness1);
+                }
                 if (StructureTypeToString (elem.wall.modelElemStructureType) == "Composite") {
                     typeSpecificDetails.Add ("compositeId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_CompWallID, elem.wall.composite)));
                 }

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -452,6 +452,12 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                 typeSpecificDetails.Add ("height", elem.wall.height);
                 typeSpecificDetails.Add ("bottomOffset", elem.wall.bottomOffset);
                 typeSpecificDetails.Add ("offset", elem.wall.offset);
+                typeSpecificDetails.Add ("flipped", elem.wall.flipped);
+                typeSpecificDetails.Add ("begThickness", elem.wall.thickness);
+                typeSpecificDetails.Add ("endThickness", elem.wall.thickness1);
+                if (StructureTypeToString (elem.wall.modelElemStructureType) == "Composite") {
+                    typeSpecificDetails.Add ("compositeId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_CompWallID, elem.wall.composite)));
+                }
                 break;
 
             case API_BeamID:
@@ -507,6 +513,10 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
 
             case API_LabelID:
                 AddLibPartBasedElementDetails (typeSpecificDetails, ((elem.label.labelClass == APILblClass_Symbol) ? elem.label.u.symbol.libInd : -1), elem.label.parent, GetElemTypeId (elem.label.parentType));
+                typeSpecificDetails.Add ("begCoordinate", Create2DCoordinateObjectState (elem.label.begC));
+                typeSpecificDetails.Add ("midCoordinate", Create2DCoordinateObjectState (elem.label.midC));
+                typeSpecificDetails.Add ("endCoordinate", Create2DCoordinateObjectState (elem.label.endC));
+                typeSpecificDetails.Add ("hasLeaderLine", elem.label.hasLeaderLine);
                 break;
 
             case API_ObjectID:
@@ -571,6 +581,7 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
             case API_CurtainWallID: {
                 typeSpecificDetails.Add ("height", elem.curtainWall.height);
                 typeSpecificDetails.Add ("angle", elem.curtainWall.angle);
+                typeSpecificDetails.Add ("flipped", elem.curtainWall.flipped);
             } break;
 
             case API_CurtainWallSegmentID: {

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -1163,6 +1163,15 @@ GS::Optional<GS::UniString> CreateLabelsCommand::GetInputParametersSchema () con
                         "$ref": "#/Coordinate2D",
                         "description": "The begin coordinate of leader line. Optional parameter, but either begCoordinate or parentElementId must be provided."
                     },
+                    "midCoordinate": {
+                        "$ref": "#/Coordinate2D",
+                        "description": "The mid coordinate of leader line. Optional parameter."
+                    },
+                    "endCoordinate": {
+                        "$ref": "#/Coordinate2D",
+                        "description": "The end coordinate of leader line. Optional parameter."
+                    },
+
                     "floorInd": {
                         "type": "number",
                         "description" : "The identifier of the floor. Optional parameter, by default the current floor or the floor of the parent element is used."	
@@ -1286,6 +1295,8 @@ GS::Optional<GS::ObjectState> CreateLabelsCommand::SetTypeSpecificParameters (AP
     parameters.Get ("floorInd", element.header.floorInd);
 
     const GS::ObjectState* begCOS = parameters.Get ("begCoordinate");
+    const GS::ObjectState* midCOS = parameters.Get ("midCoordinate");
+    const GS::ObjectState* endCOS = parameters.Get ("endCoordinate");
 
     element.label.parent = GetGuidFromArrayItem ("parentElementId", parameters);
     API_Elem_Head parentElemHead = {};
@@ -1314,7 +1325,15 @@ GS::Optional<GS::ObjectState> CreateLabelsCommand::SetTypeSpecificParameters (AP
     } else {
         return CreateErrorResponse (APIERR_BADPARS, "Missing 'begCoordinate' parameter");
     }
-    element.label.createAtDefaultPosition = true;
+
+
+    if (midCOS != nullptr && endCOS != nullptr) {
+        element.label.midC = Get2DCoordinateFromObjectState (*midCOS);
+        element.label.endC = Get2DCoordinateFromObjectState (*endCOS);
+        element.label.createAtDefaultPosition = false;
+    } else {
+        element.label.createAtDefaultPosition = true;
+    }
 
     if (element.label.labelClass == APILblClass_Text) {
         GS::UniString text;

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -2723,6 +2723,9 @@
             "zCoordinate": {
                 "type": "number"
             },
+            "flipped": {
+                "type": "boolean"
+            },
             "height": {
                 "type": "number",
                 "description": "height relative to bottom"
@@ -2741,11 +2744,11 @@
             },
             "begThickness": {
                 "type": "number",
-                "description": "Thickness at the beginning in case of trapezoid wall"
+                "description": "Thickness at the beginning of wall, it will return 0 for poly wall type"
             },
             "endThickness": {
                 "type": "number",
-                "description": "Thickness at the end in case of trapezoid wall"
+                "description": "Thickness at the end of wall, it will return 0 for poly wall type"
             },
             "polygonOutline": {
                 "type": "array",
@@ -3166,6 +3169,9 @@
             "height": {
                 "type": "number"
             },
+            "flipped": {
+                "type": "boolean"
+            },
             "angle": {
                 "type": "number",
                 "description": "The rotation angle of the curtain wall in radians."
@@ -3417,6 +3423,30 @@
             "polygonCoordinates"
         ]
     },
+    "LabelDetails": {
+        "$ref": "#/LibPartBasedElementDetails",
+        "properties": {
+          "begCoordinate": {
+            "$ref": "#/Coordinate2D"
+          },
+          "midCoordinate": {
+            "$ref": "#/Coordinate2D"
+          },
+          "endCoordinate": {
+            "$ref": "#/Coordinate2D"
+          },
+          "hasLeaderLine": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+          "required": [
+              "begCoordinate",
+              "midCoordinate",
+              "endCoordinate",
+              "hasLeaderLine"
+          ]
+    },    
     "NotYetSupportedElementTypeDetails": {
         "type": "object",
         "properties": {
@@ -3474,6 +3504,9 @@
             },
             {
                 "$ref": "#/MeshDetails"
+            },
+            {
+                "$ref": "#/LabelDetails"
             },
             {
                 "$ref": "#/NotYetSupportedElementTypeDetails"


### PR DESCRIPTION
Add Attributes to GetDetailsOfElements:
1. Wall Elements: 
Add "flipped" attribute.
Add "composite" attribute.
Add "begThickness" and "endThickness" attributes for all wall types.
    Previously, these values were only available for APIWtyp_Trapez condition. However, They are also useful for other wall types, such as determining door throat dimensions for a straight wall type.

2. Lable Elements: 
Add begin, mid, end Coordinates attributes
Add "hasLeaderLine" attribute

3. Curtain Wall elements: 
Add "flipped" attribute


Add Attributes to CreateLabels:
1. Add mid and end coordinates for "CreateLabels"