### PR TITLE
Feature/floor plan polygons

### DIFF
--- a/archicad-addon/Examples/set_elements_draw_index.py
+++ b/archicad-addon/Examples/set_elements_draw_index.py
@@ -4,12 +4,12 @@ elements = aclib.RunTapirCommand ('GetAllElements', {})['elements']
 
 # Set all elements to draw index 1 (back of the draw order)
 aclib.RunTapirCommand (
-    'SetElementsDrawIndex', {
-        'elementsWithDrawIndex': [{'elementId': e['elementId'], 'drawIndex': 1} for e in elements]
+    'SetDetailsOfElements', {
+        'elementsWithDetails': [{'elementId': e['elementId'], 'details': {'drawIndex': 1}} for e in elements]
     })
 
 # Use drawIndex 0 to reset elements to the ArchiCAD default for their type
 # aclib.RunTapirCommand (
-#     'SetElementsDrawIndex', {
-#         'elementsWithDrawIndex': [{'elementId': e['elementId'], 'drawIndex': 0} for e in elements]
+#     'SetDetailsOfElements', {
+#         'elementsWithDetails': [{'elementId': e['elementId'], 'details': {'drawIndex': 0}} for e in elements]
 #     })

--- a/archicad-addon/Examples/set_elements_draw_index.py
+++ b/archicad-addon/Examples/set_elements_draw_index.py
@@ -1,0 +1,15 @@
+import aclib
+
+elements = aclib.RunTapirCommand ('GetAllElements', {})['elements']
+
+# Set all elements to draw index 1 (back of the draw order)
+aclib.RunTapirCommand (
+    'SetElementsDrawIndex', {
+        'elementsWithDrawIndex': [{'elementId': e['elementId'], 'drawIndex': 1} for e in elements]
+    })
+
+# Use drawIndex 0 to reset elements to the ArchiCAD default for their type
+# aclib.RunTapirCommand (
+#     'SetElementsDrawIndex', {
+#         'elementsWithDrawIndex': [{'elementId': e['elementId'], 'drawIndex': 0} for e in elements]
+#     })

--- a/archicad-addon/Examples/test_floor_plan_polygons.py
+++ b/archicad-addon/Examples/test_floor_plan_polygons.py
@@ -1,0 +1,154 @@
+"""
+test_floor_plan_polygons.py
+Teste GetDetailsOfElements.floorPlanPolygons sur des murs en T créés à la volée.
+
+Scénario :
+  1. Récupère les deux premiers étages disponibles dans le fichier
+  2. Sur chaque étage, crée 3 murs formant un T (mur horizontal + mur vertical)
+  3. Appelle GetDetailsOfElements pour récupérer floorPlanPolygons
+  4. Vérifie que chaque mur retourne au moins un polygone non vide
+  5. Crée une polyligne par mur (union des pièces) pour visualisation
+  6. Supprime les murs et polylignes créés (nettoyage)
+  7. Affiche PASS / FAIL
+"""
+import sys, math
+sys.path.insert(0, r"D:\ONEDRIVE\Documents\CODE PLUGINS\tapir-archicad-automation\archicad-addon\Examples")
+import aclib
+
+def run(cmd, p):
+    return aclib.RunTapirCommand(cmd, p, debug=False)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+def coord(x, y):
+    return {"x": x, "y": y}
+
+def union_polygons(raw_polys):
+    """Retourne le polygone union (extérieur) à partir d'une liste de raw polygons."""
+    from shapely.geometry import Polygon
+    from shapely.ops import unary_union
+    pieces = []
+    for p in raw_polys:
+        pts = [(c["x"], c["y"]) for c in p.get("coordinates", [])]
+        if len(pts) < 3:
+            continue
+        try:
+            sp = Polygon(pts)
+            if not sp.is_valid:
+                sp = sp.buffer(0)
+            if sp.area > 1e-9:
+                pieces.append(sp)
+        except Exception:
+            continue
+    if not pieces:
+        return None
+    fp = unary_union(pieces)
+    if fp.is_empty:
+        return None
+    if fp.geom_type == "MultiPolygon":
+        fp = max(fp.geoms, key=lambda g: g.area)
+    from shapely.geometry import Polygon as SPoly
+    return SPoly(fp.exterior)
+
+def create_t_walls(floor_index, size=3.0, thickness=0.3):
+    """Crée 3 murs en T sur l'étage floor_index. Retourne les elementIds créés."""
+    half_t = thickness / 2
+    walls_data = [
+        {
+            "begCoordinate": coord(-size, 0.0),
+            "endCoordinate": coord( size, 0.0),
+            "floorIndex": floor_index,
+            "zCoordinate": 0.0,
+            "height": 3.0,
+            "thickness": thickness,
+        },
+        {
+            "begCoordinate": coord(-half_t, 0.0),
+            "endCoordinate": coord(-half_t, -size),
+            "floorIndex": floor_index,
+            "zCoordinate": 0.0,
+            "height": 3.0,
+            "thickness": thickness,
+        },
+        {
+            "begCoordinate": coord( half_t, 0.0),
+            "endCoordinate": coord( half_t, -size),
+            "floorIndex": floor_index,
+            "zCoordinate": 0.0,
+            "height": 3.0,
+            "thickness": thickness,
+        },
+    ]
+    result = run("CreateWalls", {"wallsData": walls_data})
+    return [el["elementId"] for el in (result or {}).get("elements", [])]
+
+def test_floor(story):
+    floor_index = story["index"]
+    label       = f"Étage {floor_index} (z={story['level']:.2f}m, nom={story.get('name', '?')!r})"
+    print(f"\n── {label} ──────────────────────────────")
+
+    # 1. Créer les murs en T directement sur cet étage (sans changer de vue)
+    wall_ids = create_t_walls(floor_index)
+    if len(wall_ids) != 3:
+        print(f"  FAIL : CreateWalls a retourné {len(wall_ids)} mur(s) au lieu de 3")
+        return [], []
+
+    elements = [{"elementId": wid} for wid in wall_ids]
+
+    # 2. GetDetailsOfElements → floorPlanPolygons
+    dets = run("GetDetailsOfElements", {"elements": elements}).get("detailsOfElements", [])
+
+    created_polylines = []
+    all_pass = True
+
+    for i, (wid, det) in enumerate(zip(wall_ids, dets)):
+        guid = wid["guid"]
+        raw_polys = det.get("floorPlanPolygons", [])
+        poly = union_polygons(raw_polys)
+
+        if poly is None or poly.area < 1e-6:
+            print(f"  FAIL mur {i+1} ({guid[:8]}) : floorPlanPolygons vide ou absent")
+            all_pass = False
+            continue
+
+        print(f"  OK   mur {i+1} ({guid[:8]}) : {len(raw_polys)} pièce(s) → {poly.area:.4f} m²")
+
+        # 3. Créer une polyligne de contour sur le même étage
+        coords_list = [{"x": x, "y": y} for x, y in poly.exterior.coords]
+        pl_result = run("CreatePolylines", {"polylinesData": [{"coordinates": coords_list, "floorInd": floor_index}]})
+        pl_els = (pl_result or {}).get("elements", [])
+        if pl_els:
+            created_polylines.append(pl_els[0]["elementId"])
+
+    if all_pass:
+        print(f"  PASS {label} — {len(created_polylines)} polyligne(s) créée(s)")
+    else:
+        print(f"  FAIL {label}")
+
+    return [wid for wid in wall_ids], created_polylines
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+print(f"ArchiCAD : {run('GetArchicadLocation', {}).get('archicadLocation', '?')}")
+
+stories = run("GetStories", {}).get("stories", [])
+if len(stories) < 2:
+    print(f"SKIP : seulement {len(stories)} étage(s) disponible(s), il en faut 2")
+    sys.exit(0)
+
+# Prendre les 2 premiers étages
+test_stories = sorted(stories, key=lambda s: s["index"])[:2]
+
+all_walls     = []
+all_polylines = []
+
+for story in test_stories:
+    walls, polylines = test_floor(story)
+    all_walls.extend(walls)
+    all_polylines.extend(polylines)
+
+# ── Nettoyage ─────────────────────────────────────────────────────────────────
+# to_delete = [{"elementId": wid} for wid in all_walls] + \
+#             [{"elementId": pid} for pid in all_polylines]
+# if to_delete:
+#     run("DeleteElements", {"elements": to_delete})
+#     print(f"  {len(all_walls)} mur(s) + {len(all_polylines)} polyligne(s) supprimés")
+print(f"\n{len(all_walls)} mur(s) + {len(all_polylines)} polyligne(s) laissés dans le fichier")

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -254,10 +254,6 @@ GSErrCode Initialize (void)
             elementCommands, "1.0.7",
             "Sets the details of the given elements (floor, layer, order etc)."
         );
-        err |= RegisterCommand<SetElementsDrawIndexCommand> (
-            elementCommands, "1.5.4",
-            "Sets the draw order position of the given elements. Use drawIndex 0 to reset to the ArchiCAD default for the element type."
-        );
         err |= RegisterCommand<Get3DBoundingBoxesCommand> (
             elementCommands, "1.1.2",
             "Get the 3D bounding box of elements. The bounding box is calculated from the global origin in the 3D view. The output is the array of the bounding boxes respective to the input array of elements."

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -254,6 +254,10 @@ GSErrCode Initialize (void)
             elementCommands, "1.0.7",
             "Sets the details of the given elements (floor, layer, order etc)."
         );
+        err |= RegisterCommand<SetElementsDrawIndexCommand> (
+            elementCommands, "1.5.4",
+            "Sets the draw order position of the given elements. Use drawIndex 0 to reset to the ArchiCAD default for the element type."
+        );
         err |= RegisterCommand<Get3DBoundingBoxesCommand> (
             elementCommands, "1.1.2",
             "Get the 3D bounding box of elements. The bounding box is calculated from the global origin in the 3D view. The output is the array of the bounding boxes respective to the input array of elements."

--- a/archicad-addon/Sources/ApplicationCommands.cpp
+++ b/archicad-addon/Sources/ApplicationCommands.cpp
@@ -316,6 +316,24 @@ GS::ObjectState ChangeWindowCommand::Execute (const GS::ObjectState& parameters,
         return CreateFailedExecutionResult (APIERR_BADPARS, "Invalid parameter: windowType.");
     }
 
+    Int32 storyIndex = 0;
+    const bool hasStoryIndex = parameters.Get ("storyIndex", storyIndex);
+    if (hasStoryIndex) {
+        if (windowInfo.typeID != APIWind_FloorPlanID) {
+            return CreateFailedExecutionResult (APIERR_BADPARS, "storyIndex is only valid when windowType is 'FloorPlan'.");
+        }
+        windowInfo.index = storyIndex;
+        // GetDatabaseInfo fills in the GUID and all fields from typeID+index,
+        // which are needed to change the current database (used by ACAPI element creation).
+        if (ACAPI_Window_GetDatabaseInfo (&windowInfo) == NoError) {
+            ACAPI_Database_ChangeCurrentDatabase (&windowInfo);
+        }
+        const GSErrCode err = ACAPI_Window_ChangeWindow (&windowInfo);
+        return err == NoError
+            ? CreateSuccessfulExecutionResult ()
+            : CreateFailedExecutionResult (err, "Failed to change active story.");
+    }
+
     const GS::ObjectState* databaseId = parameters.Get ("databaseId");
     if (databaseId != nullptr) {
         API_DatabaseInfo targetDatabase = DatabaseIdResolver::Instance ().GetDatabaseWithId (GetGuidFromObjectState (*databaseId));
@@ -341,3 +359,4 @@ GS::ObjectState ChangeWindowCommand::Execute (const GS::ObjectState& parameters,
         ? CreateSuccessfulExecutionResult ()
         : CreateErrorResponse (err, "Failed to change the window!");
 }
+

--- a/archicad-addon/Sources/ApplicationCommands.hpp
+++ b/archicad-addon/Sources/ApplicationCommands.hpp
@@ -47,3 +47,4 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -922,11 +922,23 @@ GS::ObjectState SetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                 if (drwIndexTarget == 0) {
                     ACAPI_Grouping_Tool (guids, APITool_ResetOrder, nullptr);
                 } else {
-                    const Int32 target = GS::Max (1, GS::Min ((Int32) drwIndexTarget, 14));
-                    const Int32 delta  = target - (Int32) elem.header.drwIndex;
-                    if (delta != 0) {
-                        const API_ToolCmdID step = (delta > 0) ? APITool_BringForward : APITool_SendBackward;
-                        for (Int32 i = 0; i < GS::Abs (delta); ++i)
+                    const Int32 target       = GS::Max (1, GS::Min ((Int32) drwIndexTarget, 14));
+                    const Int32 current      = (Int32) elem.header.drwIndex;
+                    const Int32 directCost   = GS::Abs (target - current);
+                    const Int32 viaFrontCost = 1 + (14 - target);
+                    const Int32 viaBackCost  = 1 + (target - 1);
+
+                    if (viaFrontCost <= GS::Min (directCost, viaBackCost)) {
+                        ACAPI_Grouping_Tool (guids, APITool_BringToFront, nullptr);
+                        for (Int32 i = 0; i < 14 - target; ++i)
+                            ACAPI_Grouping_Tool (guids, APITool_SendBackward, nullptr);
+                    } else if (viaBackCost <= GS::Min (directCost, viaFrontCost)) {
+                        ACAPI_Grouping_Tool (guids, APITool_SendToBack, nullptr);
+                        for (Int32 i = 0; i < target - 1; ++i)
+                            ACAPI_Grouping_Tool (guids, APITool_BringForward, nullptr);
+                    } else {
+                        const API_ToolCmdID step = (target > current) ? APITool_BringForward : APITool_SendBackward;
+                        for (Int32 i = 0; i < directCost; ++i)
                             ACAPI_Grouping_Tool (guids, step, nullptr);
                     }
                 }

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -839,19 +839,19 @@ GS::ObjectState SetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
 
             API_Element mask = {};
             ACAPI_ELEMENT_MASK_CLEAR (mask);
+            bool hasElementChanges = false;
             if (details->Get ("floorIndex", elem.header.floorInd)) {
                 ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, floorInd);
+                hasElementChanges = true;
             }
             Int32 layerIndex;
             if (details->Get ("layerIndex", layerIndex)) {
                 elem.header.layer = ACAPI_CreateAttributeIndex (layerIndex);
                 ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, layer);
+                hasElementChanges = true;
             }
-            short drwIndex;
-            if (details->Get ("drawIndex", drwIndex)) {
-                elem.header.drwIndex = static_cast<char> (drwIndex);
-                ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, drwIndex);
-            }
+            short drwIndexTarget = -1;
+            details->Get ("drawIndex", drwIndexTarget);
 
             const GS::ObjectState* typeSpecificDetails = details->Get ("typeSpecificDetails");
             if (typeSpecificDetails != nullptr) {
@@ -903,16 +903,33 @@ GS::ObjectState SetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                     default:
                     break;
                 }
-                ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, drwIndex);
+                hasElementChanges = true;
             }
 
             constexpr API_ElementMemo* memo = nullptr;
             constexpr UInt64 memoMask = 0;
             constexpr bool withDel = true;
-            err = ACAPI_Element_Change (&elem, &mask, memo, memoMask, withDel);
-            if (err != NoError) {
-                executionResults (CreateFailedExecutionResult (err, "Failed to change element"));
-                continue;
+            if (hasElementChanges) {
+                err = ACAPI_Element_Change (&elem, &mask, memo, memoMask, withDel);
+                if (err != NoError) {
+                    executionResults (CreateFailedExecutionResult (err, "Failed to change element"));
+                    continue;
+                }
+            }
+
+            if (drwIndexTarget >= 0) {
+                GS::Array<API_Guid> guids = { elem.header.guid };
+                if (drwIndexTarget == 0) {
+                    ACAPI_Grouping_Tool (guids, APITool_ResetOrder, nullptr);
+                } else {
+                    const Int32 target = GS::Max (1, GS::Min ((Int32) drwIndexTarget, 14));
+                    const Int32 delta  = target - (Int32) elem.header.drwIndex;
+                    if (delta != 0) {
+                        const API_ToolCmdID step = (delta > 0) ? APITool_BringForward : APITool_SendBackward;
+                        for (Int32 i = 0; i < GS::Abs (delta); ++i)
+                            ACAPI_Grouping_Tool (guids, step, nullptr);
+                    }
+                }
             }
 
             executionResults (CreateSuccessfulExecutionResult ());
@@ -2672,115 +2689,3 @@ GS::ObjectState GetRoomImageCommand::Execute (const GS::ObjectState& parameters,
     return GS::ObjectState ("roomImage", str);
 }
 
-SetElementsDrawIndexCommand::SetElementsDrawIndexCommand () :
-    CommandBase (CommonSchema::Used)
-{}
-
-GS::String SetElementsDrawIndexCommand::GetName () const
-{
-    return "SetElementsDrawIndex";
-}
-
-GS::Optional<GS::UniString> SetElementsDrawIndexCommand::GetInputParametersSchema () const
-{
-    return R"({
-        "type": "object",
-        "properties": {
-            "elementsWithDrawIndex": {
-                "type": "array",
-                "description": "Elements to reorder.",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "elementId": {
-                            "$ref": "#/ElementId"
-                        },
-                        "drawIndex": {
-                            "type": "integer",
-                            "description": "Target stack level (1 = back, 14 = front). Use 0 to reset to the ArchiCAD default for the element type.",
-                            "minimum": 0,
-                            "maximum": 14
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": ["elementId", "drawIndex"]
-                }
-            }
-        },
-        "additionalProperties": false,
-        "required": ["elementsWithDrawIndex"]
-    })";
-}
-
-GS::Optional<GS::UniString> SetElementsDrawIndexCommand::GetResponseSchema () const
-{
-    return R"({
-        "type": "object",
-        "properties": {
-            "executionResults": {
-                "$ref": "#/ExecutionResults"
-            }
-        },
-        "additionalProperties": false,
-        "required": ["executionResults"]
-    })";
-}
-
-GS::ObjectState SetElementsDrawIndexCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
-{
-    GS::Array<GS::ObjectState> elementsWithDrawIndex;
-    parameters.Get ("elementsWithDrawIndex", elementsWithDrawIndex);
-
-    GS::ObjectState response;
-    const auto& executionResults = response.AddList<GS::ObjectState> ("executionResults");
-
-    ACAPI_CallUndoableCommand ("SetElementsDrawIndex", [&] () -> GSErrCode {
-        for (const GS::ObjectState& item : elementsWithDrawIndex) {
-            const GS::ObjectState* elementId = item.Get ("elementId");
-            if (elementId == nullptr) {
-                executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "elementId is missing"));
-                continue;
-            }
-
-            const API_Guid guid = GetGuidFromObjectState (*elementId);
-            GS::Array<API_Guid> guids = { guid };
-
-            Int32 targetIndex = 0;
-            item.Get ("drawIndex", targetIndex);
-
-            if (targetIndex == 0) {
-                GSErrCode err = ACAPI_Grouping_Tool (guids, APITool_ResetOrder, nullptr);
-                executionResults (err == NoError
-                    ? CreateSuccessfulExecutionResult ()
-                    : CreateFailedExecutionResult (err, "Failed to reset draw order"));
-                continue;
-            }
-
-            API_Element elem = {};
-            elem.header.guid = guid;
-            GSErrCode err = ACAPI_Element_Get (&elem);
-            if (err != NoError) {
-                executionResults (CreateFailedExecutionResult (err, "Failed to get element"));
-                continue;
-            }
-
-            const Int32 currentDrwIdx = elem.header.drwIndex;
-            const Int32 target        = GS::Max (1, GS::Min (targetIndex, 14));
-            const Int32 delta         = target - currentDrwIdx;
-
-            if (delta == 0) {
-                executionResults (CreateSuccessfulExecutionResult ());
-                continue;
-            }
-
-            const API_ToolCmdID step = (delta > 0) ? APITool_BringForward : APITool_SendBackward;
-            for (Int32 i = 0; i < GS::Abs (delta); ++i)
-                ACAPI_Grouping_Tool (guids, step, nullptr);
-
-            executionResults (CreateSuccessfulExecutionResult ());
-        }
-        return NoError;
-    });
-
-    return response;
-}

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -2671,3 +2671,116 @@ GS::ObjectState GetRoomImageCommand::Execute (const GS::ObjectState& parameters,
     str.DeleteAll (GS::UniChar(char('\n')));
     return GS::ObjectState ("roomImage", str);
 }
+
+SetElementsDrawIndexCommand::SetElementsDrawIndexCommand () :
+    CommandBase (CommonSchema::Used)
+{}
+
+GS::String SetElementsDrawIndexCommand::GetName () const
+{
+    return "SetElementsDrawIndex";
+}
+
+GS::Optional<GS::UniString> SetElementsDrawIndexCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "elementsWithDrawIndex": {
+                "type": "array",
+                "description": "Elements to reorder.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": {
+                            "$ref": "#/ElementId"
+                        },
+                        "drawIndex": {
+                            "type": "integer",
+                            "description": "Target stack level (1 = back, 14 = front). Use 0 to reset to the ArchiCAD default for the element type.",
+                            "minimum": 0,
+                            "maximum": 14
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": ["elementId", "drawIndex"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["elementsWithDrawIndex"]
+    })";
+}
+
+GS::Optional<GS::UniString> SetElementsDrawIndexCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "executionResults": {
+                "$ref": "#/ExecutionResults"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["executionResults"]
+    })";
+}
+
+GS::ObjectState SetElementsDrawIndexCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::ObjectState> elementsWithDrawIndex;
+    parameters.Get ("elementsWithDrawIndex", elementsWithDrawIndex);
+
+    GS::ObjectState response;
+    const auto& executionResults = response.AddList<GS::ObjectState> ("executionResults");
+
+    ACAPI_CallUndoableCommand ("SetElementsDrawIndex", [&] () -> GSErrCode {
+        for (const GS::ObjectState& item : elementsWithDrawIndex) {
+            const GS::ObjectState* elementId = item.Get ("elementId");
+            if (elementId == nullptr) {
+                executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "elementId is missing"));
+                continue;
+            }
+
+            const API_Guid guid = GetGuidFromObjectState (*elementId);
+            GS::Array<API_Guid> guids = { guid };
+
+            Int32 targetIndex = 0;
+            item.Get ("drawIndex", targetIndex);
+
+            if (targetIndex == 0) {
+                GSErrCode err = ACAPI_Grouping_Tool (guids, APITool_ResetOrder, nullptr);
+                executionResults (err == NoError
+                    ? CreateSuccessfulExecutionResult ()
+                    : CreateFailedExecutionResult (err, "Failed to reset draw order"));
+                continue;
+            }
+
+            API_Element elem = {};
+            elem.header.guid = guid;
+            GSErrCode err = ACAPI_Element_Get (&elem);
+            if (err != NoError) {
+                executionResults (CreateFailedExecutionResult (err, "Failed to get element"));
+                continue;
+            }
+
+            const Int32 currentDrwIdx = elem.header.drwIndex;
+            const Int32 target        = GS::Max (1, GS::Min (targetIndex, 14));
+            const Int32 delta         = target - currentDrwIdx;
+
+            if (delta == 0) {
+                executionResults (CreateSuccessfulExecutionResult ());
+                continue;
+            }
+
+            const API_ToolCmdID step = (delta > 0) ? APITool_BringForward : APITool_SendBackward;
+            for (Int32 i = 0; i < GS::Abs (delta); ++i)
+                ACAPI_Grouping_Tool (guids, step, nullptr);
+
+            executionResults (CreateSuccessfulExecutionResult ());
+        }
+        return NoError;
+    });
+
+    return response;
+}

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -279,6 +279,21 @@ GS::Optional<GS::UniString> GetDetailsOfElementsCommand::GetResponseSchema () co
                         },
                         "details": {
                             "$ref": "#/TypeSpecificDetails"
+                        },
+                        "floorPlanPolygons": {
+                            "type": "array",
+                            "description": "Cut-fill polygons as drawn on the floor plan (wall joins resolved by ArchiCAD). Available for elements with a cut-fill representation (walls, columns, beams). Absent when the element has no cut fill or when the floor plan database is not accessible.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "coordinates": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/2DCoordinate"
+                                        }
+                                    }
+                                }
+                            }
                         }
                     },
                     "additionalProperties": false,
@@ -298,6 +313,91 @@ GS::Optional<GS::UniString> GetDetailsOfElementsCommand::GetResponseSchema () co
             "detailsOfElements"
         ]
     })";
+}
+
+// ── Floor plan polygon infrastructure (used by GetDetailsOfElements) ─────────
+
+struct FloorPlanCollectorContext {
+    GS::Array<GS::Array<API_Coord>> polys;
+    bool inCutFill = false;
+};
+
+static thread_local FloorPlanCollectorContext* tl_floorPlanCtx = nullptr;
+
+static GSErrCode CollectCutFillPolygons (const API_PrimElement* primElem,
+                                          const void* par1, const void* par2, const void* /*par3*/)
+{
+    if (tl_floorPlanCtx == nullptr)
+        return NoError;
+
+    switch (primElem->header.typeID) {
+        case API_PrimCtrl_HatchBorderBegID: {
+            const auto* border = static_cast<const API_PrimHatchBorder*> (par1);
+            tl_floorPlanCtx->inCutFill = (border != nullptr && border->determination == APIHatch_CutFills);
+            break;
+        }
+        case API_PrimCtrl_HatchBorderEndID:
+            tl_floorPlanCtx->inCutFill = false;
+            break;
+        case API_PrimPolyID: {
+            if (!tl_floorPlanCtx->inCutFill)
+                break;
+            const Int32 nCoords = primElem->poly.nCoords;
+            if (nCoords < 3)
+                break;
+            const auto* coords = static_cast<const API_Coord*> (par1);
+            const auto* pends  = static_cast<const Int32*> (par2);
+            Int32 start = 1;
+            const Int32 nSubPolys = primElem->poly.nSubPolys;
+            for (Int32 sub = 1; sub <= nSubPolys; ++sub) {
+                const Int32 end = (pends != nullptr) ? pends[sub] : nCoords;
+                GS::Array<API_Coord> ring;
+                for (Int32 i = start; i <= end; ++i)
+                    ring.Push (coords[i]);
+                if (ring.GetSize () >= 3)
+                    tl_floorPlanCtx->polys.Push (ring);
+                start = end + 1;
+            }
+            break;
+        }
+        default:
+            break;
+    }
+    return NoError;
+}
+
+static void AddFloorPlanPolygonsIfAvailable (const API_Guid& guid, GS::ObjectState& os)
+{
+    FloorPlanCollectorContext ctx;
+    tl_floorPlanCtx = &ctx;
+    const GS::OnExit ctxGuard ([&] () { tl_floorPlanCtx = nullptr; });
+
+    API_Elem_Head elemHead = {};
+    elemHead.guid = guid;
+
+    API_ShapePrimsParams params = {};
+    params.dontClip   = true;
+    params.allStories = true;
+    params.polygon    = nullptr;
+
+#ifdef ServerMainVers_2600
+    const GSErrCode fpErr = ACAPI_DrawingPrimitive_ShapePrimsExt (elemHead, CollectCutFillPolygons, &params);
+#else
+    const GSErrCode fpErr = ACAPI_Element_ShapePrimsExt (elemHead, CollectCutFillPolygons, &params);
+#endif
+    if (fpErr != NoError)
+        return;
+    if (ctx.polys.IsEmpty ())
+        return;
+
+    const auto& polygonsOS = os.AddList<GS::ObjectState> ("floorPlanPolygons");
+    for (const GS::Array<API_Coord>& poly : ctx.polys) {
+        GS::ObjectState polyOS;
+        const auto& coordsOS = polyOS.AddList<GS::ObjectState> ("coordinates");
+        for (const API_Coord& c : poly)
+            coordsOS (Create2DCoordinateObjectState (c));
+        polygonsOS (polyOS);
+    }
 }
 
 static void AddLibPartBasedElementDetails (GS::ObjectState& os, const Int32 libInd, const API_Guid& owner, API_ElemTypeID ownerType = API_ZombieElemID)
@@ -748,6 +848,7 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
         }
 
         detailsOfElement.Add ("details", typeSpecificDetails);
+        AddFloorPlanPolygonsIfAvailable (elem.header.guid, detailsOfElement);
 
         detailsOfElements (detailsOfElement);
     }

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -806,6 +806,183 @@ GS::Optional<GS::UniString> SetDetailsOfElementsCommand::GetResponseSchema () co
     })";
 }
 
+// ============================================================
+// drawIndex repositioning — implementation notes
+// ============================================================
+//
+// WHY NOT ACAPI_Element_Change WITH drwIndex MASK
+// ------------------------------------------------
+// ACAPI_Element_Change silently ignores the drwIndex field even when the
+// mask bit is set (confirmed Graphisoft bug, AC27). The only working API
+// is ACAPI_Grouping_Tool with the following commands:
+//   APITool_BringForward  (+1, reliable)
+//   APITool_SendBackward  (-1, reliable)
+//   APITool_ResetOrder    (→ class default, unreliable for some types — see below)
+//
+// DEAD ENDS (do not reintroduce)
+// --------------------------------
+//   APITool_BringToFront : unreliable on Wall and its sub-elements; causes
+//                          unexpected level jumps. Removed from all strategies.
+//   APITool_SendToBack   : does NOT reliably reach level 1. In sparse files
+//                          it stops at 2 or 3. Removed from all strategies.
+//
+// STRATEGIES FOR NORMAL ELEMENTS
+// --------------------------------
+// Target clamped to [1, 14]. Two strategies, cheapest wins:
+//   Direct  : |target - current| × BringForward or SendBackward
+//   ViaReset: 1 ResetOrder + |target - classDefault| steps
+//             (disabled for Morph, Railing, PolyLine — ResetOrder is a no-op
+//              for these types; a simulated default from GetDefaultDrwIndex is
+//              used instead if they need to reach their default level)
+//
+// CLASS DEFAULTS (per ArchiCAD documentation, levels 1-4 and 11-14 are void)
+//   5  : Drawing
+//   6  : Hatch, Zone
+//   7  : Wall, Slab, Roof, Shell, Morph, Mesh, Column, CurtainWall, Stair,
+//         Railing, Door, Window, Skylight, Opening
+//   8  : Lamp, Object
+//   9  : Line, Arc, Spline, PolyLine, Beam, Hotspot, ChangeMarker, Detail,
+//         Worksheet
+//   10 : Dimension (all types), Label, Text, CutPlane, Elevation,
+//         InteriorElevation
+//
+// OPENINGS (Door, Window, Skylight) — special case
+// --------------------------------------------------
+// ArchiCAD enforces a hard minimum of 7 for elements embedded in a host
+// (wall or roof/shell). Levels 1-6 are unreachable regardless of strategy.
+//
+// Host types by opening type:
+//   Door   → Wall
+//   Window → Wall
+//   Skylight → Roof or Shell
+//
+// Levels 8-14 require indirect host manipulation:
+//   1. Step host UP  (target - hostOriginal) × BringForward  → opening follows
+//   2. Step host DOWN the same number of times × SendBackward → host returns,
+//      opening stays elevated (the two are decoupled once host passes the
+//      opening's natural level)
+//
+// Reset (drawIndex = 0) on an elevated opening is a no-op via direct
+// ResetOrder. It must be applied to the HOST instead, which resets all its
+// openings to level 7.
+//
+// Reverse host lookup (opening → host) is not exposed by the API. It requires
+// a forward scan: enumerate all walls/roofs/shells, call GetConnectedElements
+// on each, build an inverse map.
+//
+// BATCH ORDERING CONSTRAINT
+// --------------------------
+// Openings are processed before all other elements within the same batch.
+// This ensures the host manipulation reads the host's pre-batch position, not
+// a position already shifted by another element in the same call.
+//
+// KNOWN LIMITATIONS
+// -----------------
+// • Door/Window/Skylight: levels 1-6 are unreachable (ArchiCAD constraint).
+// • An opening cannot be below its host's current level. If the host wall/roof
+//   is at level 9, the opening cannot reach levels 7 or 8.
+// • Multiple openings in the same host wall/roof with different targets in a
+//   single batch: all will end up at the same level (the last one processed),
+//   because moving the host affects all its openings simultaneously.
+// • Opening (API_OpeningID, generic void): completely immovable. All
+//   Grouping_Tool calls are no-ops. ArchiCAD displays level 0 for these
+//   elements (outside the 1-14 ordering system); the API may report 7
+//   (class default) but the actual display order cannot be changed. Likely
+//   due to multi-host nature (can span Wall, Slab, Roof, Shell, Beam, Column).
+// • Morph, Railing, PolyLine: ResetOrder is a no-op; reset (drawIndex = 0)
+//   is simulated by stepping from current position to the class default.
+// ============================================================
+
+static bool IsOpeningType (const API_Elem_Head& head)
+{
+    switch (GetElemTypeId (head)) {
+        case API_DoorID:
+        case API_WindowID:
+        case API_SkylightID: return true;
+        default:             return false;
+    }
+}
+
+static bool IsResetOrderReliable (const API_Elem_Head& head)
+{
+    switch (GetElemTypeId (head)) {
+        case API_MorphID:
+        case API_RailingID:
+        case API_PolyLineID: return false;
+        default:             return true;
+    }
+}
+
+static Int32 GetDefaultDrwIndex (const API_Elem_Head& head)
+{
+    switch (GetElemTypeId (head)) {
+        case API_DrawingID:                                                      return 5;
+        case API_HatchID:     case API_ZoneID:                                   return 6;
+        case API_WallID:      case API_SlabID:      case API_RoofID:
+        case API_ShellID:     case API_MorphID:     case API_MeshID:
+        case API_ColumnID:    case API_CurtainWallID: case API_StairID:
+        case API_RailingID:   case API_DoorID:      case API_WindowID:
+        case API_SkylightID:  case API_OpeningID:                                return 7;
+        case API_LampID:      case API_ObjectID:                                 return 8;
+        case API_LineID:      case API_ArcID:       case API_SplineID:
+        case API_PolyLineID:  case API_BeamID:      case API_HotspotID:
+        case API_ChangeMarkerID: case API_DetailID: case API_WorksheetID:        return 9;
+        case API_DimensionID: case API_RadialDimensionID:
+        case API_LevelDimensionID: case API_AngleDimensionID:
+        case API_LabelID:     case API_TextID:      case API_CutPlaneID:
+        case API_ElevationID: case API_InteriorElevationID:                      return 10;
+        default:                                                                  return 7;
+    }
+}
+
+static void ApplyDrawIndexStrategy (GS::Array<API_Guid>& guids, const API_Elem_Head& head, Int32 target, Int32 current)
+{
+    target = GS::Max (1, GS::Min (target, 14));
+    const Int32 defaultLevel = GetDefaultDrwIndex (head);
+    const Int32 directCost   = GS::Abs (target - current);
+    const Int32 viaResetCost = IsResetOrderReliable (head)
+                             ? 1 + GS::Abs (target - defaultLevel)
+                             : INT_MAX;
+
+    if (viaResetCost < directCost) {
+        ACAPI_Grouping_Tool (guids, APITool_ResetOrder, nullptr);
+        const API_ToolCmdID step = (target > defaultLevel) ? APITool_BringForward : APITool_SendBackward;
+        for (Int32 i = 0; i < GS::Abs (target - defaultLevel); ++i)
+            ACAPI_Grouping_Tool (guids, step, nullptr);
+    } else {
+        const API_ToolCmdID step = (target > current) ? APITool_BringForward : APITool_SendBackward;
+        for (Int32 i = 0; i < directCost; ++i)
+            ACAPI_Grouping_Tool (guids, step, nullptr);
+    }
+}
+
+static GS::HashTable<API_Guid, API_Guid> BuildOpeningToHostMap (const GS::HashSet<API_Guid>& targetGuids)
+{
+    GS::HashTable<API_Guid, API_Guid> result;
+    if (targetGuids.IsEmpty ())
+        return result;
+
+    auto scan = [&](API_ElemTypeID hostType, API_ElemTypeID openType) {
+        GS::Array<API_Guid> hostList;
+        ACAPI_Element_GetElemList (hostType, &hostList, APIFilt_None);
+        for (const API_Guid& hostGuid : hostList) {
+            GS::Array<API_Guid> connected;
+            ACAPI_Grouping_GetConnectedElements (hostGuid, openType, &connected);
+            for (const API_Guid& g : connected) {
+                if (targetGuids.Contains (g) && !result.ContainsKey (g))
+                    result.Add (g, hostGuid);
+            }
+        }
+    };
+
+    scan (API_WallID,  API_DoorID);
+    scan (API_WallID,  API_WindowID);
+    scan (API_RoofID,  API_SkylightID);
+    scan (API_ShellID, API_SkylightID);
+
+    return result;
+}
+
 GS::ObjectState SetDetailsOfElementsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
     GS::Array<GS::ObjectState> elementsWithDetails;
@@ -814,8 +991,41 @@ GS::ObjectState SetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
     GS::ObjectState response;
     const auto& executionResults = response.AddList<GS::ObjectState> ("executionResults");
 
+    // Pre-scan: identify openings (Door/Window/Skylight) that need host manipulation:
+    //   - target > 7  : elevate via host (step up, step back)
+    //   - target == 0 : reset via host ResetOrder (direct ResetOrder on opening doesn't work when elevated)
+    GS::HashSet<API_Guid> openingsNeedingHost;
+    for (const GS::ObjectState& ewd : elementsWithDetails) {
+        const GS::ObjectState* eid = ewd.Get ("elementId");
+        const GS::ObjectState* det = ewd.Get ("details");
+        if (eid == nullptr || det == nullptr) continue;
+        short tgt = -1;
+        det->Get ("drawIndex", tgt);
+        if (tgt > 0 && tgt <= 7) continue;   // 1-7: no host needed
+        API_Element hdr = {};
+        hdr.header.guid = GetGuidFromObjectState (*eid);
+        if (ACAPI_Element_GetHeader (&hdr.header) != NoError) continue;
+        if (IsOpeningType (hdr.header))
+            openingsNeedingHost.Add (hdr.header.guid);
+    }
+    const GS::HashTable<API_Guid, API_Guid> openingToHost = BuildOpeningToHostMap (openingsNeedingHost);
+
+    // Process openings first so host manipulation starts from the host's natural position,
+    // not a position already shifted by another element in the same batch.
+    GS::Array<GS::ObjectState> sortedElements;
+    for (const GS::ObjectState& ewd : elementsWithDetails) {
+        const GS::ObjectState* eid = ewd.Get ("elementId");
+        if (eid != nullptr && openingsNeedingHost.Contains (GetGuidFromObjectState (*eid)))
+            sortedElements.Push (ewd);
+    }
+    for (const GS::ObjectState& ewd : elementsWithDetails) {
+        const GS::ObjectState* eid = ewd.Get ("elementId");
+        if (eid == nullptr || !openingsNeedingHost.Contains (GetGuidFromObjectState (*eid)))
+            sortedElements.Push (ewd);
+    }
+
     ACAPI_CallUndoableCommand ("SetDetailsOfElementsCommand", [&]() {
-        for (const GS::ObjectState& elementWithDetails : elementsWithDetails) {
+        for (const GS::ObjectState& elementWithDetails : sortedElements) {
             const GS::ObjectState* elementId = elementWithDetails.Get ("elementId");
             if (elementId == nullptr) {
                 executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "elementId is missing"));
@@ -919,28 +1129,42 @@ GS::ObjectState SetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
 
             if (drwIndexTarget >= 0) {
                 GS::Array<API_Guid> guids = { elem.header.guid };
-                if (drwIndexTarget == 0) {
-                    ACAPI_Grouping_Tool (guids, APITool_ResetOrder, nullptr);
-                } else {
-                    const Int32 target       = GS::Max (1, GS::Min ((Int32) drwIndexTarget, 14));
-                    const Int32 current      = (Int32) elem.header.drwIndex;
-                    const Int32 directCost   = GS::Abs (target - current);
-                    const Int32 viaFrontCost = 1 + (14 - target);
-                    const Int32 viaBackCost  = 1 + (target - 1);
 
-                    if (viaFrontCost <= GS::Min (directCost, viaBackCost)) {
-                        ACAPI_Grouping_Tool (guids, APITool_BringToFront, nullptr);
-                        for (Int32 i = 0; i < 14 - target; ++i)
-                            ACAPI_Grouping_Tool (guids, APITool_SendBackward, nullptr);
-                    } else if (viaBackCost <= GS::Min (directCost, viaFrontCost)) {
-                        ACAPI_Grouping_Tool (guids, APITool_SendToBack, nullptr);
-                        for (Int32 i = 0; i < target - 1; ++i)
-                            ACAPI_Grouping_Tool (guids, APITool_BringForward, nullptr);
-                    } else {
-                        const API_ToolCmdID step = (target > current) ? APITool_BringForward : APITool_SendBackward;
-                        for (Int32 i = 0; i < directCost; ++i)
-                            ACAPI_Grouping_Tool (guids, step, nullptr);
+                if (IsOpeningType (elem.header) && drwIndexTarget > 7) {
+                    // Openings (Door/Window/Skylight) can only reach levels above 7 by
+                    // temporarily elevating their host wall/roof step by step, then
+                    // bringing it back the same way (BringToFront is unreliable on walls).
+                    const API_Guid* hostGuidPtr = openingToHost.GetPtr (elem.header.guid);
+                    if (hostGuidPtr != nullptr) {
+                        API_Element hostElem = {};
+                        hostElem.header.guid = *hostGuidPtr;
+                        if (ACAPI_Element_Get (&hostElem) == NoError) {
+                            const Int32 hostOriginal = (Int32) hostElem.header.drwIndex;
+                            const Int32 target       = GS::Max (8, GS::Min ((Int32) drwIndexTarget, 14));
+                            const Int32 steps        = target - hostOriginal;
+                            GS::Array<API_Guid> hostGuids = { *hostGuidPtr };
+                            if (steps > 0) {
+                                // Step host up — opening follows
+                                for (Int32 i = 0; i < steps; ++i)
+                                    ACAPI_Grouping_Tool (hostGuids, APITool_BringForward, nullptr);
+                                // Step host back down — opening stays elevated
+                                for (Int32 i = 0; i < steps; ++i)
+                                    ACAPI_Grouping_Tool (hostGuids, APITool_SendBackward, nullptr);
+                            }
+                        }
                     }
+                } else if (drwIndexTarget == 0 && IsOpeningType (elem.header)) {
+                    // Reset elevated opening via its host (direct ResetOrder on opening doesn't work)
+                    const API_Guid* hostGuidPtr = openingToHost.GetPtr (elem.header.guid);
+                    if (hostGuidPtr != nullptr) {
+                        GS::Array<API_Guid> hostGuids = { *hostGuidPtr };
+                        ACAPI_Grouping_Tool (hostGuids, APITool_ResetOrder, nullptr);
+                    }
+                } else if (drwIndexTarget == 0 && IsResetOrderReliable (elem.header)) {
+                    ACAPI_Grouping_Tool (guids, APITool_ResetOrder, nullptr);
+                } else if (drwIndexTarget != 0 || !IsResetOrderReliable (elem.header)) {
+                    const short resolvedTarget = (drwIndexTarget == 0) ? (short) GetDefaultDrwIndex (elem.header) : drwIndexTarget;
+                    ApplyDrawIndexStrategy (guids, elem.header, (Int32) resolvedTarget, (Int32) elem.header.drwIndex);
                 }
             }
 

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -380,7 +380,7 @@ static void AddFloorPlanPolygonsIfAvailable (const API_Guid& guid, GS::ObjectSta
     params.allStories = true;
     params.polygon    = nullptr;
 
-#ifdef ServerMainVers_2600
+#if defined(ServerMainVers_2700)
     const GSErrCode fpErr = ACAPI_DrawingPrimitive_ShapePrimsExt (elemHead, CollectCutFillPolygons, &params);
 #else
     const GSErrCode fpErr = ACAPI_Element_ShapePrimsExt (elemHead, CollectCutFillPolygons, &params);

--- a/archicad-addon/Sources/ElementCommands.hpp
+++ b/archicad-addon/Sources/ElementCommands.hpp
@@ -197,3 +197,13 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+
+class SetElementsDrawIndexCommand : public CommandBase
+{
+public:
+    SetElementsDrawIndexCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};

--- a/archicad-addon/Sources/ElementCommands.hpp
+++ b/archicad-addon/Sources/ElementCommands.hpp
@@ -198,12 +198,3 @@ public:
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
-class SetElementsDrawIndexCommand : public CommandBase
-{
-public:
-    SetElementsDrawIndexCommand ();
-    virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
-    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
-};

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -1530,7 +1530,8 @@ GS::Optional<GS::UniString> CreateWallsCommand::GetInputParametersSchema () cons
                     "properties": {
                         "begCoordinate": { "$ref": "#/Coordinate2D" },
                         "endCoordinate": { "$ref": "#/Coordinate2D" },
-                        "zCoordinate": { "type": "number" },
+                        "floorIndex": { "type": "integer", "description": "Story index (as returned by GetStories). When provided, zCoordinate is interpreted as bottomOffset relative to the floor. Takes priority over zCoordinate for floor assignment." },
+                        "zCoordinate": { "type": "number", "description": "Absolute Z when floorIndex is absent; bottomOffset relative to the floor when floorIndex is provided." },
                         "height": { "type": "number", "exclusiveMinimum": 0.0 },
                         "thickness": { "type": "number", "exclusiveMinimum": 0.0 },
                         "offset": { "type": "number" },
@@ -1548,7 +1549,7 @@ GS::Optional<GS::UniString> CreateWallsCommand::GetInputParametersSchema () cons
                         "profileId": { "$ref": "#/AttributeId" }
                     },
                     "additionalProperties": false,
-                    "required": ["begCoordinate", "endCoordinate", "zCoordinate", "height", "thickness"]
+                    "required": ["begCoordinate", "endCoordinate", "height", "thickness"]
                 }
             }
         },
@@ -1610,9 +1611,15 @@ GS::Optional<GS::ObjectState> CreateWallsCommand::SetTypeSpecificParameters (API
         element.wall.offset = offset.Get ();
     }
 
-    const auto floorIndexAndOffset = GetFloorIndexAndOffset (zCoordinate, stories);
-    element.header.floorInd = floorIndexAndOffset.first;
-    element.wall.bottomOffset = floorIndexAndOffset.second;
+    Int32 explicitFloorIndex = -1;
+    if (parameters.Get ("floorIndex", explicitFloorIndex)) {
+        element.header.floorInd   = static_cast<short> (explicitFloorIndex);
+        element.wall.bottomOffset = zCoordinate;
+    } else {
+        const auto floorIndexAndOffset = GetFloorIndexAndOffset (zCoordinate, stories);
+        element.header.floorInd   = floorIndexAndOffset.first;
+        element.wall.bottomOffset = floorIndexAndOffset.second;
+    }
 
     bool structureChanged = false;
     auto error = ApplyWallStructure (element, nullptr, parameters, structureChanged);

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -853,6 +853,10 @@
                     },
                     "databaseId": {
                         "$ref": "#/DatabaseId"
+                    },
+                    "storyIndex": {
+                        "type": "integer",
+                        "description": "Story index to activate. Only valid when windowType is 'FloorPlan'. As returned by GetStories."
                     }
                 },
                 "additionalProperties": false,


### PR DESCRIPTION
### `GetDetailsOfElements` → `floorPlanPolygons`

New optional field returned for each element: the cut-fill contour polygons as drawn in the floor plan view. Uses `ACAPI_Element_ShapePrimsExt` (AC25/26) / `ACAPI_DrawingPrimitive_ShapePrimsExt` (AC27+) with `allStories=true` — works for elements on any story without changing the active view.

### `CreateWalls` → `floorIndex` parameter

Optional parameter to place a wall directly on a story by its index (as returned by `GetStories`). When provided, `zCoordinate` becomes a `bottomOffset` relative to that floor. Avoids the fragile reverse Z → story calculation.

### `ChangeWindow` → `storyIndex` parameter

When `windowType` is `'FloorPlan'`, optional parameter to switch the active story by index.

### Test

`test_floor_plan_polygons.py`: creates T-shaped walls on two stories, retrieves their contour polygons via `GetDetailsOfElements.floorPlanPolygons`, and generates outline polylines on the correct story via `CreatePolylines` (`floorInd`). Validated on AC25 and AC29.
