### PR TITLE
Add expression-based property support and DeleteProjectInfoFields command

### DIFF
--- a/archicad-addon/Examples/test_expression_project_info.py
+++ b/archicad-addon/Examples/test_expression_project_info.py
@@ -1,0 +1,273 @@
+"""
+Test: ExpressionBasedInfo (project info) + ExpressionBasedProperty (string expression)
+
+Steps:
+  1. Create a project info field named 'ExpressionBasedInfo'
+  2. Verify it appears in GetAllProperties (required to reference it in expressions)
+  3. Create 'ExpressionBasedProperty' (type=string) with CONCAT("Test"; <ref to ExpressionBasedInfo>)
+  4. Read back and verify the expression is correct (with GUID resolved to label)
+  5. Cleanup
+"""
+
+import sys, re
+sys.path.insert(0, r'D:\ONEDRIVE\Documents\CODE PLUGINS\tapir-archicad-automation\archicad-addon\Examples')
+import aclib
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def run(cmd, params=None):
+    return aclib.RunTapirCommand(cmd, params or {}, debug=False)
+
+def get_all_classification_items():
+    """Return a flat availability list with all classification item GUIDs."""
+    availability = []
+    systems_r = aclib.RunCommand('API.GetAllClassificationSystems', {})
+    for sys_entry in (systems_r or {}).get('classificationSystems', []):
+        sys_id = sys_entry.get('classificationSystemId')
+        if not sys_id:
+            continue
+        items_r = aclib.RunCommand('API.GetAllClassificationsInSystem',
+                                   {'classificationSystemId': sys_id})
+        def collect(items):
+            for item in (items or []):
+                ci = item.get('classificationItem', {})
+                guid = ci.get('classificationItemId', {}).get('guid')
+                if guid:
+                    availability.append({'classificationItemId': {'guid': guid}})
+                collect(ci.get('children', []))
+        collect(items_r.get('classificationItems', []))
+    return availability
+
+passes = fails = 0
+
+def check(label, expected, got):
+    global passes, fails
+    ok = (got == expected)
+    tag = 'PASS' if ok else 'FAIL'
+    if ok:
+        passes += 1
+    else:
+        fails += 1
+    print(f'  [{tag}] {label}  (expected={expected}, got={got})')
+
+def build_guid_map():
+    props = (run('GetAllProperties') or {}).get('properties', [])
+    return {
+        p['propertyId']['guid']: f"{p['propertyGroupName']} / {p['propertyName']}"
+        for p in props if 'propertyId' in p
+    }, props
+
+def resolve(expr, guid_map):
+    return re.sub(
+        r'###Property:([0-9A-Fa-f\-]+)###',
+        lambda m: f'[{guid_map.get(m.group(1), m.group(1))}]',
+        expr
+    )
+
+def ref(guid):
+    return f'###Property:{guid}###'
+
+# ---------------------------------------------------------------------------
+# 1. Create project info field 'ExpressionBasedInfo'
+# ---------------------------------------------------------------------------
+print('STEP 1 -- Create project info field "ExpressionBasedInfo" (or reuse if exists)')
+# Check if already present before creating
+_, all_props_pre = build_guid_map()
+existing = next((p for p in all_props_pre
+                 if p.get('propertyName') == 'ExpressionBasedInfo'
+                 and p.get('propertyGroupName') == 'ProjectInfoPropertyDefinitionGroup'), None)
+
+info_id = None
+info_already_existed = False
+if existing:
+    print('  Already exists — reusing')
+    info_already_existed = True
+    info_id = 'existing'  # placeholder; GUID resolved in STEP 2
+    check('project info field present', True, True)
+else:
+    info_r  = run('CreateProjectInfoFields', {
+        'projectInfoFields': [
+            {'projectInfoName': 'ExpressionBasedInfo', 'projectInfoValue': 'HelloFromTapir'}
+        ]
+    })
+    info_entry = (info_r or {}).get('fields', [{}])[0]
+    info_id    = info_entry.get('projectInfoId')
+    check('project info field created', True, info_id is not None)
+    if info_id:
+        print(f'  projectInfoId : {info_id}')
+print()
+
+# ---------------------------------------------------------------------------
+# 2. Check if the new project info appears in GetAllProperties
+# ---------------------------------------------------------------------------
+print('STEP 2 -- Check if ExpressionBasedInfo appears in GetAllProperties')
+guid_map, all_props = build_guid_map()
+
+# Project info fields might appear under a group containing "ProjectInfo"
+info_prop_guid = None
+for p in all_props:
+    if p.get('propertyName') == 'ExpressionBasedInfo':
+        info_prop_guid = p['propertyId']['guid']
+        grp = p.get('propertyGroupName', '')
+        ptype = p.get('propertyType', '')
+        print(f'  Found: {grp} / ExpressionBasedInfo  (type={ptype}, guid={info_prop_guid})')
+        break
+
+# Also show all project-info-related groups for diagnostics
+pi_props = [p for p in all_props if 'ProjectInfo' in p.get('propertyGroupName', '')
+            or 'projectinfo' in p.get('propertyGroupName', '').lower()]
+if pi_props:
+    print(f'  ProjectInfo group properties ({len(pi_props)} total):')
+    for p in pi_props[:10]:
+        print(f'    {p["propertyGroupName"]} / {p["propertyName"]}')
+
+check('ExpressionBasedInfo visible in GetAllProperties', True, info_prop_guid is not None)
+print()
+
+# ---------------------------------------------------------------------------
+# 3. Create property group + ExpressionBasedProperty
+# ---------------------------------------------------------------------------
+print('STEP 3 -- Create property group "TestExprGroup" (or reuse if exists)')
+grp_r     = run('CreatePropertyGroups', {'propertyGroups': [
+    {'propertyGroup': {'name': 'TestExprGroup', 'description': 'Tapir expression test'}}
+]})
+grp_entry = (grp_r or {}).get('propertyGroupIds', [{}])[0]
+grp_guid  = grp_entry.get('propertyGroupId', {}).get('guid')
+if grp_guid:
+    check('group created', True, True)
+else:
+    # Already exists — CreatePropertyDefinitions can reference it by name directly
+    print('  Already exists — will reference by name')
+    check('group present', True, True)
+    grp_guid = '__by_name__'   # sentinel: use name-based reference below
+print()
+
+print('STEP 4 -- Create ExpressionBasedProperty (string CONCAT expression, or reuse if exists)')
+# Check if already exists
+_, all_props_now = build_guid_map()
+existing_prop = next((p for p in all_props_now
+                      if p.get('propertyName') == 'ExpressionBasedProperty'
+                      and p.get('propertyGroupName') == 'TestExprGroup'), None)
+existing_prop_guid = (existing_prop or {}).get('propertyId', {}).get('guid')
+created_prop_guid  = None
+used_type = None
+
+# Collect full availability list (all classification items)
+print('  Collecting all classification items for availability...')
+all_avail = get_all_classification_items()
+print(f'  Found {len(all_avail)} classification items')
+
+# Always delete and recreate so availability is up to date
+if existing_prop_guid:
+    print('  Deleting existing ExpressionBasedProperty to recreate with full availability...')
+    run('DeletePropertyDefinitions', {
+        'propertyIds': [{'propertyId': {'guid': existing_prop_guid}}]
+    })
+
+if grp_guid and info_prop_guid:
+    # Try multiple CONCAT syntaxes then fall back to number
+    candidates = [
+        ('string', f'CONCAT ( "Test" ; {ref(info_prop_guid)} )'),
+        ('string', f'CONCAT ( "Test", {ref(info_prop_guid)} )'),
+        ('string', f'"Test" + {ref(info_prop_guid)}'),
+        ('number', f'STRTONUM ( {ref(info_prop_guid)} )'),
+    ]
+    group_ref = {'name': 'TestExprGroup'} if grp_guid == '__by_name__' \
+                else {'propertyGroupId': {'guid': grp_guid}}
+    for prop_type, expr in candidates:
+        prop_r = run('CreatePropertyDefinitions', {'propertyDefinitions': [
+            {'propertyDefinition': {
+                'name'        : 'ExpressionBasedProperty',
+                'description' : '',
+                'type'        : prop_type,
+                'isEditable'  : False,
+                'defaultValue': {'expressions': [expr]},
+                'group'       : group_ref,
+                'availability': all_avail,
+            }}
+        ]})
+        entry = (prop_r or {}).get('propertyIds', [{}])[0]
+        created_prop_guid = entry.get('propertyId', {}).get('guid')
+        if created_prop_guid:
+            used_type = prop_type
+            print(f'  Created with type={prop_type}, expr: {expr[:60]}')
+            break
+        else:
+            err = entry.get('error', {})
+            print(f'  type={prop_type} | {expr[:50]!r} -> failed ({err.get("code")})')
+
+    check('ExpressionBasedProperty created', True, created_prop_guid is not None)
+    if used_type == 'number':
+        print('  NOTE: AC27 does not accept string-type CONCAT with ProjectInfo refs — fell back to number')
+if not created_prop_guid and not grp_guid:
+    print('  [SKIP] no group guid')
+elif not info_prop_guid:
+    print('  [SKIP] ExpressionBasedInfo not visible in properties')
+print()
+
+# ---------------------------------------------------------------------------
+# 5. Read back and verify
+# ---------------------------------------------------------------------------
+print('STEP 5 -- Read back ExpressionBasedProperty via GetAllProperties')
+if created_prop_guid:
+    guid_map2, all_props2 = build_guid_map()
+    prop = next((p for p in all_props2
+                 if p.get('propertyId', {}).get('guid') == created_prop_guid), None)
+    is_expr = (prop or {}).get('isExpressionBased', False)
+    exprs   = (prop or {}).get('expressions', [])
+    check('isExpressionBased=True', True, is_expr)
+    check('has 1 expression', True, len(exprs) == 1)
+    if exprs:
+        raw  = exprs[0]
+        read = resolve(raw, guid_map2)
+        print(f'  RAW : {raw}')
+        print(f'  READ: {read}')
+        check('expression references ExpressionBasedInfo',
+              True, info_prop_guid in raw)
+print()
+
+# ---------------------------------------------------------------------------
+# STEP 6 -- DeleteProjectInfoFields
+# ---------------------------------------------------------------------------
+print('STEP 6 -- DeleteProjectInfoFields')
+
+# Test 1: hardcoded field must be rejected
+hardcoded_id = 'PROJECT'
+del_bad    = run('DeleteProjectInfoFields', {'projectInfoIds': [hardcoded_id]})
+bad_result = (del_bad or {}).get('executionResults', [{}])[0]
+check('hardcoded field rejected', False, bad_result.get('success', False))
+
+# Test 2: create a throwaway field, delete it, verify it's gone
+throwaway_r  = run('CreateProjectInfoFields', {
+    'projectInfoFields': [{'projectInfoName': 'TestDeleteMe', 'projectInfoValue': ''}]
+})
+throwaway_id = (throwaway_r or {}).get('fields', [{}])[0].get('projectInfoId')
+if throwaway_id:
+    del_r = run('DeleteProjectInfoFields', {'projectInfoIds': [throwaway_id]})
+    ok    = (del_r or {}).get('executionResults', [{}])[0].get('success', False)
+    check('custom field deleted', True, ok)
+    _, props_after = build_guid_map()
+    still_there = any(p.get('propertyName') == 'TestDeleteMe' for p in props_after)
+    check('field no longer in GetAllProperties', False, still_there)
+else:
+    print('  [SKIP] could not create throwaway field')
+# ExpressionBasedInfo is kept alive so ExpressionBasedProperty displays correctly
+print()
+
+# ---------------------------------------------------------------------------
+# Cleanup (disabled for visual verification in ArchiCAD)
+# ---------------------------------------------------------------------------
+print('Cleanup skipped — verify in ArchiCAD:')
+print(f'  Group        : TestExprGroup')
+if created_prop_guid:
+    print(f'  Property     : ExpressionBasedProperty  ({created_prop_guid})')
+print(f'  Project info : ExpressionBasedInfo (kept alive — referenced by ExpressionBasedProperty)')
+
+print()
+print('=' * 60)
+print(f'BILAN :  {passes} PASS  |  {fails} FAIL')
+print('=' * 60)
+if fails:
+    sys.exit(1)

--- a/archicad-addon/Examples/test_property_expressions.py
+++ b/archicad-addon/Examples/test_property_expressions.py
@@ -1,0 +1,256 @@
+import sys, re
+sys.stdout.reconfigure(encoding='utf-8')
+import aclib
+
+PASS = 'PASS'
+FAIL = 'FAIL'
+log  = []
+
+def run(cmd, params):
+    return aclib.RunTapirCommand(cmd, params, debug=False)
+
+def check(name, expected, got):
+    ok = expected == got
+    status = PASS if ok else FAIL
+    log.append((name, status, expected, got))
+    print(f'  [{status}] {name}  (expected={expected!r}, got={got!r})')
+
+def ref(guid):
+    return f'###Property:{guid}###'
+
+# ---------------------------------------------------------------------------
+# Build lookup tables from GetAllProperties
+# ---------------------------------------------------------------------------
+all_r = run('GetAllProperties', {})
+all_props = (all_r or {}).get('properties', [])
+guid_to_label = {
+    p['propertyId']['guid']: f"{p['propertyGroupName']} / {p['propertyName']}"
+    for p in all_props if 'propertyId' in p
+}
+
+def resolve(expr):
+    """Replace ###Property:GUID### with [Group / Name] for readability."""
+    return re.sub(
+        r'###Property:([0-9A-Fa-f\-]+)###',
+        lambda m: f'[{guid_to_label.get(m.group(1), m.group(1))}]',
+        expr
+    )
+
+def find_prop(ptype=None, vtype=None, exclude_expr=False):
+    """Return first property matching type filters."""
+    for p in all_props:
+        if ptype and p.get('propertyType') != ptype:
+            continue
+        if vtype and p.get('propertyValueType') != vtype:
+            continue
+        if exclude_expr and p.get('isExpressionBased'):
+            continue
+        return p
+    return None
+
+# Locate reference properties for expressions
+builtin_area   = find_prop(ptype='DynamicBuiltIn', vtype='Real')
+builtin_str    = find_prop(ptype='DynamicBuiltIn', vtype='String')
+builtin_int    = find_prop(ptype='DynamicBuiltIn', vtype='Integer')
+custom_prop    = find_prop(ptype='Custom', vtype='Real',    exclude_expr=True) or \
+                 find_prop(ptype='Custom', vtype='Integer', exclude_expr=True)
+
+print(f'Built-in (Real)   : {guid_to_label.get((builtin_area  or {}).get("propertyId",{}).get("guid",""), "not found")}')
+print(f'Built-in (String) : {guid_to_label.get((builtin_str   or {}).get("propertyId",{}).get("guid",""), "not found")}')
+print(f'Built-in (Integer): {guid_to_label.get((builtin_int   or {}).get("propertyId",{}).get("guid",""), "not found")}')
+print(f'Custom (non-expr) : {guid_to_label.get((custom_prop   or {}).get("propertyId",{}).get("guid",""), "not found")}')
+print()
+
+# ---------------------------------------------------------------------------
+# Setup: temporary group
+# ---------------------------------------------------------------------------
+print('Setup...')
+group_r = run('CreatePropertyGroups', {'propertyGroups': [
+    {'propertyGroup': {'name': '__TapirExprTest__', 'description': 'temporary'}}
+]})
+group_guid = (group_r or {}).get('propertyGroupIds', [{}])[0].get('propertyGroupId', {}).get('guid')
+if not group_guid:
+    print('FATAL: could not create test group'); sys.exit(1)
+
+created_guids = []
+
+def make_prop(name, ptype, expr_list):
+    r = run('CreatePropertyDefinitions', {'propertyDefinitions': [
+        {'propertyDefinition': {
+            'name': name, 'description': '', 'type': ptype, 'isEditable': False,
+            'defaultValue': {'expressions': expr_list},
+            'group': {'propertyGroupId': {'guid': group_guid}},
+            'availability': [],
+        }}
+    ]})
+    entry = (r or {}).get('propertyIds', [{}])[0]
+    guid  = entry.get('propertyId', {}).get('guid')
+    if guid:
+        created_guids.append(guid)
+    elif 'error' in entry:
+        print(f'  ERROR: {entry["error"]}')
+    return guid, entry
+
+def get_prop(guid):
+    fresh = run('GetAllProperties', {})
+    return next((p for p in (fresh or {}).get('properties', [])
+                 if p.get('propertyId', {}).get('guid') == guid), None)
+
+# =============================================================================
+print('TEST 1 -- GetAllProperties: isExpressionBased on existing properties')
+# =============================================================================
+expr_props = [p for p in all_props if p.get('isExpressionBased')]
+non_expr   = [p for p in all_props if not p.get('isExpressionBased')]
+check('expression-based props exist in project', True, len(expr_props) > 0)
+check('isExpressionBased=True has expressions key', True,
+      all('expressions' in p for p in expr_props))
+check('isExpressionBased=False has no expressions key', True,
+      all('expressions' not in p for p in non_expr))
+if expr_props:
+    sample = expr_props[0]
+    print(f'  Sample: {guid_to_label[sample["propertyId"]["guid"]]}')
+    for e in sample.get('expressions', []):
+        print(f'    RAW : {e}')
+        print(f'    READ: {resolve(e)}')
+print()
+
+# =============================================================================
+print('TEST 2 -- Create expression referencing a built-in Real property')
+# =============================================================================
+if builtin_area:
+    ag = builtin_area['propertyId']['guid']
+    guid2, _ = make_prop('TestExpr_BuiltinReal', 'number', [f'{ref(ag)} * 2'])
+    check('created successfully', True, guid2 is not None)
+    if guid2:
+        p = get_prop(guid2)
+        check('isExpressionBased=True', True, (p or {}).get('isExpressionBased'))
+        exprs = (p or {}).get('expressions', [])
+        check('expression count = 1', 1, len(exprs))
+        check('expression contains built-in ref', True, ag in (exprs[0] if exprs else ''))
+        if exprs:
+            print(f'  Expression: {resolve(exprs[0])}')
+else:
+    print('  [SKIP] no built-in Real property found')
+print()
+
+# =============================================================================
+print('TEST 3 -- Create expression referencing a built-in DynamicBuiltIn property')
+# =============================================================================
+if builtin_str:
+    sg = builtin_str['propertyId']['guid']
+    # DynamicBuiltIn String: wrap with STRTONUM to stay in number domain
+    guid3, _ = make_prop('TestExpr_BuiltinDynamic', 'number',
+                         [f'STRTONUM({ref(sg)})'])
+    if not guid3:
+        # Fallback: plain reference if string prop can't be wrapped
+        guid3, _ = make_prop('TestExpr_BuiltinDynamic2', 'number',
+                             [f'{ref(sg)}'])
+    check('created successfully', True, guid3 is not None)
+    if guid3:
+        p = get_prop(guid3)
+        exprs = (p or {}).get('expressions', [])
+        check('expression readable', True, len(exprs) > 0)
+        if exprs:
+            print(f'  Expression: {resolve(exprs[0])}')
+else:
+    print('  [SKIP] no DynamicBuiltIn property found')
+print()
+
+# =============================================================================
+print('TEST 4 -- Create expression referencing a custom Real/Integer property')
+# =============================================================================
+if custom_prop:
+    cg   = custom_prop['propertyId']['guid']
+    ag   = builtin_area['propertyId']['guid'] if builtin_area else None
+    expr = f'{ref(cg)} + {ref(ag)}' if ag else f'{ref(cg)} * 1'
+    guid4, _ = make_prop('TestExpr_CustomRef', 'number', [expr])
+    check('created successfully', True, guid4 is not None)
+    if guid4:
+        p = get_prop(guid4)
+        exprs = (p or {}).get('expressions', [])
+        check('references custom property', True, cg in (exprs[0] if exprs else ''))
+        if exprs:
+            print(f'  Expression: {resolve(exprs[0])}')
+else:
+    print('  [SKIP] no custom Real/Integer property found')
+print()
+
+# =============================================================================
+print('TEST 5 -- Create expression with multiple per-type expressions')
+# =============================================================================
+# Use the two properties we know work (both Real)
+guid5 = None
+if builtin_area and custom_prop:
+    ag = builtin_area['propertyId']['guid']
+    cg = custom_prop['propertyId']['guid']
+    guid5, _ = make_prop('TestExpr_MultiExpr', 'number',
+                         [f'{ref(ag)} * 1.1', f'{ref(cg)} + 0'])
+    check('created successfully', True, guid5 is not None)
+    if guid5:
+        p = get_prop(guid5)
+        exprs = (p or {}).get('expressions', [])
+        check('expression count = 2', 2, len(exprs))
+        for e in exprs:
+            print(f'  Expression: {resolve(e)}')
+else:
+    print('  [SKIP] need built-in Real and custom property')
+print()
+
+# =============================================================================
+print('TEST 6 -- UpdatePropertyDefinitions: change expression')
+# =============================================================================
+if guid5 and builtin_area and custom_prop:
+    ag       = builtin_area['propertyId']['guid']
+    cg       = custom_prop['propertyId']['guid']
+    new_expr = f'{ref(ag)} + {ref(cg)}'
+    upd_r = run('UpdatePropertyDefinitions', {'propertyDefinitions': [
+        {'propertyId': {'guid': guid5}, 'expressions': [new_expr]}
+    ]})
+    ok = (upd_r or {}).get('executionResults', [{}])[0].get('success')
+    check('update success', True, ok)
+    p = get_prop(guid5)
+    exprs = (p or {}).get('expressions', [])
+    check('expression count after update = 1', 1, len(exprs))
+    check('expression matches new value', new_expr, exprs[0] if exprs else None)
+    if exprs:
+        print(f'  Updated: {resolve(exprs[0])}')
+else:
+    print('  [SKIP] need guid5 + built-in Real + custom property')
+print()
+
+# =============================================================================
+print('TEST 7 -- UpdatePropertyDefinitions: error on unknown GUID')
+# =============================================================================
+fake = '00000000-0000-0000-0000-000000000000'
+err_r = run('UpdatePropertyDefinitions', {'propertyDefinitions': [
+    {'propertyId': {'guid': fake}, 'expressions': ['1 + 1']}
+]})
+ok = (err_r or {}).get('executionResults', [{}])[0].get('success')
+check('unknown guid returns failure', False, ok)
+print()
+
+# =============================================================================
+print('TEST 8 -- resolve_expr: all existing expression props are resolvable')
+# =============================================================================
+unresolved = [p for p in expr_props
+              if '###Property:' in ''.join(p.get('expressions', []))
+              and '[' not in resolve(''.join(p.get('expressions', [])))]
+check('all GUID refs in project are resolvable', 0, len(unresolved))
+print()
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+print('Cleanup...')
+for g in created_guids:
+    run('DeletePropertyDefinitions', {'propertyIds': [{'propertyId': {'guid': g}}]})
+run('DeletePropertyGroups', {'propertyGroupIds': [{'propertyGroupId': {'guid': group_guid}}]})
+
+# ---------------------------------------------------------------------------
+passed = sum(1 for _, s, _, _ in log if s == PASS)
+failed = sum(1 for _, s, _, _ in log if s == FAIL)
+print()
+print('=' * 60)
+print(f'BILAN :  {passed} PASS  |  {failed} FAIL')
+print('=' * 60)
+sys.exit(0 if failed == 0 else 1)

--- a/archicad-addon/Examples/test_property_expressions.py
+++ b/archicad-addon/Examples/test_property_expressions.py
@@ -36,6 +36,26 @@ def resolve(expr):
         expr
     )
 
+def get_all_classification_items():
+    """Return a flat availability list with all classification item GUIDs."""
+    availability = []
+    systems_r = aclib.RunCommand('API.GetAllClassificationSystems', {})
+    for sys_entry in (systems_r or {}).get('classificationSystems', []):
+        sys_id = sys_entry.get('classificationSystemId')
+        if not sys_id:
+            continue
+        items_r = aclib.RunCommand('API.GetAllClassificationsInSystem',
+                                   {'classificationSystemId': sys_id})
+        def collect(items):
+            for item in (items or []):
+                ci = item.get('classificationItem', {})
+                guid = ci.get('classificationItemId', {}).get('guid')
+                if guid:
+                    availability.append({'classificationItemId': {'guid': guid}})
+                collect(ci.get('children', []))
+        collect(items_r.get('classificationItems', []))
+    return availability
+
 def find_prop(ptype=None, vtype=None, exclude_expr=False):
     """Return first property matching type filters."""
     for p in all_props:
@@ -72,6 +92,10 @@ group_guid = (group_r or {}).get('propertyGroupIds', [{}])[0].get('propertyGroup
 if not group_guid:
     print('FATAL: could not create test group'); sys.exit(1)
 
+print('  Collecting classification items for availability...')
+all_avail = get_all_classification_items()
+print(f'  Found {len(all_avail)} classification items')
+
 created_guids = []
 
 def make_prop(name, ptype, expr_list):
@@ -80,7 +104,7 @@ def make_prop(name, ptype, expr_list):
             'name': name, 'description': '', 'type': ptype, 'isEditable': False,
             'defaultValue': {'expressions': expr_list},
             'group': {'propertyGroupId': {'guid': group_guid}},
-            'availability': [],
+            'availability': all_avail,
         }}
     ]})
     entry = (r or {}).get('propertyIds', [{}])[0]
@@ -119,7 +143,7 @@ print('TEST 2 -- Create expression referencing a built-in Real property')
 # =============================================================================
 if builtin_area:
     ag = builtin_area['propertyId']['guid']
-    guid2, _ = make_prop('TestExpr_BuiltinReal', 'number', [f'{ref(ag)} * 2'])
+    guid2, _ = make_prop('TestExpr_BuiltinReal', 'number', [f'{ref(ag)} / 1 m * 2'])
     check('created successfully', True, guid2 is not None)
     if guid2:
         p = get_prop(guid2)
@@ -162,7 +186,7 @@ print('TEST 4 -- Create expression referencing a custom Real/Integer property')
 if custom_prop:
     cg   = custom_prop['propertyId']['guid']
     ag   = builtin_area['propertyId']['guid'] if builtin_area else None
-    expr = f'{ref(cg)} + {ref(ag)}' if ag else f'{ref(cg)} * 1'
+    expr = f'{ref(cg)} + {ref(ag)} / 1 m' if ag else f'{ref(cg)} * 1'
     guid4, _ = make_prop('TestExpr_CustomRef', 'number', [expr])
     check('created successfully', True, guid4 is not None)
     if guid4:
@@ -184,7 +208,7 @@ if builtin_area and custom_prop:
     ag = builtin_area['propertyId']['guid']
     cg = custom_prop['propertyId']['guid']
     guid5, _ = make_prop('TestExpr_MultiExpr', 'number',
-                         [f'{ref(ag)} * 1.1', f'{ref(cg)} + 0'])
+                         [f'{ref(ag)} / 1 m + {ref(cg)}', f'{ref(cg)} + {ref(ag)} / 1 m'])
     check('created successfully', True, guid5 is not None)
     if guid5:
         p = get_prop(guid5)
@@ -202,7 +226,7 @@ print('TEST 6 -- UpdatePropertyDefinitions: change expression')
 if guid5 and builtin_area and custom_prop:
     ag       = builtin_area['propertyId']['guid']
     cg       = custom_prop['propertyId']['guid']
-    new_expr = f'{ref(ag)} + {ref(cg)}'
+    new_expr = f'{ref(ag)} / 1 m + {ref(cg)}'
     upd_r = run('UpdatePropertyDefinitions', {'propertyDefinitions': [
         {'propertyId': {'guid': guid5}, 'expressions': [new_expr]}
     ]})

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -518,7 +518,7 @@ GSErrCode Initialize (void)
             "Deletes the given Custom Property Definitions."
         );
         err |= RegisterCommand<UpdatePropertyDefinitionsCommand> (
-            propertyCommands, "1.0.9",
+            propertyCommands, "1.5.4",
             "Updates the expression(s) of existing expression-based Custom Property Definitions."
         );
         AddCommandGroup (propertyCommands);

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -177,6 +177,10 @@ GSErrCode Initialize (void)
             projectCommands, "1.5.2",
             "Creates one or more custom project info fields."
         );
+        err |= RegisterCommand<DeleteProjectInfoFieldsCommand> (
+            projectCommands, "1.5.4",
+            "Deletes one or more custom project info fields. Hardcoded fields cannot be deleted."
+        );
         err |= RegisterCommand<GetStoriesCommand> (
             projectCommands, "1.1.5",
             "Retrieves information about the story sructure of the currently loaded project."

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -517,6 +517,10 @@ GSErrCode Initialize (void)
             propertyCommands, "1.0.9",
             "Deletes the given Custom Property Definitions."
         );
+        err |= RegisterCommand<UpdatePropertyDefinitionsCommand> (
+            propertyCommands, "1.0.9",
+            "Updates the expression(s) of existing expression-based Custom Property Definitions."
+        );
         AddCommandGroup (propertyCommands);
     }
 

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -175,6 +175,11 @@ inline GSErrCode ACAPI_AutoText_CreateAnAutoText (const API_Guid* autotextDbKey,
     return ACAPI_Goodies (APIAny_CreateAnAutoTextID, (void*) autotextDbKey, (void*) autotextKey);
 }
 
+inline GSErrCode ACAPI_AutoText_DeleteAnAutoText (const char* dbKey)
+{
+    return ACAPI_Goodies (APIAny_DeleteAnAutoTextID, (void*) dbKey);
+}
+
 inline GSErrCode ACAPI_Hotlink_GetHotlinkNode (API_HotlinkNode* hotlinkNode, bool* enableUnplaced = nullptr)
 {
     return ACAPI_Database (APIDb_GetHotlinkNodeID, hotlinkNode, enableUnplaced);

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -326,8 +326,7 @@ GS::Optional<GS::UniString> DeleteProjectInfoFieldsCommand::GetInputParametersSc
                 "type": "array",
                 "description": "List of project info field ids to delete. Only custom fields (ids starting with 'autotext-') can be deleted.",
                 "items": {
-                    "type": "string",
-                    "minLength": 1
+                    "type": "string"
                 },
                 "minItems": 1
             }

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -307,6 +307,85 @@ GS::ObjectState CreateProjectInfoFieldsCommand::Execute (const GS::ObjectState& 
     return response;
 }
 
+DeleteProjectInfoFieldsCommand::DeleteProjectInfoFieldsCommand () :
+    CommandBase (CommonSchema::NotUsed)
+{
+}
+
+GS::String DeleteProjectInfoFieldsCommand::GetName () const
+{
+    return "DeleteProjectInfoFields";
+}
+
+GS::Optional<GS::UniString> DeleteProjectInfoFieldsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "projectInfoIds": {
+                "type": "array",
+                "description": "List of project info field ids to delete. Only custom fields (ids starting with 'autotext-') can be deleted.",
+                "items": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "minItems": 1
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "projectInfoIds"
+        ]
+    })";
+}
+
+GS::Optional<GS::UniString> DeleteProjectInfoFieldsCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "executionResults": {
+                "$ref": "#/ExecutionResults"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executionResults"
+        ]
+    })";
+}
+
+GS::ObjectState DeleteProjectInfoFieldsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::UniString> projectInfoIds;
+    if (!parameters.Get ("projectInfoIds", projectInfoIds) || projectInfoIds.IsEmpty ()) {
+        return CreateErrorResponse (APIERR_BADPARS, "projectInfoIds is missing or empty.");
+    }
+
+    GS::ObjectState response;
+    const auto& executionResults = response.AddList<GS::ObjectState> ("executionResults");
+
+    ACAPI_CallUndoableCommand ("DeleteProjectInfoFields", [&]() -> GSErrCode {
+        for (const GS::UniString& projectInfoId : projectInfoIds) {
+            if (!projectInfoId.BeginsWith ("autotext-")) {
+                executionResults (CreateFailedExecutionResult (APIERR_BADPARS,
+                    "Only custom project info fields (ids starting with 'autotext-') can be deleted."));
+                continue;
+            }
+
+            GSErrCode err = ACAPI_AutoText_DeleteAnAutoText (projectInfoId.ToCStr ());
+            if (err != NoError) {
+                executionResults (CreateFailedExecutionResult (err, "Failed to delete project info field."));
+            } else {
+                executionResults (CreateSuccessfulExecutionResult ());
+            }
+        }
+        return NoError;
+    });
+
+    return response;
+}
+
 GetHotlinksCommand::GetHotlinksCommand () :
     CommandBase (CommonSchema::Used)
 {

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -308,7 +308,7 @@ GS::ObjectState CreateProjectInfoFieldsCommand::Execute (const GS::ObjectState& 
 }
 
 DeleteProjectInfoFieldsCommand::DeleteProjectInfoFieldsCommand () :
-    CommandBase (CommonSchema::NotUsed)
+    CommandBase (CommonSchema::Used)
 {
 }
 

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -327,8 +327,7 @@ GS::Optional<GS::UniString> DeleteProjectInfoFieldsCommand::GetInputParametersSc
                 "description": "List of project info field ids to delete. Only custom fields (ids starting with 'autotext-') can be deleted.",
                 "items": {
                     "type": "string"
-                },
-                "minItems": 1
+                }
             }
         },
         "additionalProperties": false,

--- a/archicad-addon/Sources/ProjectCommands.hpp
+++ b/archicad-addon/Sources/ProjectCommands.hpp
@@ -39,6 +39,16 @@ public:
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
+class DeleteProjectInfoFieldsCommand : public CommandBase
+{
+public:
+    DeleteProjectInfoFieldsCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
 class GetHotlinksCommand : public CommandBase
 {
 public:

--- a/archicad-addon/Sources/PropertyCommands.cpp
+++ b/archicad-addon/Sources/PropertyCommands.cpp
@@ -210,6 +210,13 @@ GS::ObjectState GetAllPropertiesCommand::Execute (const GS::ObjectState& /*param
             details.Add ("propertyValueType", GetPropertyTypeString (definition.valueType));
             details.Add ("propertyMeasureType", GetPropertyTypeString (definition.measureType));
             details.Add ("propertyIsEditable", definition.canValueBeEditable);
+            details.Add ("isExpressionBased", definition.defaultValue.hasExpression);
+            if (definition.defaultValue.hasExpression) {
+                const auto& expressionList = details.AddList<GS::UniString> ("expressions");
+                for (const GS::UniString& expr : definition.defaultValue.propertyExpressions) {
+                    expressionList (expr);
+                }
+            }
 
             propertyAdder (details);
         }
@@ -1372,6 +1379,134 @@ GS::ObjectState DeletePropertyDefinitionsCommand::Execute (const GS::ObjectState
             GSErrCode err = ACAPI_Property_DeletePropertyDefinition (GetGuidFromObjectState (*propertyId));
             if (err != NoError) {
                 executionResults (CreateFailedExecutionResult (err, "failed to delete property"));
+                continue;
+            }
+
+            executionResults (CreateSuccessfulExecutionResult ());
+        }
+
+        return NoError;
+    });
+
+    return response;
+}
+
+UpdatePropertyDefinitionsCommand::UpdatePropertyDefinitionsCommand () :
+    CommandBase (CommonSchema::Used)
+{}
+
+GS::String UpdatePropertyDefinitionsCommand::GetName () const
+{
+    return "UpdatePropertyDefinitions";
+}
+
+GS::Optional<GS::UniString> UpdatePropertyDefinitionsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "propertyDefinitions": {
+                "type": "array",
+                "description": "The list of expression-based property definitions to update.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "propertyId": {
+                            "$ref": "#/PropertyId"
+                        },
+                        "expressions": {
+                            "type": "array",
+                            "description": "The new expression strings for the property.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "propertyId",
+                        "expressions"
+                    ]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "propertyDefinitions"
+        ]
+    })";
+}
+
+GS::Optional<GS::UniString> UpdatePropertyDefinitionsCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "executionResults": {
+                "$ref": "#/ExecutionResults"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executionResults"
+        ]
+    })";
+}
+
+GS::ObjectState UpdatePropertyDefinitionsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::ObjectState> propertyDefinitions;
+    parameters.Get ("propertyDefinitions", propertyDefinitions);
+
+    GS::ObjectState response;
+    const auto& executionResults = response.AddList<GS::ObjectState> ("executionResults");
+
+    ACAPI_CallUndoableCommand ("UpdatePropertyDefinitions", [&]() -> GSErrCode {
+        for (const GS::ObjectState& item : propertyDefinitions) {
+            const GS::ObjectState* propertyId = item.Get ("propertyId");
+            if (propertyId == nullptr) {
+                executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "propertyId is missing"));
+                continue;
+            }
+
+            const API_Guid guid = GetGuidFromObjectState (*propertyId);
+
+            // GetPropertyDefinitions takes a group GUID, not a definition GUID.
+            // Search all groups to locate the definition by its own GUID.
+            GS::Array<API_PropertyGroup> groups;
+            ACAPI_Property_GetPropertyGroups (groups);
+            bool found = false;
+            API_PropertyDefinition definition;
+            for (const API_PropertyGroup& group : groups) {
+                GS::Array<API_PropertyDefinition> defs;
+                ACAPI_Property_GetPropertyDefinitions (group.guid, defs);
+                for (const API_PropertyDefinition& def : defs) {
+                    if (def.guid == guid) {
+                        definition = def;
+                        found = true;
+                        break;
+                    }
+                }
+                if (found) break;
+            }
+            if (!found) {
+                executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "property not found"));
+                continue;
+            }
+
+            if (!definition.defaultValue.hasExpression) {
+                executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "property is not expression-based"));
+                continue;
+            }
+
+            GS::Array<GS::UniString> expressions;
+            item.Get ("expressions", expressions);
+            definition.defaultValue.propertyExpressions = expressions;
+
+            GSErrCode err = ACAPI_Property_ChangePropertyDefinition (definition);
+            if (err != NoError) {
+                executionResults (CreateFailedExecutionResult (err, "failed to update property definition"));
                 continue;
             }
 

--- a/archicad-addon/Sources/PropertyCommands.cpp
+++ b/archicad-addon/Sources/PropertyCommands.cpp
@@ -1470,27 +1470,9 @@ GS::ObjectState UpdatePropertyDefinitionsCommand::Execute (const GS::ObjectState
                 continue;
             }
 
-            const API_Guid guid = GetGuidFromObjectState (*propertyId);
-
-            // GetPropertyDefinitions takes a group GUID, not a definition GUID.
-            // Search all groups to locate the definition by its own GUID.
-            GS::Array<API_PropertyGroup> groups;
-            ACAPI_Property_GetPropertyGroups (groups);
-            bool found = false;
             API_PropertyDefinition definition;
-            for (const API_PropertyGroup& group : groups) {
-                GS::Array<API_PropertyDefinition> defs;
-                ACAPI_Property_GetPropertyDefinitions (group.guid, defs);
-                for (const API_PropertyDefinition& def : defs) {
-                    if (def.guid == guid) {
-                        definition = def;
-                        found = true;
-                        break;
-                    }
-                }
-                if (found) break;
-            }
-            if (!found) {
+            definition.guid = GetGuidFromObjectState (*propertyId);
+            if (ACAPI_Property_GetPropertyDefinition (definition) != NoError) {
                 executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "property not found"));
                 continue;
             }

--- a/archicad-addon/Sources/PropertyCommands.hpp
+++ b/archicad-addon/Sources/PropertyCommands.hpp
@@ -90,3 +90,13 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+
+class UpdatePropertyDefinitionsCommand : public CommandBase
+{
+public:
+    UpdatePropertyDefinitionsCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -1091,6 +1091,17 @@
             },
             "propertyIsEditable": {
                 "type": "boolean"
+            },
+            "isExpressionBased": {
+                "type": "boolean",
+                "description": "True if the property value is computed from an expression."
+            },
+            "expressions": {
+                "type": "array",
+                "description": "The expression strings of an expression-based property. Only present when isExpressionBased is true.",
+                "items": {
+                    "type": "string"
+                }
             }
         },
         "additionalProperties": false,
@@ -1102,7 +1113,8 @@
             "propertyCollectionType",
             "propertyValueType",
             "propertyMeasureType",
-            "propertyIsEditable"
+            "propertyIsEditable",
+            "isExpressionBased"
         ]
     },
     "PropertyValue": {


### PR DESCRIPTION
## Summary

- `GetAllProperties` now returns `isExpressionBased` (bool) and `expressions` (array of strings) for each property definition, exposing the ArchiCAD expression formula with `###Property:GUID###` references
- New command `UpdatePropertyDefinitions`: update the expression(s) of an existing expression-based custom property without changing its GUID
- New command `DeleteProjectInfoFields`: delete custom project info fields (ids starting with `autotext-`); hardcoded fields are rejected with a clear error
- Schema updated in `CommonSchemaDefinitions.json` with new fields on `PropertyDetails`

## Expression type support

Supported scalar types: `number`, `integer`, `string`, `boolean`, `length`, `area`, `volume`, `angle`

Notable syntax rules:
- `string` CONCAT uses comma separator: `CONCAT ( "prefix", ###Property:GUID### )`
- `integer` and `angle`: plain property reference, ArchiCAD converts automatically
- `length` / `area` / `volume`: use unit suffix, e.g. `value * 1 mm`

List types and enumeration types do not support expression-based values.

## Example scripts

- `test_property_expressions.py`: round-trip create/read/update of expression-based properties, GUID-to-label resolution, error handling (18 tests)
- `test_expression_project_info.py`: demonstrates `CreateProjectInfoFields`, `DeleteProjectInfoFields`, and a `string` property using `CONCAT` to reference a project info field
