### PR TITLE
fix(stairs): support multi-segment (L/U-shaped) baselines in CreateStairs

### DIFF
--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -1857,26 +1857,16 @@ GS::Optional<GS::ObjectState> CreateStairsCommand::SetTypeSpecificParameters (AP
 
     // Allocate new baseline: polyline (not polygon), so no closing vertex needed
     // Coords: index 1..nCoords (1-based), index 0 unused
+    // edgeData/vertexData are intentionally left null: ACAPI_Element_Create derives them
+    // from the baseline geometry (see the Element_Test example in the DevKit). Pre-filling
+    // them marks every edge as a steps segment, which makes multi-segment (L/U-shaped)
+    // baselines fail with -2130313215 (#444).
     memo.stairBaseLine.coords = reinterpret_cast<API_Coord**> (BMAllocateHandle ((nCoords + 1) * sizeof (API_Coord), ALLOCATE_CLEAR, 0));
     memo.stairBaseLine.pends = reinterpret_cast<Int32**> (BMAllocateHandle (2 * sizeof (Int32), ALLOCATE_CLEAR, 0));
     memo.stairBaseLine.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (0, ALLOCATE_CLEAR, 0));
-    memo.stairBaseLine.edgeData = reinterpret_cast<API_StairPolylineEdgeData*> (BMAllocatePtr (nCoords * sizeof (API_StairPolylineEdgeData), ALLOCATE_CLEAR, 0));
-    memo.stairBaseLine.vertexData = reinterpret_cast<API_StairPolylineVertexData*> (BMAllocatePtr ((nCoords + 1) * sizeof (API_StairPolylineVertexData), ALLOCATE_CLEAR, 0));
 
     for (Int32 i = 0; i < nCoords; ++i) {
         (*memo.stairBaseLine.coords)[i + 1] = Get2DCoordinateFromObjectState (baseLinePoints[i]);
-
-        // Set vertex data
-        memo.stairBaseLine.vertexData[i + 1].type = APISP_BaseLine;
-        memo.stairBaseLine.vertexData[i + 1].geometryType = APISG_Vertex;
-        memo.stairBaseLine.vertexData[i + 1].subElemId = 0;
-
-        // Set edge data (between vertices, so nCoords-1 edges)
-        if (i < nCoords - 1) {
-            memo.stairBaseLine.edgeData[i].type = APISP_BaseLine;
-            memo.stairBaseLine.edgeData[i].geometryType = APISG_Edge;
-            memo.stairBaseLine.edgeData[i].subElemId = 0;
-        }
     }
 
     (*memo.stairBaseLine.pends)[1] = nCoords;


### PR DESCRIPTION
## Summary

Fixes #444. `CreateStairs` (from #388) failed with `-2130313215 "Failed to create new Stair"` for **every** multi-segment (L-shaped / U-shaped) baseline, while straight 2-point baselines worked.

## Root cause

`SetTypeSpecificParameters` pre-filled `stairBaseLine.edgeData` / `vertexData` by hand. The allocation is cleared, so `segmentType` stayed `0` = `APIST_StepsSegment` on **every** edge. A multi-segment baseline whose corner edges are forced to be steps segments is unsolvable for the stair solver, so `ACAPI_Element_Create` rejected all L/U baselines.

## Change

Leave `edgeData`/`vertexData` null and let `ACAPI_Element_Create` derive them from the baseline geometry — the same pattern as the `Element_Test` example in the API DevKit (`Do_CreateStair` sets only `coords`/`parcs`/`polygon`). Net −10 lines.

## Testing (live against AC28, Win)

| Case | Before | After |
|---|---|---|
| Straight 2-point baseline (regression) | ✅ | ✅ unchanged (footprint 1.2 × 4.65 at totalHeight 3.4) |
| L-shaped 3-point baseline (issue repro) | ❌ `-2130313215` | ✅ stair created |
| U-shaped 4-point baseline, legs 3.0 m apart | ❌ `-2130313215` | ✅ stair created |
| U-shaped, legs only 1.4 m apart (issue's exact coordinates) | ❌ | ❌ solver error — expected: the flights/landings physically don't fit between legs that close (the UI rejects this geometry too) |

So after the fix the remaining `-2130313215` cases are genuine "stair rules cannot solve this geometry" results (per-item error, other items in the batch unaffected), not a blanket multi-segment failure.

Built clean on AC26 and AC28 (Win, VS2019, DevKit 26.3000 / 28.3001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)