### PR TITLE
fix(walls): reject zero-length walls in CreateWalls instead of crashing

### DIFF
--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -1569,6 +1569,10 @@ GS::Optional<GS::ObjectState> CreateWallsCommand::SetTypeSpecificParameters (API
     API_Coord begCoordinate = Get2DCoordinateFromObjectState (*parameters.Get ("begCoordinate"));
     API_Coord endCoordinate = Get2DCoordinateFromObjectState (*parameters.Get ("endCoordinate"));
 
+    if (IsSame2DCoordinate (begCoordinate, endCoordinate)) {
+        return CreateErrorResponse (APIERR_BADPARS, "Zero-length wall: 'begCoordinate' and 'endCoordinate' are identical.");
+    }
+
     double zCoordinate = 0.0;
     double height = 0.0;
     double thickness = 0.0;


### PR DESCRIPTION
## Summary

Fixes #433. `CreateWalls` with a wall whose `begCoordinate == endCoordinate` (zero length) **crashes Archicad** (access violation, connection reset) instead of returning an error. This happens easily with real source data when axis/corner intersection collapses a segment.

## Change

Guard at the top of `CreateWallsCommand::SetTypeSpecificParameters`: if begin and end coordinates are the same (via the existing `IsSame2DCoordinate` helper), return a controlled `APIERR_BADPARS` error for that item instead of proceeding into `ACAPI_Element_Create` (which crashes). Other walls in the same batch are unaffected — they still succeed, and the offending item gets an error entry in the result, consistent with the command's existing per-item error handling.

```cpp
if (IsSame2DCoordinate (begCoordinate, endCoordinate)) {
    return CreateErrorResponse (APIERR_BADPARS, "Zero-length wall: 'begCoordinate' and 'endCoordinate' are identical.");
}
```

## Testing

- Built clean on AC26 and AC28 (Win, VS2019, DevKit 26.3000 / 28.3001).
- Before: a batch containing a zero-length wall force-closed Archicad (reproduced on AC26, ~18 walls in, matching #433).
- After: the zero-length item returns `APIERR_BADPARS` with the message above; the remaining walls in the batch are created normally; no crash.

Mirrors the existing degenerate-polygon guards elsewhere in this file (slabs/zones use `IsSame2DCoordinate` the same way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)