### PR TITLE
feat(stories): return per-story height from GetStories

### DIFF
--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -461,6 +461,9 @@ GS::ObjectState GetStoriesCommand::Execute (const GS::ObjectState& /*parameters*
         storyData.Add ("floorId", story.floorId);
         storyData.Add ("dispOnSections", story.dispOnSections);
         storyData.Add ("level", story.level);
+        if (i + 1 < storyCount) {
+            storyData.Add ("height", (*storyInfo.data)[i + 1].level - story.level);
+        }
         storyData.Add ("name", uName);
 
         listAdder (storyData);

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -3812,6 +3812,10 @@
                 "type": "number",
                 "description": "The story level."
             },
+            "height": {
+                "type": "number",
+                "description": "Story height, calculated as the level of the story above minus this story's level. Omitted for the topmost story, which has no story above."
+            },
             "name": {
                 "type": "string",
                 "description": "The name of the story."


### PR DESCRIPTION
Adds a computed `height` to each story in the `GetStories` response, so callers can read back floor-to-floor storey heights (previously only `level` was returned, and there was no way to verify a storey height set via `SetStories`).

`API_StoryType` does not store a height — the DevKit notes it "should be calculated based on neighboring stories". So `height` is computed as **the next story's level minus this story's level**. The topmost story has no story above, so `height` is omitted there. The `StoryParameters` response schema documents the field.

Built clean on AC28.