### PR TITLE
 Let Column/Slab/Object/Lamp/Beam/Stair/Roof/Morph creation take an explicit floorIndex

### DIFF
--- a/archicad-addon/Sources/CommandBase.cpp
+++ b/archicad-addon/Sources/CommandBase.cpp
@@ -371,6 +371,15 @@ double GetZPos (const short floorIndex, const double offset, const Stories& stor
     return story.level + offset;
 }
 
+GS::Pair<short, double> ResolveFloorIndexAndOffset (const GS::ObjectState& parameters, const char* floorIndexFieldName, const double zPos, const Stories& stories)
+{
+    short floorIndex = 0;
+    if (parameters.Get (floorIndexFieldName, floorIndex)) {
+        return { floorIndex, zPos - GetZPos (floorIndex, 0.0, stories) };
+    }
+    return GetFloorIndexAndOffset (zPos, stories);
+}
+
 GS::UniString GetElementTypeNonLocalizedName (API_ElemTypeID typeID)
 {
     switch (typeID) {

--- a/archicad-addon/Sources/CommandBase.hpp
+++ b/archicad-addon/Sources/CommandBase.hpp
@@ -89,6 +89,13 @@ using Stories = std::map<short, Story>;
 Stories GetStories ();
 GS::Pair<short, double> GetFloorIndexAndOffset (const double zPos, const Stories& stories);
 double GetZPos (const short floorIndex, const double offset, const Stories& stories);
+// Same result as GetFloorIndexAndOffset (zPos, stories), except an explicit floorIndex value under
+// floorIndexFieldName in `parameters` (when present) picks the floor directly instead of it being
+// derived from zPos - the offset is still computed against zPos, just relative to the chosen
+// floor's own base level. Use this wherever a Create/Modify command currently derives floorInd
+// purely from a Z coordinate, to let callers pin the floor explicitly instead of relying on a
+// guess that can land on the wrong floor for a Z value shared by more than one story.
+GS::Pair<short, double> ResolveFloorIndexAndOffset (const GS::ObjectState& parameters, const char* floorIndexFieldName, const double zPos, const Stories& stories);
 GS::UniString GetElementTypeNonLocalizedName (API_ElemTypeID typeID);
 API_ElemTypeID GetElementTypeFromNonLocalizedName (const GS::UniString& typeStr);
 short ParseAnchorPointString (const GS::UniString& anchorPoint);

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -162,6 +162,10 @@ GS::Optional<GS::UniString> CreateColumnsCommand::GetInputParametersSchema () co
                             "type": "string",
                             "description": "Optional anchor point of the column core on a 3x3 grid.",
                             "enum": ["TopLeft", "TopCenter", "TopRight", "MiddleLeft", "Center", "MiddleRight", "BottomLeft", "BottomCenter", "BottomRight"]
+                        },
+                        "floorIndex": {
+                            "type": "integer",
+                            "description": "Optional floor index. If omitted, derived from the coordinate's z value."
                         }
                     },
                     "additionalProperties": false,
@@ -184,7 +188,7 @@ GS::Optional<GS::ObjectState> CreateColumnsCommand::SetTypeSpecificParameters (A
     parameters.Get ("coordinates", coordinates);
     API_Coord3D apiCoordinate = Get3DCoordinateFromObjectState (coordinates);
 
-    const auto floorIndexAndOffset = GetFloorIndexAndOffset (apiCoordinate.z, stories);
+    const auto floorIndexAndOffset = ResolveFloorIndexAndOffset (parameters, "floorIndex", apiCoordinate.z, stories);
     element.header.floorInd = floorIndexAndOffset.first;
     element.column.bottomOffset = floorIndexAndOffset.second;
     element.column.origoPos.x = apiCoordinate.x;
@@ -265,7 +269,11 @@ GS::Optional<GS::UniString> CreateSlabsCommand::GetInputParametersSchema () cons
                     },
                     "holes" : {
                         "$ref": "#/Holes2D"
-                    }    
+                    },
+                    "floorIndex": {
+                        "type": "integer",
+                        "description": "Optional floor index. If omitted, derived from level."
+                    }
                 },
                 "additionalProperties": false,
                 "required" : [
@@ -352,7 +360,7 @@ GS::Optional<GS::ObjectState> CreateSlabsCommand::SetTypeSpecificParameters (API
 {
     double inputLevel = 0.0;
     parameters.Get ("level", inputLevel);
-    const auto floorIndexAndOffset = GetFloorIndexAndOffset (inputLevel, stories);
+    const auto floorIndexAndOffset = ResolveFloorIndexAndOffset (parameters, "floorIndex", inputLevel, stories);
     element.header.floorInd = floorIndexAndOffset.first;
     element.slab.level = floorIndexAndOffset.second;
     parameters.Get ("thickness", element.slab.thickness);
@@ -711,6 +719,10 @@ static GS::UniString BuildLibraryPartBasedSchema (const char* arrayFieldName,
                         },
                         "dimensions": {
                             "$ref": "#/Dimensions3D"
+                        },
+                        "floorIndex": {
+                            "type": "integer",
+                            "description": "Optional floor index. If omitted, derived from the coordinate's z value."
                         }
                     },
                     "additionalProperties": false,
@@ -852,7 +864,7 @@ static GS::Optional<GS::ObjectState> SetLibraryPartElementParameters (
         element.object.pos.x = apiCoordinate.x;
         element.object.pos.y = apiCoordinate.y;
 
-        const auto floorIndexAndOffset = GetFloorIndexAndOffset (apiCoordinate.z, stories);
+        const auto floorIndexAndOffset = ResolveFloorIndexAndOffset (parameters, "floorIndex", apiCoordinate.z, stories);
         element.header.floorInd = floorIndexAndOffset.first;
         element.object.level = floorIndexAndOffset.second;
     }

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -1286,7 +1286,7 @@ GS::Optional<GS::UniString> ApplyRoofDetails (
     auto level = GetOptionalDouble (details, "level");
 
     if (level.HasValue ()) {
-        const auto floorIndexAndOffset = GetFloorIndexAndOffset (level.Get (), stories);
+        const auto floorIndexAndOffset = ResolveFloorIndexAndOffset (details, "floorIndex", level.Get (), stories);
         element.header.floorInd = floorIndexAndOffset.first;
         element.roof.shellBase.level = floorIndexAndOffset.second;
         if (mask != nullptr) {
@@ -1647,6 +1647,7 @@ GS::Optional<GS::UniString> CreateBeamsCommand::GetInputParametersSchema () cons
                     "properties": {
                         "begCoordinate": { "$ref": "#/Coordinate2D" },
                         "endCoordinate": { "$ref": "#/Coordinate2D" },
+                        "floorIndex": { "type": "integer", "description": "Optional floor index. If omitted, derived from zCoordinate." },
                         "zCoordinate": { "type": "number" },
                         "offset": { "type": "number" },
                         "slantAngle": { "type": "number" },
@@ -1691,7 +1692,7 @@ GS::Optional<GS::ObjectState> CreateBeamsCommand::SetTypeSpecificParameters (API
 
     double zCoordinate = 0.0;
     parameters.Get ("zCoordinate", zCoordinate);
-    const auto floorIndexAndOffset = GetFloorIndexAndOffset (zCoordinate, stories);
+    const auto floorIndexAndOffset = ResolveFloorIndexAndOffset (parameters, "floorIndex", zCoordinate, stories);
     element.header.floorInd = floorIndexAndOffset.first;
     element.beam.level = floorIndexAndOffset.second;
 
@@ -1763,6 +1764,10 @@ GS::Optional<GS::UniString> CreateStairsCommand::GetInputParametersSchema () con
                             "type": "number",
                             "description": "The Z coordinate (absolute elevation) of the stair base."
                         },
+                        "floorIndex": {
+                            "type": "integer",
+                            "description": "Optional floor index. If omitted, derived from zCoordinate."
+                        },
                         "totalHeight": {
                             "type": "number",
                             "description": "Total height of the stair.",
@@ -1809,7 +1814,7 @@ GS::Optional<GS::ObjectState> CreateStairsCommand::SetTypeSpecificParameters (AP
 
     double zCoordinate = 0.0;
     parameters.Get ("zCoordinate", zCoordinate);
-    const auto floorIndexAndOffset = GetFloorIndexAndOffset (zCoordinate, stories);
+    const auto floorIndexAndOffset = ResolveFloorIndexAndOffset (parameters, "floorIndex", zCoordinate, stories);
     element.header.floorInd = floorIndexAndOffset.first;
 
     auto totalHeight = GetOptionalDouble (parameters, "totalHeight");
@@ -2313,7 +2318,8 @@ GS::Optional<GS::UniString> CreateMorphsCommand::GetInputParametersSchema () con
                     "properties": {
                         "basePoint": { "$ref": "#/Coordinate3D" },
                         "size": { "$ref": "#/Dimensions3D" },
-                        "buildingMaterialId": { "$ref": "#/AttributeId" }
+                        "buildingMaterialId": { "$ref": "#/AttributeId" },
+                        "floorIndex": { "type": "integer", "description": "Optional floor index. If omitted, derived from the basePoint's z value." }
                     },
                     "additionalProperties": false,
                     "required": ["basePoint", "size"]
@@ -2347,6 +2353,8 @@ GS::ObjectState CreateMorphsCommand::Execute (const GS::ObjectState& parameters,
         return CreateErrorResponse (APIERR_BADPARS, error.Get ());
     }
 
+    const Stories stories = GetStories ();
+
     return ExecuteCreateWithElements ("Create Morphs", [&](GS::Array<GS::ObjectState>& elements) {
         for (const auto& data : morphsData) {
             API_Element element = {};
@@ -2371,6 +2379,14 @@ GS::ObjectState CreateMorphsCommand::Execute (const GS::ObjectState& parameters,
                 elements.Push (CreateErrorResponse (APIERR_BADPARS, "Morph 'size' values must be positive."));
                 continue;
             }
+
+            // GetDefaults leaves floorInd at whatever story is currently active in the UI,
+            // regardless of basePoint's z - a morph built far above/below that story's own
+            // elevation would get correctly placed in absolute 3D space (tmx below stays absolute)
+            // but assigned to the wrong story for floor-plan/story-based queries. Only floorInd is
+            // derived here; tmx[11] intentionally stays basePoint.z (absolute), matching how the
+            // rest of this command already places the morph in world space.
+            element.header.floorInd = ResolveFloorIndexAndOffset (data, "floorIndex", basePoint.z, stories).first;
 
             auto buildingMaterialId = GetOptionalObjectState (data, "buildingMaterialId");
 
@@ -2432,6 +2448,7 @@ GS::Optional<GS::UniString> CreateRoofsCommand::GetInputParametersSchema () cons
                     "type": "object",
                     "properties": {
                         "level": { "type": "number" },
+                        "floorIndex": { "type": "integer", "description": "Optional floor index. If omitted, derived from level." },
                         "thickness": { "type": "number", "exclusiveMinimum": 0.0 },
                         "polygonCoordinates": {
                             "type": "array",


### PR DESCRIPTION
## Summary

Several element-creation commands derived the new element's floor purely by guessing from a Z/level coordinate (`GetFloorIndexAndOffset`), with no way to pin the floor explicitly. A Z value near a story boundary could land on the wrong floor, and there was no way to force a specific one — the same class of bug already fixed for `CreateMeshes`/`CreateTexts`.

This adds an optional `floorIndex` input to the commands that were still missing it.

## What changed

- Added a shared helper, `ResolveFloorIndexAndOffset` (`CommandBase.hpp`/`.cpp`): identical to the existing Z-guess when no `floorIndex` is given, but an explicit `floorIndex` picks the story directly. The offset is still computed from the given Z (via `GetZPos`), so the element's **absolute 3D position is preserved exactly** — only which floor-plan it's grouped under changes.
- Applied it to:
  - `CreateColumns`
  - `CreateSlabs`
  - `CreateObjects` / `CreateLamps` (share `SetLibraryPartElementParameters`)
  - `CreateBeams`
  - `CreateStairs`
  - `ApplyRoofDetails` — shared with the existing modify-roof command, so modifying an existing roof's level also benefits, even though `CreateRoofs` itself is a separate pre-existing no-op (multi-plane pivot-edge setup was never implemented) unrelated to this change.
- `CreateMorphs` got its own fix: it never derived `header.floorInd` from position at all — it silently used whatever `ACAPI_Element_GetDefaults` defaulted to, regardless of the requested position. Now computed via the same helper, while its transform matrix's absolute Z placement (already correct) is left untouched.

## Not affected

- `CreateWalls` already had `floorIndex` support.
- `CreateWindows` / `CreateDoors` / `CreateOpenings` never had this bug: they're positioned relative to a host element (`ownerWallId` / `ownerElementId`), with no absolute Z to guess a floor from.

## Testing

Compiled cleanly on AC25/26/27/29.

Live-verified on AC29 and AC25 with a disposable test script: for Column, Slab, Beam, Stair, Morph, and Object, created one instance at a Z that would naturally guess floor B, both with no `floorIndex` (confirms the guess fallback still works) and with an explicit `floorIndex=A` that contradicts the guess (confirms the override wins) — read back via `GetDetailsOfElements`. 12/12 checks passed on AC29, 10/10 on AC25 (AC25's project incidentally has a basement story, so this also exercised a negative floor index).

Specifically double-checked that the fix changes the floor *assignment* and not the element's real position: creating a Column with `floorIndex=-1` at `z=0.5` (which would guess floor `0`) came back as:

```json
{
  "floorIndex": -1,
  "details": {
    "zCoordinate": 0.5,
    "bottomOffset": 3.3
  }
}
```

i.e. `floorIndex` reflects the override, `zCoordinate` stays exactly as requested (not snapped to floor `-1`'s own base level of `-2.8`), and `bottomOffset` is correctly back-computed (`0.5 - (-2.8) = 3.3`).
