### PR TITLE
fix(walls,columns): explicit height overrides story top-link

### DIFF
--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -189,7 +189,9 @@ GS::Optional<GS::ObjectState> CreateColumnsCommand::SetTypeSpecificParameters (A
     element.column.bottomOffset = floorIndexAndOffset.second;
     element.column.origoPos.x = apiCoordinate.x;
     element.column.origoPos.y = apiCoordinate.y;
-    parameters.Get ("height", element.column.height);
+    if (parameters.Get ("height", element.column.height)) {
+        element.column.relativeTopStory = 0;
+    }
     parameters.Get ("axisRotationAngle", element.column.axisRotationAngle);
 
     GS::UniString coreAnchor;

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -1180,7 +1180,9 @@ bool ApplyWallDetails (API_Element& element, API_Element& mask, const GS::Object
     auto height = GetOptionalDouble (details, "height");
     if (height.HasValue ()) {
         element.wall.height = height.Get ();
+        element.wall.relativeTopStory = 0;
         ACAPI_ELEMENT_MASK_SET (mask, API_WallType, height);
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, relativeTopStory);
         changed = true;
     }
     auto offset = GetOptionalDouble (details, "offset");
@@ -1332,7 +1334,9 @@ bool ApplyColumnDetails (API_Element& element, API_Element& mask, const GS::Obje
     auto height = GetOptionalDouble (details, "height");
     if (height.HasValue ()) {
         element.column.height = height.Get ();
+        element.column.relativeTopStory = 0;
         ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, height);
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, relativeTopStory);
         changed = true;
     }
     auto bottomOffset = GetOptionalDouble (details, "bottomOffset");
@@ -1584,6 +1588,7 @@ GS::Optional<GS::ObjectState> CreateWallsCommand::SetTypeSpecificParameters (API
         element.wall.angle = arcAngle.Get ();
     }
     element.wall.height = height;
+    element.wall.relativeTopStory = 0;
     element.wall.thickness = thickness;
     element.wall.referenceLineLocation = APIWallRefLine_Center;
     GS::UniString referenceLineLocation;


### PR DESCRIPTION
## Summary

`CreateColumns` with `height: 2.0` produces a 2.65 m column when the template's column tool default is top-linked to a story — the explicit value is silently ignored. The same template dependence is behind long-standing "`CreateWalls` `height` is not honored" reports: whether an explicit height works currently depends on whether the tool default happens to be story-linked.

## Root cause

`CreateWalls`, `CreateColumns`, `ModifyWalls` and `ModifyColumns` write `element.wall.height` / `element.column.height` but never touch **`relativeTopStory`**. When the default is top-linked (`relativeTopStory > 0`), Archicad derives the element height from the link and ignores the field.

## Change

Set `relativeTopStory = 0` whenever an explicit `height` is applied (in the Modify commands together with the corresponding mask bit). Callers who want story-linked elements keep using the linked tool default — creating **without** `height` is unchanged.

## Testing (live against AC28, Win, story grid UG −3.0 / EG 0.0 / OG 3.0)

| Case | Before | After |
|---|---|---|
| `CreateColumns` `height: 2.0` | bbox zMax 2.65 (link wins) | ✅ zMax 2.0 |
| `CreateColumns` without `height` | zMax 2.65 (template default) | ✅ zMax 2.65 — unchanged |
| `ModifyColumns` `height: 1.5` | no effect on linked column | ✅ zMax 1.5 |
| `CreateWalls` `height: 2.2` | template-dependent | ✅ zMax 2.2 |
| `ModifyWalls` `height: 1.8` | template-dependent | ✅ zMax 1.8 |

Built clean on AC26 and AC28 (Win, VS2019, DevKit 26.3000 / 28.3001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)