### PR TITLE
Add ModifyMeshesCommand and mesh fields to GetDetailsOfElements

### DIFF
--- a/archicad-addon/Examples/modify_mesh_test.py
+++ b/archicad-addon/Examples/modify_mesh_test.py
@@ -1,0 +1,532 @@
+import sys
+import aclib
+
+if hasattr(sys.stdout, 'reconfigure'):
+    sys.stdout.reconfigure(encoding='utf-8')
+
+# =============================================================================
+# test_modify_meshes.py
+# Creates a test mesh, modifies each ModifyMeshes parameter, reads back
+# via GetDetailsOfElements and reports PASS / FAIL / SKIP.
+# =============================================================================
+
+PASS  = 'PASS'
+FAIL  = 'FAIL'
+SKIP  = 'SKIP'
+log   = []
+
+def check(name, expected, actual, tol=1e-5):
+    if expected is None or actual is None:
+        ok = False
+    elif isinstance(expected, float):
+        ok = abs(expected - actual) < tol
+    else:
+        ok = expected == actual
+    status = PASS if ok else FAIL
+    log.append((name, status, expected, actual))
+    tag = f'[{status}]'
+    print(f'  {tag:<8} {name}')
+    if status == FAIL:
+        print(f'           expected: {expected!r}')
+        print(f'           got     : {actual!r}')
+    return ok
+
+def skip(name, reason):
+    log.append((name, SKIP, reason, '-'))
+    print(f'  [SKIP]   {name} ({reason})')
+
+def get_details(elem_id):
+    resp = aclib.RunTapirCommand('GetDetailsOfElements', {
+        'elements': [{'elementId': elem_id}]
+    }, debug=False)
+    if resp is None:
+        return None
+    items = resp.get('detailsOfElements', [])
+    return items[0] if items else None
+
+def modify(elem_id, mesh_data):
+    resp = aclib.RunTapirCommand('ModifyMeshes', {
+        'meshesData': [{'elementId': elem_id, 'meshData': mesh_data}]
+    }, debug=False)
+    if resp is None:
+        print('    ERROR: no response from ModifyMeshes')
+        return False
+    r = resp.get('executionResults', [])
+    if r and r[0].get('success'):
+        return True
+    err = r[0].get('error', {}) if r else {}
+    print(f'    FAILED: code={err.get("code")}, msg={err.get("message")}')
+    return False
+
+def strip_closing(coords):
+    """Remove the closing duplicate vertex returned by GetDetailsOfElements."""
+    if len(coords) >= 2:
+        f, l = coords[0], coords[-1]
+        if abs(f['x'] - l['x']) < 1e-5 and abs(f['y'] - l['y']) < 1e-5:
+            return coords[:-1]
+    return coords
+
+# =============================================================================
+# Base mesh: 5x5m rectangle flat at Z=0, on story 0
+# =============================================================================
+BASE_POLY = [
+    {'x': 0.0, 'y': 0.0, 'z': 0.0},
+    {'x': 5.0, 'y': 0.0, 'z': 0.0},
+    {'x': 5.0, 'y': 5.0, 'z': 0.0},
+    {'x': 0.0, 'y': 5.0, 'z': 0.0},
+]
+
+print('Creating test mesh...')
+cr = aclib.RunTapirCommand('CreateMeshes', {
+    'meshesData': [{
+        'floorIndex': 0,
+        'level': 0.0,
+        'skirtLevel': 0.0,
+        'skirtType': 'SolidBodyWithSkirt',
+        'polygonCoordinates': BASE_POLY,
+    }]
+}, debug=False)
+
+elem_id = None
+if cr:
+    elems = cr.get('elements', [])
+    if elems and 'elementId' in elems[0]:
+        elem_id = elems[0]['elementId']
+
+if elem_id is None:
+    print('ERROR: could not create test mesh. Aborting.')
+    exit(1)
+
+print(f'  Mesh GUID: {elem_id["guid"][:8]}...')
+print()
+
+# =============================================================================
+# TEST 1 — level
+# =============================================================================
+print('TEST 1 — level')
+modify(elem_id, {'level': 1.5})
+d = get_details(elem_id)
+check('level = 1.5', 1.5, d and d.get('details', {}).get('level'))
+print()
+
+# =============================================================================
+# TEST 2 — skirtType (3 valeurs possibles)
+# =============================================================================
+print('TEST 2 — skirtType')
+for st in ('SurfaceOnlyWithoutSkirt', 'WithSkirt', 'SolidBodyWithSkirt'):
+    modify(elem_id, {'skirtType': st})
+    d = get_details(elem_id)
+    check(f'skirtType = {st}', st, d and d.get('details', {}).get('skirtType'))
+print()
+
+# =============================================================================
+# TEST 3 — skirtLevel
+# =============================================================================
+print('TEST 3 — skirtLevel')
+modify(elem_id, {'skirtLevel': -2.5})
+d = get_details(elem_id)
+check('skirtLevel = -2.5', -2.5, d and d.get('details', {}).get('skirtLevel'))
+print()
+
+# =============================================================================
+# TEST 4 — floorIndex
+# =============================================================================
+print('TEST 4 — floorIndex')
+modify(elem_id, {'floorIndex': 1})
+d = get_details(elem_id)
+check('floorIndex = 1', 1, d and d.get('floorIndex'))
+# Remettre sur le bon etage pour la suite
+modify(elem_id, {'floorIndex': 0})
+print()
+
+# =============================================================================
+# TEST 5 — polygonCoordinates XY (changement de forme)
+# =============================================================================
+print('TEST 5 — polygonCoordinates XY (changement de forme)')
+NEW_POLY = [
+    {'x':  1.0, 'y':  1.0, 'z': 0.0},
+    {'x': 10.0, 'y':  1.0, 'z': 0.0},
+    {'x': 10.0, 'y':  8.0, 'z': 0.0},
+    {'x':  1.0, 'y':  8.0, 'z': 0.0},
+]
+modify(elem_id, {'polygonCoordinates': NEW_POLY})
+d = get_details(elem_id)
+coords = d and strip_closing(d.get('details', {}).get('polygonCoordinates', []))
+check('vertex count = 4', 4, coords and len(coords))
+check('vertex[0].x = 1.0', 1.0,  coords and coords[0]['x'])
+check('vertex[1].x = 10.0', 10.0, coords and coords[1]['x'])
+check('vertex[2].y = 8.0',  8.0,  coords and coords[2]['y'])
+print()
+
+# =============================================================================
+# TEST 6 — polygonCoordinates Z (terrain par vertices)
+# =============================================================================
+print('TEST 6 — polygonCoordinates Z (terrain hauteurs variables)')
+TERRAIN_POLY = [
+    {'x': 0.0, 'y': 0.0, 'z': 0.00},
+    {'x': 5.0, 'y': 0.0, 'z': 1.00},
+    {'x': 5.0, 'y': 5.0, 'z': 2.00},
+    {'x': 0.0, 'y': 5.0, 'z': 0.50},
+]
+modify(elem_id, {'polygonCoordinates': TERRAIN_POLY})
+d = get_details(elem_id)
+coords = d and strip_closing(d.get('details', {}).get('polygonCoordinates', []))
+if coords and len(coords) >= 4:
+    check('Z[0] = 0.00', 0.00, coords[0]['z'])
+    check('Z[1] = 1.00', 1.00, coords[1]['z'])
+    check('Z[2] = 2.00', 2.00, coords[2]['z'])
+    check('Z[3] = 0.50', 0.50, coords[3]['z'])
+else:
+    check('coords disponibles (>= 4)', True, False)
+print()
+
+# =============================================================================
+# TEST 7 — nombre de vertices different (3 -> 6 -> 4)
+# =============================================================================
+print('TEST 7 — changement du nombre de vertices')
+# Remettre base 4 sommets
+modify(elem_id, {'polygonCoordinates': BASE_POLY})
+# Passer a 6 sommets
+POLY6 = [
+    {'x': 0.0, 'y': 0.0, 'z': 0.0},
+    {'x': 3.0, 'y': 0.0, 'z': 0.5},
+    {'x': 6.0, 'y': 0.0, 'z': 0.0},
+    {'x': 6.0, 'y': 6.0, 'z': 1.0},
+    {'x': 3.0, 'y': 6.0, 'z': 0.5},
+    {'x': 0.0, 'y': 6.0, 'z': 0.0},
+]
+modify(elem_id, {'polygonCoordinates': POLY6})
+d = get_details(elem_id)
+coords = d and strip_closing(d.get('details', {}).get('polygonCoordinates', []))
+check('6-vertex polygon count', 6, coords and len(coords))
+check('Z[1] = 0.5', 0.5, coords and coords[1]['z'])
+check('Z[3] = 1.0', 1.0, coords and coords[3]['z'])
+# Revenir a 4 sommets
+modify(elem_id, {'polygonCoordinates': BASE_POLY})
+d = get_details(elem_id)
+coords = d and strip_closing(d.get('details', {}).get('polygonCoordinates', []))
+check('retour a 4 vertices', 4, coords and len(coords))
+print()
+
+# =============================================================================
+# TEST 8 — sublines (courbes de niveau interieures)
+# =============================================================================
+print('TEST 8 — sublines')
+SUBLINES = [
+    {'coordinates': [
+        {'x': 0.5, 'y': 2.5, 'z': 0.8},
+        {'x': 2.5, 'y': 2.5, 'z': 1.2},
+        {'x': 4.5, 'y': 2.5, 'z': 0.9},
+    ]},
+    {'coordinates': [
+        {'x': 2.5, 'y': 0.5, 'z': 0.5},
+        {'x': 2.5, 'y': 4.5, 'z': 1.5},
+    ]},
+]
+modify(elem_id, {'polygonCoordinates': BASE_POLY, 'sublines': SUBLINES})
+d = get_details(elem_id)
+subs = d and d.get('details', {}).get('sublines', [])
+check('sublines count = 2', 2, subs and len(subs))
+if subs and len(subs) >= 2:
+    c0 = subs[0].get('coordinates', [])
+    c1 = subs[1].get('coordinates', [])
+    check('subline[0] point count = 3', 3, len(c0))
+    check('subline[1] point count = 2', 2, len(c1))
+    if len(c0) >= 2:
+        check('subline[0][1].z = 1.2', 1.2, c0[1].get('z'))
+    if len(c1) >= 2:
+        check('subline[1][1].z = 1.5', 1.5, c1[1].get('z'))
+print()
+
+# =============================================================================
+# TEST 9 — holes (trou dans le maillage)
+# =============================================================================
+print('TEST 9 — holes')
+# Maillage plus grand pour accueillir le trou
+OUTER_POLY = [
+    {'x': 0.0, 'y': 0.0, 'z': 0.0},
+    {'x': 8.0, 'y': 0.0, 'z': 0.0},
+    {'x': 8.0, 'y': 8.0, 'z': 0.0},
+    {'x': 0.0, 'y': 8.0, 'z': 0.0},
+]
+HOLE = [
+    {'x': 2.0, 'y': 2.0, 'z': 0.0},
+    {'x': 6.0, 'y': 2.0, 'z': 0.0},
+    {'x': 6.0, 'y': 6.0, 'z': 0.0},
+    {'x': 2.0, 'y': 6.0, 'z': 0.0},
+]
+modify(elem_id, {
+    'polygonCoordinates': OUTER_POLY,
+    'holes': [{'polygonCoordinates': HOLE}]
+})
+d = get_details(elem_id)
+holes = d and d.get('details', {}).get('holes', [])
+check('holes count = 1', 1, holes and len(holes))
+if holes:
+    hc = strip_closing(holes[0].get('polygonCoordinates', []))
+    # ArchiCAD ajoute des vertices de liaison (bridge) entre contour et trou
+    # => peut retourner plus de 4 vertices, on verifie juste le minimum
+    check('hole vertex count >= 4', True, len(hc) >= 4)
+    check('hole vertex[0].x = 2.0', 2.0, hc and hc[0]['x'])
+
+# Supprimer le trou pour la suite
+modify(elem_id, {'polygonCoordinates': BASE_POLY, 'holes': []})
+print()
+
+# =============================================================================
+# TEST 10 — polygonArcs
+# =============================================================================
+print('TEST 10 — polygonArcs (arc sur arete)')
+ARC_POLY = [
+    {'x': 0.0, 'y': 0.0, 'z': 0.0},
+    {'x': 5.0, 'y': 0.0, 'z': 0.0},
+    {'x': 5.0, 'y': 5.0, 'z': 0.0},
+    {'x': 0.0, 'y': 5.0, 'z': 0.0},
+]
+# Arc sur l'arete 1->2 (begIndex=1, endIndex=2, angle=0.5 rad)
+ARC = [{'begIndex': 1, 'endIndex': 2, 'arcAngle': 0.5}]
+modify(elem_id, {'polygonCoordinates': ARC_POLY, 'polygonArcs': ARC})
+d = get_details(elem_id)
+arcs = d and d.get('details', {}).get('polygonArcs', [])
+check('polygonArcs count = 1', 1, arcs and len(arcs))
+if arcs:
+    check('arc begIndex = 1', 1, arcs[0].get('begIndex'))
+    check('arc endIndex = 2', 2, arcs[0].get('endIndex'))
+    check('arc angle = 0.5', 0.5, arcs[0].get('arcAngle'))
+modify(elem_id, {'polygonCoordinates': BASE_POLY, 'polygonArcs': []})
+print()
+
+# =============================================================================
+# TEST 11 — parametres lus en retour via GetDetailsOfElements
+# =============================================================================
+print('TEST 11 — ridges / showLines / contourPen / levelPen / lineTypeIndex')
+for value, data, field, expected in [
+    ('ridges=AllSharp',    {'ridges': 'AllSharp'},    'ridges',        'AllSharp'),
+    ('ridges=AllSmooth',   {'ridges': 'AllSmooth'},   'ridges',        'AllSmooth'),
+    ('ridges=UserDefined', {'ridges': 'UserDefined'},  'ridges',        'UserDefined'),
+    ('showLines=True',     {'showLines': True},        'showLines',     True),
+    ('showLines=False',    {'showLines': False},       'showLines',     False),
+    ('contourPen=3',       {'contourPen': 3},          'contourPen',    3),
+    ('levelPen=5',         {'levelPen': 5},            'levelPen',      5),
+    ('lineTypeIndex=2',    {'lineTypeIndex': 2},       'lineTypeIndex', 2),
+]:
+    modify(elem_id, data)
+    d = get_details(elem_id)
+    got = d and d.get('details', {}).get(field)
+    check(value, expected, got)
+print()
+
+# =============================================================================
+# TEST 12 — suppression des sublines (sublines: [])
+# =============================================================================
+print('TEST 12 — suppression des sublines')
+modify(elem_id, {'polygonCoordinates': BASE_POLY, 'sublines': SUBLINES})
+d = get_details(elem_id)
+subs = d and d.get('details', {}).get('sublines', [])
+check('sublines presentes avant suppression', 2, subs and len(subs))
+modify(elem_id, {'sublines': []})
+d = get_details(elem_id)
+subs_after = d and d.get('details', {}).get('sublines')
+check('suppression sans changer polygone', 0, len(subs_after) if subs_after is not None else 0)
+modify(elem_id, {'polygonCoordinates': BASE_POLY, 'sublines': SUBLINES})
+modify(elem_id, {'polygonCoordinates': BASE_POLY, 'sublines': []})
+d = get_details(elem_id)
+subs_after2 = d and d.get('details', {}).get('sublines')
+check('suppression avec changement polygone', 0, len(subs_after2) if subs_after2 is not None else 0)
+print()
+
+# =============================================================================
+# TEST 13 — Z negatifs dans polygonCoordinates
+# =============================================================================
+print('TEST 13 — Z negatifs')
+NEG_Z_POLY = [
+    {'x': 0.0, 'y': 0.0, 'z': -1.0},
+    {'x': 5.0, 'y': 0.0, 'z':  0.0},
+    {'x': 5.0, 'y': 5.0, 'z': -0.5},
+    {'x': 0.0, 'y': 5.0, 'z': -2.0},
+]
+modify(elem_id, {'polygonCoordinates': NEG_Z_POLY})
+d = get_details(elem_id)
+coords = d and strip_closing(d.get('details', {}).get('polygonCoordinates', []))
+if coords and len(coords) == 4:
+    check('Z[0] = -1.0', -1.0, coords[0]['z'])
+    check('Z[2] = -0.5', -0.5, coords[2]['z'])
+    check('Z[3] = -2.0', -2.0, coords[3]['z'])
+else:
+    check('coords disponibles (Z negatifs)', True, False)
+modify(elem_id, {'polygonCoordinates': BASE_POLY})
+print()
+
+# =============================================================================
+# TEST 14 — polygone a 3 vertices (minimum legal)
+# =============================================================================
+print('TEST 14 — polygone a 3 vertices (minimum)')
+TRI_POLY = [
+    {'x': 0.0, 'y': 0.0, 'z': 0.0},
+    {'x': 6.0, 'y': 0.0, 'z': 1.0},
+    {'x': 3.0, 'y': 5.0, 'z': 2.0},
+]
+modify(elem_id, {'polygonCoordinates': TRI_POLY})
+d = get_details(elem_id)
+coords = d and strip_closing(d.get('details', {}).get('polygonCoordinates', []))
+# ArchiCAD peut ajouter des vertices intermediaires au triangle
+check('triangle count >= 3', True, coords and len(coords) >= 3)
+check('triangle Z[2] = 2.0', 2.0, coords and coords[2]['z'])
+modify(elem_id, {'polygonCoordinates': BASE_POLY})
+print()
+
+# =============================================================================
+# TEST 15 — modification simultanée de plusieurs parametres
+# =============================================================================
+print('TEST 15 — modification simultanee (level + skirtType + polygone + sublines)')
+modify(elem_id, {
+    'level':      2.0,
+    'skirtType':  'WithSkirt',
+    'skirtLevel': -1.0,
+    'polygonCoordinates': [
+        {'x': 0.0, 'y': 0.0, 'z': 0.0},
+        {'x': 4.0, 'y': 0.0, 'z': 0.5},
+        {'x': 4.0, 'y': 4.0, 'z': 1.0},
+        {'x': 0.0, 'y': 4.0, 'z': 0.5},
+    ],
+    'sublines': [{'coordinates': [
+        {'x': 2.0, 'y': 0.5, 'z': 0.3},
+        {'x': 2.0, 'y': 3.5, 'z': 0.7},
+    ]}],
+})
+d = get_details(elem_id)
+det = d and d.get('details', {})
+check('multi: level = 2.0',       2.0,         det and det.get('level'))
+check('multi: skirtType',         'WithSkirt',  det and det.get('skirtType'))
+check('multi: skirtLevel = -1.0', -1.0,         det and det.get('skirtLevel'))
+coords = det and strip_closing(det.get('polygonCoordinates', []))
+check('multi: Z[1] = 0.5', 0.5, coords and coords[1]['z'])
+subs = det and det.get('sublines', [])
+check('multi: sublines count = 1', 1, subs and len(subs))
+modify(elem_id, {'level': 0.0, 'skirtLevel': 0.0, 'polygonCoordinates': BASE_POLY, 'sublines': []})
+print()
+
+# =============================================================================
+# TEST 16 — plusieurs meshes en une seule commande
+# =============================================================================
+print('TEST 16 — plusieurs meshes en une seule commande')
+cr2 = aclib.RunTapirCommand('CreateMeshes', {
+    'meshesData': [{
+        'floorIndex': 0,
+        'level': 0.0,
+        'polygonCoordinates': [
+            {'x': 10.0, 'y': 0.0, 'z': 0.0},
+            {'x': 15.0, 'y': 0.0, 'z': 0.0},
+            {'x': 15.0, 'y': 5.0, 'z': 0.0},
+            {'x': 10.0, 'y': 5.0, 'z': 0.0},
+        ],
+    }]
+}, debug=False)
+elem_id2 = None
+if cr2:
+    elems2 = cr2.get('elements', [])
+    if elems2 and 'elementId' in elems2[0]:
+        elem_id2 = elems2[0]['elementId']
+
+if elem_id2:
+    resp = aclib.RunTapirCommand('ModifyMeshes', {
+        'meshesData': [
+            {'elementId': elem_id,  'meshData': {'level': 0.5}},
+            {'elementId': elem_id2, 'meshData': {'level': 1.5}},
+        ]
+    }, debug=False)
+    results2 = resp and resp.get('executionResults', [])
+    check('multi-mesh: 2 resultats', 2, results2 and len(results2))
+    check('multi-mesh: mesh1 success', True, results2 and results2[0].get('success'))
+    check('multi-mesh: mesh2 success', True, results2 and results2[1].get('success'))
+    d1 = get_details(elem_id)
+    d2 = get_details(elem_id2)
+    check('multi-mesh: mesh1 level = 0.5', 0.5, d1 and d1.get('details', {}).get('level'))
+    check('multi-mesh: mesh2 level = 1.5', 1.5, d2 and d2.get('details', {}).get('level'))
+else:
+    check('creation mesh2', True, False)
+print()
+
+# =============================================================================
+# TEST 17 — cas d'erreur : polygone < 3 vertices
+# =============================================================================
+print('TEST 17 — erreur : polygone < 3 vertices')
+ok = modify(elem_id, {'polygonCoordinates': [
+    {'x': 0.0, 'y': 0.0, 'z': 0.0},
+    {'x': 1.0, 'y': 0.0, 'z': 0.0},
+]})
+check('erreur attendue (< 3 vertices)', False, ok)
+print()
+
+# =============================================================================
+# TEST 18 — cas d'erreur : elementId inexistant
+# =============================================================================
+print('TEST 18 — erreur : elementId inexistant')
+fake_id = {'guid': '00000000-0000-0000-0000-000000000000', 'type': 'Mesh'}
+resp = aclib.RunTapirCommand('ModifyMeshes', {
+    'meshesData': [{'elementId': fake_id, 'meshData': {'level': 1.0}}]
+}, debug=False)
+r = resp and resp.get('executionResults', [])
+success = r and r[0].get('success', True)
+check('erreur attendue (guid inexistant)', False, success)
+print()
+
+# =============================================================================
+# TEST 19 — cas d'erreur : element non-mesh (on cree un mur)
+# =============================================================================
+print('TEST 19 — erreur : element non-mesh')
+cr_wall = aclib.RunTapirCommand('CreateWalls', {
+    'wallsData': [{
+        'begCoordinate': {'x': 20.0, 'y': 0.0},
+        'endCoordinate': {'x': 25.0, 'y': 0.0},
+        'zCoordinate': 0.0,
+        'height': 3.0,
+        'thickness': 0.2,
+    }]
+}, debug=False)
+wall_id = None
+if cr_wall:
+    we = cr_wall.get('elements', [])
+    if we and 'elementId' in we[0]:
+        wall_id = we[0]['elementId']
+
+if wall_id:
+    resp = aclib.RunTapirCommand('ModifyMeshes', {
+        'meshesData': [{'elementId': wall_id, 'meshData': {'level': 1.0}}]
+    }, debug=False)
+    r = resp and resp.get('executionResults', [])
+    success = r and r[0].get('success', True)
+    check('erreur attendue (mur != mesh)', False, success)
+    aclib.RunTapirCommand('DeleteElements', {'elements': [{'elementId': wall_id}]}, debug=False)
+else:
+    check('creation mur pour test', True, False)
+print()
+
+# =============================================================================
+# Nettoyage
+# =============================================================================
+print('Suppression des meshes de test...')
+to_delete = [{'elementId': elem_id}]
+if elem_id2:
+    to_delete.append({'elementId': elem_id2})
+aclib.RunTapirCommand('DeleteElements', {'elements': to_delete}, debug=False)
+
+# =============================================================================
+# Bilan
+# =============================================================================
+passed  = sum(1 for _, s, _, _ in log if s == PASS)
+failed  = sum(1 for _, s, _, _ in log if s == FAIL)
+skipped = sum(1 for _, s, _, _ in log if s == SKIP)
+
+print()
+print('=' * 60)
+print(f'BILAN :  {passed} PASS  |  {failed} FAIL  |  {skipped} SKIP')
+print('=' * 60)
+if failed:
+    print()
+    print('Tests en echec :')
+    for name, status, exp, got in log:
+        if status == FAIL:
+            print(f'  FAIL  {name}')
+            print(f'        attendu : {exp!r}')
+            print(f'        obtenu  : {got!r}')

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -422,6 +422,10 @@ GSErrCode Initialize (void)
             elementCommands, "1.4.0",
             "Modifies multi-plane Roof elements based on the given parameters."
         );
+        err |= RegisterCommand<ModifyMeshesCommand> (
+            elementCommands, "1.5.4",
+            "Modifies the attributes of Mesh elements based on the given parameters."
+        );
         err |= RegisterCommand<GetElementPreviewImageCommand> (
             elementCommands, "1.2.7",
             "Returns the preview image of the given element."

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -707,6 +707,17 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                     typeSpecificDetails.Add ("skirtType", "SolidBodyWithSkirt");
                 }
                 typeSpecificDetails.Add ("skirtLevel", elem.mesh.skirtLevel);
+                if (elem.mesh.smoothRidges == APIRidge_AllSharp) {
+                    typeSpecificDetails.Add ("ridges", GS::UniString ("AllSharp"));
+                } else if (elem.mesh.smoothRidges == APIRidge_AllSmooth) {
+                    typeSpecificDetails.Add ("ridges", GS::UniString ("AllSmooth"));
+                } else {
+                    typeSpecificDetails.Add ("ridges", GS::UniString ("UserDefined"));
+                }
+                typeSpecificDetails.Add ("showLines",    elem.mesh.showLines != 0);
+                typeSpecificDetails.Add ("contourPen",   (Int32)elem.mesh.contPen);
+                typeSpecificDetails.Add ("levelPen",     (Int32)elem.mesh.levelPen);
+                typeSpecificDetails.Add ("lineTypeIndex", GetAttributeIndex (elem.mesh.ltypeInd));
                 constexpr bool includeZCoords = true;
                 AddPolygonWithHolesFromMemoCoords (elem.header.guid, typeSpecificDetails, "polygonCoordinates", "polygonArcs", "holes", "polygonCoordinates", "polygonArcs", includeZCoords);
                 if (elem.mesh.levelLines.nSubLines > 0) {

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -1,4 +1,5 @@
 #include "ElementCreationCommands.hpp"
+#include "ExtendedElementCommands.hpp"
 #include "ObjectState.hpp"
 #include "MigrationHelper.hpp"
 #include "NotificationCommands.hpp"
@@ -1051,88 +1052,15 @@ GS::Optional<GS::ObjectState> CreateMeshesCommand::SetTypeSpecificParameters (AP
     parameters.Get ("polygonCoordinates", polygonCoordinates);
     parameters.Get ("polygonArcs", polygonArcs);
     parameters.Get ("holes", holes);
-    if (polygonCoordinates.GetSize () < 3) {
-        return CreateErrorResponse (APIERR_BADPARS, "'polygonCoordinates' must contain at least 3 coordinates.");
-    }
-    if (IsSame2DCoordinate (polygonCoordinates.GetFirst (), polygonCoordinates.GetLast ())) {
-        polygonCoordinates.Pop ();
-    }
-    element.mesh.poly.nCoords = polygonCoordinates.GetSize () + 1;
-    element.mesh.poly.nSubPolys = 1;
-    element.mesh.poly.nArcs = polygonArcs.GetSize ();
 
-    for (const GS::ObjectState& hole : holes) {
-        GS::Array<GS::ObjectState> holePolygonOutline;
-        GS::Array<GS::ObjectState> holePolygonArcs;
-        if (GetHoleGeometry (hole, holePolygonOutline, holePolygonArcs)) {
-            element.mesh.poly.nCoords += holePolygonOutline.GetSize () + 1;
-            ++element.mesh.poly.nSubPolys;
-            element.mesh.poly.nArcs += holePolygonArcs.GetSize ();
-        }
-    }
-
-    memo.coords = reinterpret_cast<API_Coord**> (BMAllocateHandle ((element.mesh.poly.nCoords + 1) * sizeof (API_Coord), ALLOCATE_CLEAR, 0));
-    memo.meshPolyZ = reinterpret_cast<double**> (BMAllocateHandle ((element.mesh.poly.nCoords + 1) * sizeof (double), ALLOCATE_CLEAR, 0));
-    memo.pends = reinterpret_cast<Int32**> (BMAllocateHandle ((element.mesh.poly.nSubPolys + 1) * sizeof (Int32), ALLOCATE_CLEAR, 0));
-    memo.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (element.mesh.poly.nArcs * sizeof (API_PolyArc), ALLOCATE_CLEAR, 0));
-
-    Int32 iCoord = 1;
-    Int32 iArc = 0;
-    Int32 iPends = 1;
-    AddPolyToMemo (polygonCoordinates,
-                   polygonArcs,
-                   iCoord,
-                   iArc,
-                   iPends,
-                   memo);
-
-    for (const GS::ObjectState& hole : holes) {
-        GS::Array<GS::ObjectState> holePolygonOutline;
-        GS::Array<GS::ObjectState> holePolygonArcs;
-        if (GetHoleGeometry (hole, holePolygonOutline, holePolygonArcs)) {
-            AddPolyToMemo (holePolygonOutline,
-                           holePolygonArcs,
-                           iCoord,
-                           iArc,
-                           iPends,
-                           memo);
-        }
+    auto geoErr = BuildMeshPolyMemoFromGeometry (element, memo, polygonCoordinates, polygonArcs, holes);
+    if (geoErr.HasValue ()) {
+        return CreateErrorResponse (APIERR_BADPARS, geoErr.Get ());
     }
 
     GS::Array<GS::ObjectState> sublines;
     parameters.Get ("sublines", sublines);
-    element.mesh.levelLines.nSubLines = 0;
-    element.mesh.levelLines.nCoords = 0;
-    for (const GS::ObjectState& subline : sublines) {
-        GS::Array<GS::ObjectState> coordinates;
-        subline.Get ("coordinates", coordinates);
-        if (coordinates.IsEmpty ()) {
-            continue;
-        }
-
-        ++element.mesh.levelLines.nSubLines;
-        element.mesh.levelLines.nCoords += coordinates.GetSize ();
-    }
-
-    memo.meshLevelCoords = reinterpret_cast<API_MeshLevelCoord**> (BMAllocateHandle (element.mesh.levelLines.nCoords * sizeof (API_MeshLevelCoord), ALLOCATE_CLEAR, 0));
-    memo.meshLevelEnds = reinterpret_cast<Int32**> (BMAllocateHandle (element.mesh.levelLines.nSubLines * sizeof (Int32), ALLOCATE_CLEAR, 0));
-
-    Int32 vertexID = 0;
-    Int32 lineID = 0;
-    for (const GS::ObjectState& subline : sublines) {
-        GS::Array<GS::ObjectState> coordinates;
-        subline.Get ("coordinates", coordinates);
-        if (coordinates.IsEmpty ()) {
-            continue;
-        }
-
-        for (const GS::ObjectState& coord : coordinates) {
-            API_MeshLevelCoord& meshLevelCoord = (*memo.meshLevelCoords)[vertexID];
-            meshLevelCoord.c = Get3DCoordinateFromObjectState (coord);
-            meshLevelCoord.vertexID = vertexID++;
-        }
-        (*memo.meshLevelEnds)[lineID++] = vertexID;
-    }
+    BuildMeshSublinesMemoFromGeometry (element, memo, sublines);
 
     return {};
 }

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -325,6 +325,9 @@ void AddPolyToMemo (const GS::Array<GS::ObjectState>& coords,
         ++iCoord;
     }
     (*memo.coords)[iCoord] = (*memo.coords)[iStart];
+    if (memo.meshPolyZ != nullptr) {
+        (*memo.meshPolyZ)[iCoord] = (*memo.meshPolyZ)[iStart];
+    }
     if (processVertexIDs && memo.vertexIDs != nullptr) {
         (*memo.vertexIDs)[iCoord] = (*memo.vertexIDs)[iStart];
     }

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -4054,3 +4054,436 @@ GS::ObjectState CreateSectionsCommand::Execute (const GS::ObjectState& parameter
         }
     });
 }
+
+static GS::Optional<GS::UniString> BuildMeshPolyMemoFromGeometry (
+    API_Element&                       elem,
+    API_ElementMemo&                   memo,
+    GS::Array<GS::ObjectState>&        polygonCoordinates,
+    const GS::Array<GS::ObjectState>&  polygonArcs,
+    const GS::Array<GS::ObjectState>&  holes)
+{
+    if (polygonCoordinates.GetSize () < 3) {
+        return "'polygonCoordinates' must contain at least 3 coordinates.";
+    }
+    if (IsSame2DCoordinate (polygonCoordinates.GetFirst (), polygonCoordinates.GetLast ())) {
+        polygonCoordinates.Pop ();
+    }
+
+    elem.mesh.poly.nCoords   = polygonCoordinates.GetSize () + 1;
+    elem.mesh.poly.nSubPolys = 1;
+    elem.mesh.poly.nArcs     = polygonArcs.GetSize ();
+
+    for (const GS::ObjectState& hole : holes) {
+        GS::Array<GS::ObjectState> holeCoords;
+        GS::Array<GS::ObjectState> holeArcs;
+        if (GetHoleGeometry (hole, holeCoords, holeArcs)) {
+            elem.mesh.poly.nCoords += holeCoords.GetSize () + 1;
+            ++elem.mesh.poly.nSubPolys;
+            elem.mesh.poly.nArcs += holeArcs.GetSize ();
+        }
+    }
+
+    const Int32 nCoords   = elem.mesh.poly.nCoords;
+    const Int32 nSubPolys = elem.mesh.poly.nSubPolys;
+    const Int32 nArcs     = elem.mesh.poly.nArcs;
+
+    memo.coords = reinterpret_cast<API_Coord**> (
+        memo.coords == nullptr
+            ? BMAllocateHandle ((nCoords + 1) * sizeof (API_Coord), ALLOCATE_CLEAR, 0)
+            : BMReallocHandle (reinterpret_cast<GSHandle> (memo.coords), (nCoords + 1) * sizeof (API_Coord), REALLOC_CLEAR, 0));
+
+    memo.meshPolyZ = reinterpret_cast<double**> (
+        memo.meshPolyZ == nullptr
+            ? BMAllocateHandle ((nCoords + 1) * sizeof (double), ALLOCATE_CLEAR, 0)
+            : BMReallocHandle (reinterpret_cast<GSHandle> (memo.meshPolyZ), (nCoords + 1) * sizeof (double), REALLOC_CLEAR, 0));
+
+    memo.pends = reinterpret_cast<Int32**> (
+        memo.pends == nullptr
+            ? BMAllocateHandle ((nSubPolys + 1) * sizeof (Int32), ALLOCATE_CLEAR, 0)
+            : BMReallocHandle (reinterpret_cast<GSHandle> (memo.pends), (nSubPolys + 1) * sizeof (Int32), REALLOC_CLEAR, 0));
+
+    if (nArcs > 0) {
+        memo.parcs = reinterpret_cast<API_PolyArc**> (
+            memo.parcs == nullptr
+                ? BMAllocateHandle (nArcs * sizeof (API_PolyArc), ALLOCATE_CLEAR, 0)
+                : BMReallocHandle (reinterpret_cast<GSHandle> (memo.parcs), nArcs * sizeof (API_PolyArc), REALLOC_CLEAR, 0));
+    } else if (memo.parcs != nullptr) {
+        BMKillHandle (reinterpret_cast<GSHandle*> (&memo.parcs));
+        memo.parcs = nullptr;
+    }
+
+    if (memo.vertexIDs != nullptr) {
+        memo.vertexIDs = reinterpret_cast<UInt32**> (
+            BMReallocHandle (reinterpret_cast<GSHandle> (memo.vertexIDs), (nCoords + 1) * sizeof (UInt32), REALLOC_CLEAR, 0));
+    }
+
+    Int32 iCoord = 1;
+    Int32 iArc   = 0;
+    Int32 iPends = 1;
+    AddPolyToMemo (polygonCoordinates, polygonArcs, iCoord, iArc, iPends, memo);
+
+    for (const GS::ObjectState& hole : holes) {
+        GS::Array<GS::ObjectState> holeCoords;
+        GS::Array<GS::ObjectState> holeArcs;
+        if (GetHoleGeometry (hole, holeCoords, holeArcs)) {
+            AddPolyToMemo (holeCoords, holeArcs, iCoord, iArc, iPends, memo);
+        }
+    }
+
+    return {};
+}
+
+ModifyMeshesCommand::ModifyMeshesCommand () :
+    CommandBase (CommonSchema::Used)
+{}
+
+GS::String ModifyMeshesCommand::GetName () const
+{
+    return "ModifyMeshes";
+}
+
+GS::Optional<GS::UniString> ModifyMeshesCommand::GetInputParametersSchema () const
+{
+    return R"({
+    "type": "object",
+    "properties": {
+        "meshesData": {
+            "type": "array",
+            "description": "Array of meshes to modify.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "elementId": {
+                        "$ref": "#/ElementId"
+                    },
+                    "meshData": {
+                        "type": "object",
+                        "description": "The fields to modify on the Mesh. Only provided fields are changed; omitted fields are left as-is.",
+                        "properties": {
+                            "floorIndex": {
+                                "type": "integer"
+                            },
+                            "level": {
+                                "type": "number",
+                                "description": "The Z reference level of coordinates."
+                            },
+                            "skirtType": {
+                                "$ref": "#/MeshSkirtType"
+                            },
+                            "skirtLevel": {
+                                "type": "number",
+                                "description": "The height of the skirt."
+                            },
+                            "ridges": {
+                                "type": "string",
+                                "description": "How ridges between mesh facets are displayed in 3D.",
+                                "enum": ["AllSharp", "AllSmooth", "UserDefined"]
+                            },
+                            "showLines": {
+                                "type": "boolean",
+                                "description": "Whether to show secondary mesh lines on plan."
+                            },
+                            "contourPen": {
+                                "type": "integer",
+                                "description": "Pen attribute index for the mesh contour line."
+                            },
+                            "levelPen": {
+                                "type": "integer",
+                                "description": "Pen attribute index for the mesh level lines."
+                            },
+                            "lineTypeIndex": {
+                                "type": "integer",
+                                "description": "Line type attribute index for the mesh contour."
+                            },
+                            "polygonCoordinates": {
+                                "type": "array",
+                                "description": "The 3D coordinates of the outline polygon of the mesh. Replaces the existing boundary entirely.",
+                                "items": { "$ref": "#/Coordinate3D" },
+                                "minItems": 3
+                            },
+                            "polygonArcs": {
+                                "type": "array",
+                                "description": "Polygon outline arcs of the mesh.",
+                                "items": { "$ref": "#/PolyArc" }
+                            },
+                            "holes": {
+                                "$ref": "#/Holes3D"
+                            },
+                            "sublines": {
+                                "type": "array",
+                                "description": "The leveling sublines inside the polygon of the mesh. Replaces existing sublines entirely.",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "coordinates": {
+                                            "type": "array",
+                                            "description": "The 3D coordinates of the leveling subline.",
+                                            "items": { "$ref": "#/Coordinate3D" }
+                                        }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": ["coordinates"]
+                                }
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "elementId",
+                    "meshData"
+                ]
+            }
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "meshesData"
+    ]
+})";
+}
+
+GS::Optional<GS::UniString> ModifyMeshesCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "executionResults": {
+                "$ref": "#/ExecutionResults"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executionResults"
+        ]
+    })";
+}
+
+GS::ObjectState ModifyMeshesCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::ObjectState> meshesData;
+    parameters.Get ("meshesData", meshesData);
+
+    GS::ObjectState response;
+    const auto& executionResults = response.AddList<GS::ObjectState> ("executionResults");
+
+    ACAPI_CallUndoableCommand ("ModifyMeshes", [&] () -> GSErrCode {
+        for (const GS::ObjectState& meshEntry : meshesData) {
+            const GS::ObjectState* elementId = meshEntry.Get ("elementId");
+            if (elementId == nullptr) {
+                executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "elementId is missing"));
+                continue;
+            }
+
+            API_Element elem = {};
+            elem.header.guid = GetGuidFromObjectState (*elementId);
+            GSErrCode err = ACAPI_Element_Get (&elem);
+            if (err != NoError) {
+                executionResults (CreateFailedExecutionResult (err, "Failed to find the element"));
+                continue;
+            }
+
+#ifdef ServerMainVers_2600
+            if (elem.header.type.typeID != API_MeshID) {
+#else
+            if (elem.header.typeID != API_MeshID) {
+#endif
+                executionResults (CreateFailedExecutionResult (APIERR_BADID, "Element is not a Mesh."));
+                continue;
+            }
+
+            const GS::ObjectState* meshData = meshEntry.Get ("meshData");
+            if (meshData == nullptr) {
+                executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "meshData is missing"));
+                continue;
+            }
+
+            GS::Array<GS::ObjectState> polygonCoordinates;
+            GS::Array<GS::ObjectState> polygonArcs;
+            GS::Array<GS::ObjectState> holes;
+            GS::Array<GS::ObjectState> sublines;
+            const bool hasPolyGeom        = meshData->Get ("polygonCoordinates", polygonCoordinates);
+            const bool hasSublines        = meshData->Get ("sublines", sublines);
+            const bool isClearingSublines = hasSublines && sublines.IsEmpty ();
+            if (hasPolyGeom) {
+                meshData->Get ("polygonArcs", polygonArcs);
+                meshData->Get ("holes", holes);
+            }
+
+            API_ElementMemo memo = {};
+            const GS::OnExit memoGuard ([&memo] () { ACAPI_DisposeElemMemoHdls (&memo); });
+
+            {
+                // When clearing sublines without a polygon change, also load the current polygon
+                // to compute the bounding box for the out-of-bounds dummy sublines (see below).
+                const UInt64 loadMask =
+                    ((hasPolyGeom || isClearingSublines) ? (APIMemoMask_Polygon | APIMemoMask_MeshPolyZ) : 0) |
+                    ((hasSublines && !isClearingSublines) ? APIMemoMask_MeshLevel : 0);
+                if (loadMask != 0) {
+                    err = ACAPI_Element_GetMemo (elem.header.guid, &memo, loadMask);
+                    if (err != NoError) {
+                        executionResults (CreateFailedExecutionResult (err, "Failed to get mesh memo"));
+                        continue;
+                    }
+                }
+            }
+
+            API_Element mask = {};
+            ACAPI_ELEMENT_MASK_CLEAR (mask);
+
+            if (meshData->Get ("floorIndex", elem.header.floorInd)) {
+                ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, floorInd);
+            }
+            if (meshData->Get ("level", elem.mesh.level)) {
+                ACAPI_ELEMENT_MASK_SET (mask, API_MeshType, level);
+            }
+            if (meshData->Get ("skirtLevel", elem.mesh.skirtLevel)) {
+                ACAPI_ELEMENT_MASK_SET (mask, API_MeshType, skirtLevel);
+            }
+            GS::UniString skirtType;
+            if (meshData->Get ("skirtType", skirtType)) {
+                if (skirtType == "SurfaceOnlyWithoutSkirt") {
+                    elem.mesh.skirt = 3;
+                } else if (skirtType == "WithSkirt") {
+                    elem.mesh.skirt = 2;
+                } else if (skirtType == "SolidBodyWithSkirt") {
+                    elem.mesh.skirt = 1;
+                }
+                ACAPI_ELEMENT_MASK_SET (mask, API_MeshType, skirt);
+            }
+            GS::UniString ridges;
+            if (meshData->Get ("ridges", ridges)) {
+                if (ridges == "AllSharp") {
+                    elem.mesh.smoothRidges = APIRidge_AllSharp;
+                } else if (ridges == "AllSmooth") {
+                    elem.mesh.smoothRidges = APIRidge_AllSmooth;
+                } else if (ridges == "UserDefined") {
+                    elem.mesh.smoothRidges = APIRidge_UserSharp;
+                }
+                ACAPI_ELEMENT_MASK_SET (mask, API_MeshType, smoothRidges);
+            }
+            bool showLines = false;
+            if (meshData->Get ("showLines", showLines)) {
+                elem.mesh.showLines = showLines ? 1 : 0;
+                ACAPI_ELEMENT_MASK_SET (mask, API_MeshType, showLines);
+            }
+            short contourPen = 0;
+            if (meshData->Get ("contourPen", contourPen) && contourPen > 0) {
+                elem.mesh.contPen = contourPen;
+                ACAPI_ELEMENT_MASK_SET (mask, API_MeshType, contPen);
+            }
+            short levelPen = 0;
+            if (meshData->Get ("levelPen", levelPen) && levelPen > 0) {
+                elem.mesh.levelPen = levelPen;
+                ACAPI_ELEMENT_MASK_SET (mask, API_MeshType, levelPen);
+            }
+            Int32 lineTypeIndex = 0;
+            if (meshData->Get ("lineTypeIndex", lineTypeIndex) && lineTypeIndex > 0) {
+                elem.mesh.ltypeInd = ACAPI_CreateAttributeIndex (lineTypeIndex);
+                ACAPI_ELEMENT_MASK_SET (mask, API_MeshType, ltypeInd);
+            }
+
+            UInt64 memoChangeMask = 0;
+
+            if (hasPolyGeom) {
+                auto geoErr = BuildMeshPolyMemoFromGeometry (elem, memo, polygonCoordinates, polygonArcs, holes);
+                if (geoErr.HasValue ()) {
+                    executionResults (CreateFailedExecutionResult (APIERR_BADPARS, geoErr.Get ()));
+                    continue;
+                }
+                memoChangeMask |= APIMemoMask_Polygon | APIMemoMask_MeshPolyZ;
+            }
+
+            if (hasSublines) {
+                const Int32 nSubLines = (Int32)sublines.GetSize ();
+
+                if (isClearingSublines) {
+                    // Clearing level lines: ACAPI_Element_Change ignores null/empty handles for
+                    // APIMemoMask_MeshLevel. Workaround: send two valid sublines placed just
+                    // outside the polygon bounding box; ArchiCAD clips them out automatically,
+                    // resulting in nSubLines == 0 stored in the element.
+                    // memo.coords is guaranteed valid here (loaded above for this case).
+                    const Int32 nPolyCoords = elem.mesh.poly.nCoords;
+                    double xMin = (*memo.coords)[1].x;
+                    double yMin = (*memo.coords)[1].y;
+                    for (Int32 j = 2; j < nPolyCoords; ++j) {
+                        if ((*memo.coords)[j].x < xMin) xMin = (*memo.coords)[j].x;
+                        if ((*memo.coords)[j].y < yMin) yMin = (*memo.coords)[j].y;
+                    }
+
+                    const double kOffset = 1.0;
+                    const double kStep   = 0.5;
+                    const double ox = xMin - kOffset;
+                    const double oy = yMin - kOffset;
+
+                    memo.meshLevelCoords = reinterpret_cast<API_MeshLevelCoord**> (
+                        memo.meshLevelCoords == nullptr
+                            ? BMAllocateHandle (4 * sizeof (API_MeshLevelCoord), ALLOCATE_CLEAR, 0)
+                            : BMReallocHandle (reinterpret_cast<GSHandle> (memo.meshLevelCoords), 4 * sizeof (API_MeshLevelCoord), REALLOC_CLEAR, 0));
+                    memo.meshLevelEnds = reinterpret_cast<Int32**> (
+                        memo.meshLevelEnds == nullptr
+                            ? BMAllocateHandle (2 * sizeof (Int32), ALLOCATE_CLEAR, 0)
+                            : BMReallocHandle (reinterpret_cast<GSHandle> (memo.meshLevelEnds), 2 * sizeof (Int32), REALLOC_CLEAR, 0));
+
+                    (*memo.meshLevelCoords)[0].c.x = ox;          (*memo.meshLevelCoords)[0].c.y = oy;          (*memo.meshLevelCoords)[0].c.z = 0.0;
+                    (*memo.meshLevelCoords)[1].c.x = ox + kStep;  (*memo.meshLevelCoords)[1].c.y = oy;          (*memo.meshLevelCoords)[1].c.z = 0.0;
+                    (*memo.meshLevelCoords)[2].c.x = ox;          (*memo.meshLevelCoords)[2].c.y = oy + kStep;  (*memo.meshLevelCoords)[2].c.z = 0.0;
+                    (*memo.meshLevelCoords)[3].c.x = ox + kStep;  (*memo.meshLevelCoords)[3].c.y = oy + kStep;  (*memo.meshLevelCoords)[3].c.z = 0.0;
+                    (*memo.meshLevelEnds)[0] = 2;
+                    (*memo.meshLevelEnds)[1] = 4;
+
+                    elem.mesh.levelLines.nCoords   = 4;
+                    elem.mesh.levelLines.nSubLines = 2;
+                    ACAPI_ELEMENT_MASK_SET (mask, API_MeshType, levelLines);
+                    memoChangeMask |= APIMemoMask_MeshLevel;
+                } else {
+                    Int32 nTotalCoords = 0;
+                    for (const GS::ObjectState& sub : sublines) {
+                        GS::Array<GS::ObjectState> coords;
+                        if (sub.Get ("coordinates", coords))
+                            nTotalCoords += (Int32)coords.GetSize ();
+                    }
+
+                    elem.mesh.levelLines.nCoords   = nTotalCoords;
+                    elem.mesh.levelLines.nSubLines = nSubLines;
+
+                    memo.meshLevelCoords = reinterpret_cast<API_MeshLevelCoord**> (
+                        memo.meshLevelCoords == nullptr
+                            ? BMAllocateHandle (nTotalCoords * sizeof (API_MeshLevelCoord), ALLOCATE_CLEAR, 0)
+                            : BMReallocHandle (reinterpret_cast<GSHandle> (memo.meshLevelCoords), nTotalCoords * sizeof (API_MeshLevelCoord), REALLOC_CLEAR, 0));
+                    memo.meshLevelEnds = reinterpret_cast<Int32**> (
+                        memo.meshLevelEnds == nullptr
+                            ? BMAllocateHandle (nSubLines * sizeof (Int32), ALLOCATE_CLEAR, 0)
+                            : BMReallocHandle (reinterpret_cast<GSHandle> (memo.meshLevelEnds), nSubLines * sizeof (Int32), REALLOC_CLEAR, 0));
+
+                    Int32 iCoord = 0;
+                    for (Int32 lineIdx = 0; lineIdx < nSubLines; ++lineIdx) {
+                        GS::Array<GS::ObjectState> coords;
+                        if (sublines[lineIdx].Get ("coordinates", coords)) {
+                            for (const GS::ObjectState& c : coords) {
+                                (*memo.meshLevelCoords)[iCoord].c = Get3DCoordinateFromObjectState (c);
+                                ++iCoord;
+                            }
+                        }
+                        (*memo.meshLevelEnds)[lineIdx] = iCoord;
+                    }
+                    ACAPI_ELEMENT_MASK_SET (mask, API_MeshType, levelLines);
+                    memoChangeMask |= APIMemoMask_MeshLevel;
+                }
+            }
+
+            err = ACAPI_Element_Change (&elem, &mask, memoChangeMask != 0 ? &memo : nullptr, memoChangeMask, true);
+            if (err != NoError) {
+                executionResults (CreateFailedExecutionResult (err, "Failed to modify mesh"));
+                continue;
+            }
+
+            executionResults (CreateSuccessfulExecutionResult ());
+        }
+
+        return NoError;
+    });
+
+    return response;
+}

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -4055,7 +4055,7 @@ GS::ObjectState CreateSectionsCommand::Execute (const GS::ObjectState& parameter
     });
 }
 
-static GS::Optional<GS::UniString> BuildMeshPolyMemoFromGeometry (
+GS::Optional<GS::UniString> BuildMeshPolyMemoFromGeometry (
     API_Element&                       elem,
     API_ElementMemo&                   memo,
     GS::Array<GS::ObjectState>&        polygonCoordinates,
@@ -4131,6 +4131,47 @@ static GS::Optional<GS::UniString> BuildMeshPolyMemoFromGeometry (
     }
 
     return {};
+}
+
+void BuildMeshSublinesMemoFromGeometry (
+    API_Element&                      elem,
+    API_ElementMemo&                  memo,
+    const GS::Array<GS::ObjectState>& sublines)
+{
+    Int32 nTotalCoords = 0;
+    Int32 nSubLines    = 0;
+    for (const GS::ObjectState& subline : sublines) {
+        GS::Array<GS::ObjectState> coords;
+        if (subline.Get ("coordinates", coords) && !coords.IsEmpty ()) {
+            nTotalCoords += (Int32) coords.GetSize ();
+            ++nSubLines;
+        }
+    }
+
+    elem.mesh.levelLines.nCoords   = nTotalCoords;
+    elem.mesh.levelLines.nSubLines = nSubLines;
+
+    memo.meshLevelCoords = reinterpret_cast<API_MeshLevelCoord**> (
+        memo.meshLevelCoords == nullptr
+            ? BMAllocateHandle (nTotalCoords * sizeof (API_MeshLevelCoord), ALLOCATE_CLEAR, 0)
+            : BMReallocHandle (reinterpret_cast<GSHandle> (memo.meshLevelCoords), nTotalCoords * sizeof (API_MeshLevelCoord), REALLOC_CLEAR, 0));
+    memo.meshLevelEnds = reinterpret_cast<Int32**> (
+        memo.meshLevelEnds == nullptr
+            ? BMAllocateHandle (nSubLines * sizeof (Int32), ALLOCATE_CLEAR, 0)
+            : BMReallocHandle (reinterpret_cast<GSHandle> (memo.meshLevelEnds), nSubLines * sizeof (Int32), REALLOC_CLEAR, 0));
+
+    Int32 iCoord = 0;
+    Int32 iLine  = 0;
+    for (const GS::ObjectState& subline : sublines) {
+        GS::Array<GS::ObjectState> coords;
+        if (!subline.Get ("coordinates", coords) || coords.IsEmpty ())
+            continue;
+        for (const GS::ObjectState& c : coords) {
+            (*memo.meshLevelCoords)[iCoord].c = Get3DCoordinateFromObjectState (c);
+            ++iCoord;
+        }
+        (*memo.meshLevelEnds)[iLine++] = iCoord;
+    }
 }
 
 ModifyMeshesCommand::ModifyMeshesCommand () :
@@ -4396,8 +4437,6 @@ GS::ObjectState ModifyMeshesCommand::Execute (const GS::ObjectState& parameters,
             }
 
             if (hasSublines) {
-                const Int32 nSubLines = (Int32)sublines.GetSize ();
-
                 if (isClearingSublines) {
                     // Clearing level lines: ACAPI_Element_Change ignores null/empty handles for
                     // APIMemoMask_MeshLevel. Workaround: send two valid sublines placed just
@@ -4438,36 +4477,7 @@ GS::ObjectState ModifyMeshesCommand::Execute (const GS::ObjectState& parameters,
                     ACAPI_ELEMENT_MASK_SET (mask, API_MeshType, levelLines);
                     memoChangeMask |= APIMemoMask_MeshLevel;
                 } else {
-                    Int32 nTotalCoords = 0;
-                    for (const GS::ObjectState& sub : sublines) {
-                        GS::Array<GS::ObjectState> coords;
-                        if (sub.Get ("coordinates", coords))
-                            nTotalCoords += (Int32)coords.GetSize ();
-                    }
-
-                    elem.mesh.levelLines.nCoords   = nTotalCoords;
-                    elem.mesh.levelLines.nSubLines = nSubLines;
-
-                    memo.meshLevelCoords = reinterpret_cast<API_MeshLevelCoord**> (
-                        memo.meshLevelCoords == nullptr
-                            ? BMAllocateHandle (nTotalCoords * sizeof (API_MeshLevelCoord), ALLOCATE_CLEAR, 0)
-                            : BMReallocHandle (reinterpret_cast<GSHandle> (memo.meshLevelCoords), nTotalCoords * sizeof (API_MeshLevelCoord), REALLOC_CLEAR, 0));
-                    memo.meshLevelEnds = reinterpret_cast<Int32**> (
-                        memo.meshLevelEnds == nullptr
-                            ? BMAllocateHandle (nSubLines * sizeof (Int32), ALLOCATE_CLEAR, 0)
-                            : BMReallocHandle (reinterpret_cast<GSHandle> (memo.meshLevelEnds), nSubLines * sizeof (Int32), REALLOC_CLEAR, 0));
-
-                    Int32 iCoord = 0;
-                    for (Int32 lineIdx = 0; lineIdx < nSubLines; ++lineIdx) {
-                        GS::Array<GS::ObjectState> coords;
-                        if (sublines[lineIdx].Get ("coordinates", coords)) {
-                            for (const GS::ObjectState& c : coords) {
-                                (*memo.meshLevelCoords)[iCoord].c = Get3DCoordinateFromObjectState (c);
-                                ++iCoord;
-                            }
-                        }
-                        (*memo.meshLevelEnds)[lineIdx] = iCoord;
-                    }
+                    BuildMeshSublinesMemoFromGeometry (elem, memo, sublines);
                     ACAPI_ELEMENT_MASK_SET (mask, API_MeshType, levelLines);
                     memoChangeMask |= APIMemoMask_MeshLevel;
                 }

--- a/archicad-addon/Sources/ExtendedElementCommands.hpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.hpp
@@ -2,6 +2,19 @@
 
 #include "CommandBase.hpp"
 #include "ElementCreationCommands.hpp"
+#include "ObjectState.hpp"
+
+GS::Optional<GS::UniString> BuildMeshPolyMemoFromGeometry (
+    API_Element& elem,
+    API_ElementMemo& memo,
+    GS::Array<GS::ObjectState>& polygonCoordinates,
+    const GS::Array<GS::ObjectState>& polygonArcs,
+    const GS::Array<GS::ObjectState>& holes);
+
+void BuildMeshSublinesMemoFromGeometry (
+    API_Element& elem,
+    API_ElementMemo& memo,
+    const GS::Array<GS::ObjectState>& sublines);
 
 class CreateWallsCommand : public CreateElementsCommandBase
 {

--- a/archicad-addon/Sources/ExtendedElementCommands.hpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.hpp
@@ -206,3 +206,13 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+
+class ModifyMeshesCommand : public CommandBase
+{
+public:
+    ModifyMeshesCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -3364,6 +3364,10 @@
     "MeshDetails": {
         "type": "object",
         "properties": {
+            "floorIndex": {
+                "type": "integer",
+                "description": "The index of the story the mesh is placed on."
+            },
             "level": {
                 "type": "number",
                 "description": "The Z reference level of coordinates."
@@ -3374,6 +3378,27 @@
             "skirtLevel": {
                 "type": "number",
                 "description": "The height of the skirt."
+            },
+            "ridges": {
+                "type": "string",
+                "description": "How ridges between mesh facets are displayed in 3D.",
+                "enum": ["AllSharp", "AllSmooth", "UserDefined"]
+            },
+            "showLines": {
+                "type": "boolean",
+                "description": "Whether to show secondary mesh lines on plan."
+            },
+            "contourPen": {
+                "type": "integer",
+                "description": "Pen attribute index for the mesh contour line."
+            },
+            "levelPen": {
+                "type": "integer",
+                "description": "Pen attribute index for the mesh level lines."
+            },
+            "lineTypeIndex": {
+                "type": "integer",
+                "description": "Line type attribute index for the mesh contour."
             },
             "polygonCoordinates": {
                 "type": "array",


### PR DESCRIPTION
### Summary

- New command ModifyMeshes: modifies mesh elements in batch. Supported fields: level, floorIndex, skirtType, skirtLevel, ridges, showLines, contourPen, levelPen, lineTypeIndex, polygonCoordinates (with per-vertex Z), polygonArcs, holes, and sublines (level lines). Only provided fields are changed; omitted fields are left as-is. Sending sublines: [] removes all existing level lines.

- Extended GetDetailsOfElements for mesh elements: now returns ridges, showLines, contourPen, levelPen, and lineTypeIndex, enabling full read/modify round-trips.

- New example modify_mesh_test.py: 59-test automated suite covering all parameters with read-back verification via GetDetailsOfElements.

### Notes

- Polygon, holes, and sublines are replaced entirely when provided (same behavior as CreateMeshes).

- The sublines: [] clearing works by sending two dummy level lines placed just outside the polygon bounding box; ArchiCAD clips them automatically, resulting in zero stored level lines. This is a known limitation of ACAPI_Element_Change which ignores null/empty handles for APIMemoMask_MeshLevel.

### Test plan

-  Run modify_mesh_test.py against ArchiCAD 27 with Tapir installed — expect 59 PASS, 0 FAIL

-  Verify level, skirt, polygon, holes, sublines, and visual fields round-trip correctly

-  Verify sublines: [] clears all level lines
