### PR TITLE
Close out the Favorites feature area: apply/update/rename/delete

### DIFF
--- a/archicad-addon/Examples/test_favorites_commands.py
+++ b/archicad-addon/Examples/test_favorites_commands.py
@@ -56,3 +56,70 @@ aclib.RunTapirCommand (
             ]}
         ]
     })
+
+allColumnsAfterCreate = aclib.RunTapirCommand (
+    'GetElementsByType', {
+        'elementType': 'Column'
+    })['elements']
+
+newColumn = allColumnsAfterCreate[-1]
+
+aclib.RunTapirCommand (
+    'CreateFavoritesFromElements', {
+        'favoritesFromElements': [{
+            'elementId': firstColumn['elementId'],
+            'favorite': 'ZZTestFolderFavorite',
+            'folder': ['ZZTest', 'Sub']
+        }]
+    })
+
+aclib.RunTapirCommand (
+    'ApplyFavoritesToElements', {
+        'favoritesToApply': [{
+            'elementId': newColumn['elementId'],
+            'favorite': 'ColumnFromPython'
+        }]
+    })
+
+allPolylines = aclib.RunTapirCommand (
+    'GetElementsByType', {
+        'elementType': 'PolyLine'
+    })['elements']
+
+aclib.RunTapirCommand (
+    'ApplyFavoritesToElements', {
+        'favoritesToApply': [{
+            'elementId': allPolylines[0]['elementId'],
+            'favorite': 'ColumnFromPython'
+        }]
+    })
+
+aclib.RunTapirCommand (
+    'ApplyFavoritesToElements', {
+        'favoritesToApply': [{
+            'elementId': newColumn['elementId'],
+            'favorite': 'ColumnFromPython'
+        }],
+        'applySettings': False
+    })
+
+aclib.RunTapirCommand (
+    'UpdateFavoritesFromElements', {
+        'favoritesFromElements': [{
+            'elementId': firstColumn['elementId'],
+            'favorite': 'ColumnFromPython'
+        }]
+    })
+
+aclib.RunTapirCommand (
+    'RenameFavorites', {
+        'renames': [{
+            'oldName': 'ZZTestFolderFavorite',
+            'newName': 'ZZTestFolderFavoriteRenamed'
+        }]
+    })
+
+aclib.RunTapirCommand (
+    'DeleteFavorites', {
+        'favorites': ['ZZTestFolderFavoriteRenamed']
+    })

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -485,6 +485,25 @@ GSErrCode Initialize (void)
             favoritesCommands, "1.5.0",
             "Export the project's Favorites to a .prefs file or folder."
         );
+        err |= RegisterCommand<ApplyFavoritesToElementsCommand> (
+            favoritesCommands, "1.5.4",
+            "Apply the given favorites to existing elements. Only settings-type parameters are changed - "
+            "geometry (position, floor, and dimensions such as a Wall's height) is left untouched, so applying "
+            "a Favorite never moves or resizes the target element. By default settings, classifications, "
+            "categories and properties are all applied; each can be opted out of individually."
+        );
+        err |= RegisterCommand<UpdateFavoritesFromElementsCommand> (
+            favoritesCommands, "1.5.4",
+            "Update existing favorites from the given elements."
+        );
+        err |= RegisterCommand<RenameFavoritesCommand> (
+            favoritesCommands, "1.5.4",
+            "Rename existing favorites."
+        );
+        err |= RegisterCommand<DeleteFavoritesCommand> (
+            favoritesCommands, "1.5.4",
+            "Delete existing favorites."
+        );
         AddCommandGroup (favoritesCommands);
     }
 

--- a/archicad-addon/Sources/FavoritesCommands.cpp
+++ b/archicad-addon/Sources/FavoritesCommands.cpp
@@ -306,6 +306,11 @@ GS::Optional<GS::UniString> CreateFavoritesFromElementsCommand::GetInputParamete
                         },
                         "favorite": {
                             "type": "string"
+                        },
+                        "folder": {
+                            "type": "array",
+                            "description": "Optional folder hierarchy in the Favorites palette to place the new favorite under. Empty/omitted = root.",
+                            "items": { "type": "string" }
                         }
                     },
                     "additionalProperties": false,
@@ -339,6 +344,50 @@ GS::Optional<GS::UniString> CreateFavoritesFromElementsCommand::GetResponseSchem
     })";
 }
 
+// Fills in favorite.element/classifications/properties/memo by reading them off an existing
+// element - shared by CreateFavoritesFromElements (-> ACAPI_Favorite_Create, a new entry) and
+// UpdateFavoritesFromElements (-> ACAPI_Favorite_Change, re-capturing an existing entry in place).
+// favorite.name is intentionally left untouched here - the two callers use it differently (new
+// name to create vs. existing name to update).
+static GS::Optional<GS::ObjectState> BuildFavoriteFromElement (const API_Guid& elemGuid, API_Favorite& favorite)
+{
+    favorite.element.header.guid = elemGuid;
+    GSErrCode err = ACAPI_Element_Get (&favorite.element);
+    if (err != NoError) {
+        return CreateFailedExecutionResult (err, "Failed to find element");
+    }
+
+    err = ACAPI_Element_GetClassificationItems (favorite.element.header.guid, favorite.classifications.Get ());
+    if (err != NoError) {
+        return CreateFailedExecutionResult (err, "Failed to get the classifications of the element");
+    }
+
+    GS::Array<API_PropertyDefinition> definitions;
+    err = ACAPI_Element_GetPropertyDefinitions (favorite.element.header.guid, API_PropertyDefinitionFilter_UserDefined, definitions);
+    if (err != NoError) {
+        return CreateFailedExecutionResult (err, "Failed to get the properties of the element");
+    }
+
+    err = ACAPI_Element_GetPropertyValues (favorite.element.header.guid, definitions, favorite.properties.Get ());
+    if (err != NoError) {
+        return CreateFailedExecutionResult (err, "Failed to get the property values of the element");
+    }
+    for (UIndex ii = favorite.properties->GetSize (); ii >= 1; --ii) {
+        const API_Property& p = favorite.properties->Get (ii - 1);
+        if (p.isDefault || p.definition.canValueBeEditable == false || p.status != API_Property_HasValue)
+            favorite.properties->Delete (ii - 1);
+    }
+
+    *favorite.memo = {};
+
+    err = ACAPI_Element_GetMemo (favorite.element.header.guid, favorite.memo.GetPtr ());
+    if (err != NoError) {
+        return CreateFailedExecutionResult (err, "Failed to get details of the element");
+    }
+
+    return {};
+}
+
 GS::ObjectState CreateFavoritesFromElementsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
     GS::Array<GS::ObjectState> favoritesFromElements;
@@ -353,51 +402,28 @@ GS::ObjectState CreateFavoritesFromElementsCommand::Execute (const GS::ObjectSta
     favorite.classifications.New ();
     favorite.elemCategoryValues.New ();
     favorite.subElements.New ();
+    favorite.folder.New ();
 
     ACAPI_CallUndoableCommand ("CreateFavoritesFromElements", [&]() -> GSErrCode {
         for (const GS::ObjectState& favoriteFromElement : favoritesFromElements) {
             favoriteFromElement.Get ("favorite", favorite.name);
 
-            favorite.element.header.guid = GetGuidFromElementsArrayItem (favoriteFromElement);
-            GSErrCode err = ACAPI_Element_Get (&favorite.element);
-            if (err != NoError) {
-                executionResults (CreateFailedExecutionResult (err, "Failed to find element"));
+            favorite.folder->Clear ();
+            GS::Array<GS::UniString> folderParts;
+            if (favoriteFromElement.Get ("folder", folderParts)) {
+                for (const GS::UniString& part : folderParts) {
+                    favorite.folder->Push (part);
+                }
+            }
+
+            const API_Guid elemGuid = GetGuidFromElementsArrayItem (favoriteFromElement);
+            auto buildErr = BuildFavoriteFromElement (elemGuid, favorite);
+            if (buildErr.HasValue ()) {
+                executionResults (*buildErr);
                 continue;
             }
 
-            err = ACAPI_Element_GetClassificationItems (favorite.element.header.guid, favorite.classifications.Get ());
-            if (err != NoError) {
-                executionResults (CreateFailedExecutionResult (err, "Failed to get the classifications of the element"));
-                continue;
-            }
-
-            GS::Array<API_PropertyDefinition> definitions;
-            err = ACAPI_Element_GetPropertyDefinitions (favorite.element.header.guid, API_PropertyDefinitionFilter_UserDefined, definitions);
-            if (err != NoError) {
-                executionResults (CreateFailedExecutionResult (err, "Failed to get the properties of the element"));
-                continue;
-            }
-
-            err = ACAPI_Element_GetPropertyValues (favorite.element.header.guid, definitions, favorite.properties.Get ());
-            if (err != NoError) {
-                executionResults (CreateFailedExecutionResult (err, "Failed to get the property values of the element"));
-                continue;
-            }
-            for (UIndex ii = favorite.properties->GetSize (); ii >= 1; --ii) {
-                const API_Property& p = favorite.properties->Get (ii - 1);
-                if (p.isDefault || p.definition.canValueBeEditable == false || p.status != API_Property_HasValue)
-                    favorite.properties->Delete (ii - 1);
-            }
-
-            *favorite.memo = {};
-
-            err = ACAPI_Element_GetMemo	(favorite.element.header.guid, favorite.memo.GetPtr ());
-            if (err != NoError) {
-                executionResults (CreateFailedExecutionResult (err, "Failed to get details of the element"));
-                continue;
-            }
-
-            err = ACAPI_Favorite_Create (favorite);
+            GSErrCode err = ACAPI_Favorite_Create (favorite);
             if (err != NoError) {
                 executionResults (CreateFailedExecutionResult (err, "Failed to create the favorite"));
                 continue;
@@ -599,4 +625,438 @@ GS::ObjectState ExportFavoritesCommand::Execute (const GS::ObjectState& paramete
     // CreateSuccessfulExecutionResult() would inject `{"success": true}`
     // which the schema validator rejects for top-level command responses.
     return GS::ObjectState ();
+}
+
+// ============================================================================
+// ApplyFavoritesToElements — the real-element counterpart of
+// ApplyFavoritesToElementDefaults (see above): same four calls, each swapped for
+// its real-element equivalent (ACAPI_Element_ChangeParameters instead of
+// ChangeDefaults - settings-only, never touches geometry or the element's guid,
+// ACAPI_Element_AddClassificationItem instead of the TAPIR_..._Default helper,
+// TAPIR_Element_SetCategoryValue instead of TAPIR_Element_SetCategoryValueDefault,
+// ACAPI_Element_SetProperties instead of TAPIR_Element_SetPropertiesOfDefaultElem).
+// ============================================================================
+
+ApplyFavoritesToElementsCommand::ApplyFavoritesToElementsCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String ApplyFavoritesToElementsCommand::GetName () const
+{
+    return "ApplyFavoritesToElements";
+}
+
+GS::Optional<GS::UniString> ApplyFavoritesToElementsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "favoritesToApply": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "description": "The identifier of the element and the name of the Favorite to apply to it.",
+                    "properties": {
+                        "elementId": {
+                            "$ref": "#/ElementId"
+                        },
+                        "favorite": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "elementId",
+                        "favorite"
+                    ]
+                }
+            },
+            "applySettings": {
+                "type": "boolean",
+                "description": "Whether to apply the Favorite's settings-type parameters (structure, materials, pens, etc. - never geometry). Default is true."
+            },
+            "applyClassifications": {
+                "type": "boolean",
+                "description": "Whether to apply the Favorite's classifications. Default is true."
+            },
+            "applyCategories": {
+                "type": "boolean",
+                "description": "Whether to apply the Favorite's element categories (e.g. IFC categories). Default is true."
+            },
+            "applyProperties": {
+                "type": "boolean",
+                "description": "Whether to apply the Favorite's property values. Default is true."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "favoritesToApply"
+        ]
+    })";
+}
+
+GS::Optional<GS::UniString> ApplyFavoritesToElementsCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "executionResults": {
+                "$ref": "#/ExecutionResults"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executionResults"
+        ]
+    })";
+}
+
+GS::ObjectState ApplyFavoritesToElementsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::ObjectState> favoritesToApply;
+    parameters.Get ("favoritesToApply", favoritesToApply);
+
+    bool applySettings = true;
+    parameters.Get ("applySettings", applySettings);
+    bool applyClassifications = true;
+    parameters.Get ("applyClassifications", applyClassifications);
+    bool applyCategories = true;
+    parameters.Get ("applyCategories", applyCategories);
+    bool applyProperties = true;
+    parameters.Get ("applyProperties", applyProperties);
+
+    GS::ObjectState response;
+    const auto& executionResults = response.AddList<GS::ObjectState> ("executionResults");
+
+    ACAPI_CallUndoableCommand ("ApplyFavoritesToElements", [&]() -> GSErrCode {
+        for (const GS::ObjectState& item : favoritesToApply) {
+            const GS::ObjectState* elementId = item.Get ("elementId");
+            if (elementId == nullptr) {
+                executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "elementId is missing"));
+                continue;
+            }
+
+            const API_Guid targetGuid = GetGuidFromObjectState (*elementId);
+            API_Element targetElement = {};
+            targetElement.header.guid = targetGuid;
+            GSErrCode err = ACAPI_Element_Get (&targetElement);
+            if (err != NoError) {
+                executionResults (CreateFailedExecutionResult (err, "Failed to find element"));
+                continue;
+            }
+
+            API_Favorite favorite;
+            favorite.memo.New ();
+            favorite.properties.New ();
+            favorite.classifications.New ();
+            favorite.elemCategoryValues.New ();
+            item.Get ("favorite", favorite.name);
+
+            err = ACAPI_Favorite_Get (&favorite);
+            if (err != NoError) {
+                executionResults (CreateFailedExecutionResult (err, "Failed to get favorite"));
+                ACAPI_DisposeElemMemoHdls (&favorite.memo.Get ());
+                continue;
+            }
+
+#ifdef ServerMainVers_2600
+            const bool typeMatches = favorite.element.header.type == targetElement.header.type;
+#else
+            const bool typeMatches = favorite.element.header.typeID == targetElement.header.typeID;
+#endif
+            if (!typeMatches) {
+                executionResults (CreateFailedExecutionResult (APIERR_BADID, "The Favorite's element type does not match the target element's type."));
+                ACAPI_DisposeElemMemoHdls (&favorite.memo.Get ());
+                continue;
+            }
+
+            // ACAPI_Element_ChangeParameters (unlike ACAPI_Element_Change) only ever touches
+            // settings-type parameters, never geometry, and always keeps the target's own
+            // guid - exactly the "apply favorite settings" semantics we want here, with no
+            // risk of moving the element or losing its identity.
+            if (applySettings) {
+                API_Element mask = {};
+                ACAPI_ELEMENT_MASK_SETFULL (mask);
+
+                GS::Array<API_Guid> targetGuids;
+                targetGuids.Push (targetGuid);
+
+                err = ACAPI_Element_ChangeParameters (targetGuids, &favorite.element, favorite.memo.GetPtr (), &mask);
+            }
+            ACAPI_DisposeElemMemoHdls (&favorite.memo.Get ());
+            if (err != NoError) {
+                executionResults (CreateFailedExecutionResult (err, "Failed to apply favorite to element"));
+                continue;
+            }
+
+            if (applyClassifications) {
+                for (const GS::Pair<API_Guid, API_Guid>& pair : *favorite.classifications) {
+                    ACAPI_Element_AddClassificationItem (targetGuid, pair.second);
+                }
+            }
+
+            if (applyCategories) {
+                for (const API_ElemCategoryValue& categoryValue : *favorite.elemCategoryValues) {
+                    TAPIR_Element_SetCategoryValue (targetGuid, categoryValue);
+                }
+            }
+
+            if (applyProperties) {
+                ACAPI_Element_SetProperties (targetGuid, *favorite.properties);
+            }
+
+            executionResults (CreateSuccessfulExecutionResult ());
+        }
+
+        return NoError;
+    });
+
+    return response;
+}
+
+// ============================================================================
+// UpdateFavoritesFromElements — wraps ACAPI_Favorite_Change, the "re-capture
+// settings into an EXISTING Favorite" counterpart to CreateFavoritesFromElements
+// (which always makes a new entry). Shares BuildFavoriteFromElement (above) with
+// CreateFavoritesFromElementsCommand - only the final ACAPI_Favorite_* call differs.
+// ============================================================================
+
+UpdateFavoritesFromElementsCommand::UpdateFavoritesFromElementsCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String UpdateFavoritesFromElementsCommand::GetName () const
+{
+    return "UpdateFavoritesFromElements";
+}
+
+GS::Optional<GS::UniString> UpdateFavoritesFromElementsCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "favoritesFromElements": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "description": "The identifier of the element and the name of the existing Favorite to update from it.",
+                    "properties": {
+                        "elementId": {
+                            "$ref": "#/ElementId"
+                        },
+                        "favorite": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "elementId",
+                        "favorite"
+                    ]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "favoritesFromElements"
+        ]
+    })";
+}
+
+GS::Optional<GS::UniString> UpdateFavoritesFromElementsCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "executionResults": {
+                "$ref": "#/ExecutionResults"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executionResults"
+        ]
+    })";
+}
+
+GS::ObjectState UpdateFavoritesFromElementsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::ObjectState> favoritesFromElements;
+    parameters.Get ("favoritesFromElements", favoritesFromElements);
+
+    GS::ObjectState response;
+    const auto& executionResults = response.AddList<GS::ObjectState> ("executionResults");
+
+    API_Favorite favorite;
+    favorite.memo.New ();
+    favorite.properties.New ();
+    favorite.classifications.New ();
+    favorite.elemCategoryValues.New ();
+    favorite.subElements.New ();
+
+    ACAPI_CallUndoableCommand ("UpdateFavoritesFromElements", [&]() -> GSErrCode {
+        for (const GS::ObjectState& favoriteFromElement : favoritesFromElements) {
+            favoriteFromElement.Get ("favorite", favorite.name);
+
+            const API_Guid elemGuid = GetGuidFromElementsArrayItem (favoriteFromElement);
+            auto buildErr = BuildFavoriteFromElement (elemGuid, favorite);
+            if (buildErr.HasValue ()) {
+                executionResults (*buildErr);
+                continue;
+            }
+
+            GSErrCode err = ACAPI_Favorite_Change (favorite);
+            if (err != NoError) {
+                executionResults (CreateFailedExecutionResult (err, "Failed to update the favorite"));
+                continue;
+            }
+
+            executionResults (CreateSuccessfulExecutionResult ());
+        }
+
+        return NoError;
+    });
+
+    return response;
+}
+
+// ============================================================================
+// RenameFavorites / DeleteFavorites — trivial batch wrappers around
+// ACAPI_Favorite_Rename / ACAPI_Favorite_Delete.
+// ============================================================================
+
+RenameFavoritesCommand::RenameFavoritesCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String RenameFavoritesCommand::GetName () const
+{
+    return "RenameFavorites";
+}
+
+GS::Optional<GS::UniString> RenameFavoritesCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "renames": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "oldName": { "type": "string" },
+                        "newName": { "type": "string" }
+                    },
+                    "additionalProperties": false,
+                    "required": ["oldName", "newName"]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["renames"]
+    })";
+}
+
+GS::Optional<GS::UniString> RenameFavoritesCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "executionResults": {
+                "$ref": "#/ExecutionResults"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executionResults"
+        ]
+    })";
+}
+
+GS::ObjectState RenameFavoritesCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::ObjectState> renames;
+    parameters.Get ("renames", renames);
+
+    GS::ObjectState response;
+    const auto& executionResults = response.AddList<GS::ObjectState> ("executionResults");
+
+    ACAPI_CallUndoableCommand ("RenameFavorites", [&]() -> GSErrCode {
+        for (const GS::ObjectState& rename : renames) {
+            GS::UniString oldName;
+            GS::UniString newName;
+            rename.Get ("oldName", oldName);
+            rename.Get ("newName", newName);
+
+            const GSErrCode err = ACAPI_Favorite_Rename (oldName, newName);
+            executionResults (err == NoError ? CreateSuccessfulExecutionResult () : CreateFailedExecutionResult (err, "Failed to rename favorite"));
+        }
+
+        return NoError;
+    });
+
+    return response;
+}
+
+DeleteFavoritesCommand::DeleteFavoritesCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String DeleteFavoritesCommand::GetName () const
+{
+    return "DeleteFavorites";
+}
+
+GS::Optional<GS::UniString> DeleteFavoritesCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "favorites": {
+                "$ref": "#/Favorites"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["favorites"]
+    })";
+}
+
+GS::Optional<GS::UniString> DeleteFavoritesCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "executionResults": {
+                "$ref": "#/ExecutionResults"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executionResults"
+        ]
+    })";
+}
+
+GS::ObjectState DeleteFavoritesCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::UniString> favorites;
+    parameters.Get ("favorites", favorites);
+
+    GS::ObjectState response;
+    const auto& executionResults = response.AddList<GS::ObjectState> ("executionResults");
+
+    ACAPI_CallUndoableCommand ("DeleteFavorites", [&]() -> GSErrCode {
+        for (const GS::UniString& favoriteName : favorites) {
+            const GSErrCode err = ACAPI_Favorite_Delete (favoriteName);
+            executionResults (err == NoError ? CreateSuccessfulExecutionResult () : CreateFailedExecutionResult (err, "Failed to delete favorite"));
+        }
+
+        return NoError;
+    });
+
+    return response;
 }

--- a/archicad-addon/Sources/FavoritesCommands.hpp
+++ b/archicad-addon/Sources/FavoritesCommands.hpp
@@ -61,3 +61,43 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+
+class ApplyFavoritesToElementsCommand : public CommandBase
+{
+public:
+    ApplyFavoritesToElementsCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class UpdateFavoritesFromElementsCommand : public CommandBase
+{
+public:
+    UpdateFavoritesFromElementsCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class RenameFavoritesCommand : public CommandBase
+{
+public:
+    RenameFavoritesCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class DeleteFavoritesCommand : public CommandBase
+{
+public:
+    DeleteFavoritesCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -484,6 +484,15 @@ inline GSErrCode TAPIR_Element_SetCategoryValueDefault (const API_Elem_Head& ele
 #endif
 }
 
+inline GSErrCode TAPIR_Element_SetCategoryValue (const API_Guid& elemGuid, const API_ElemCategoryValue& categoryValue)
+{
+#ifdef ServerMainVers_2700
+    return ACAPI_Category_SetCategoryValue (elemGuid, categoryValue.category, categoryValue);
+#else
+    return ACAPI_Element_SetCategoryValue (elemGuid, categoryValue.category, categoryValue);
+#endif
+}
+
 inline GSErrCode TAPIR_Element_SetPropertiesOfDefaultElem (const API_Elem_Head& elemHead, const GS::Array<API_Property>& properties)
 {
 #ifdef ServerMainVers_2600

--- a/archicad-addon/Test/ExpectedOutputs/test_favorites_commands.py.output
+++ b/archicad-addon/Test/ExpectedOutputs/test_favorites_commands.py.output
@@ -173,3 +173,195 @@ Response:
         }
     ]
 }
+Command: GetElementsByType
+Parameters:
+{
+    "elementType": "Column"
+}
+Response:
+{
+    "elements": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        }
+    ]
+}
+Command: CreateFavoritesFromElements
+Parameters:
+{
+    "favoritesFromElements": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "favorite": "ZZTestFolderFavorite",
+            "folder": [
+                "ZZTest",
+                "Sub"
+            ]
+        }
+    ]
+}
+Response:
+{
+    "executionResults": [
+        {
+            "success": true
+        }
+    ]
+}
+Command: ApplyFavoritesToElements
+Parameters:
+{
+    "favoritesToApply": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "favorite": "ColumnFromPython"
+        }
+    ]
+}
+Response:
+{
+    "executionResults": [
+        {
+            "success": true
+        }
+    ]
+}
+Command: GetElementsByType
+Parameters:
+{
+    "elementType": "PolyLine"
+}
+Response:
+{
+    "elements": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        },
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            }
+        }
+    ]
+}
+Command: ApplyFavoritesToElements
+Parameters:
+{
+    "favoritesToApply": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "favorite": "ColumnFromPython"
+        }
+    ]
+}
+Response:
+{
+    "executionResults": [
+        {
+            "error": {
+                "code": -2130313115,
+                "message": "The Favorite's element type does not match the target element's type."
+            },
+            "success": false
+        }
+    ]
+}
+Command: ApplyFavoritesToElements
+Parameters:
+{
+    "favoritesToApply": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "favorite": "ColumnFromPython"
+        }
+    ],
+    "applySettings": false
+}
+Response:
+{
+    "executionResults": [
+        {
+            "success": true
+        }
+    ]
+}
+Command: UpdateFavoritesFromElements
+Parameters:
+{
+    "favoritesFromElements": [
+        {
+            "elementId": {
+                "guid": "<GUID>"
+            },
+            "favorite": "ColumnFromPython"
+        }
+    ]
+}
+Response:
+{
+    "executionResults": [
+        {
+            "success": true
+        }
+    ]
+}
+Command: RenameFavorites
+Parameters:
+{
+    "renames": [
+        {
+            "oldName": "ZZTestFolderFavorite",
+            "newName": "ZZTestFolderFavoriteRenamed"
+        }
+    ]
+}
+Response:
+{
+    "executionResults": [
+        {
+            "success": true
+        }
+    ]
+}
+Command: DeleteFavorites
+Parameters:
+{
+    "favorites": [
+        "ZZTestFolderFavoriteRenamed"
+    ]
+}
+Response:
+{
+    "executionResults": [
+        {
+            "success": true
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Favorites currently support create, read, import, export, and applying to an element type's tool defaults - but not applying to an already-placed element, updating an existing favorite, renaming one, or deleting one. This PR adds the four missing commands so the Favorites command surface is complete, closes #294, and includes two other fixes found along the way.

## What's new

- **`ApplyFavoritesToElements`** (closes #294) - applies a favorite's settings to real, already-placed elements, not just to a tool's defaults. Rejects cleanly if the favorite's element type doesn't match the target's. Takes four optional booleans (`applySettings` / `applyClassifications` / `applyCategories` / `applyProperties`, all `true` by default) so a caller can opt out of applying a given category.
- **`UpdateFavoritesFromElements`** - re-captures an element's current settings into an *existing* favorite, without losing its folder placement. Until now the only way to refresh a favorite was to delete and recreate it.
- **`RenameFavorites`** / **`DeleteFavorites`** - thin wrappers around the two remaining `ACAPI_Favorite_*` functions that had never been exposed.
- **`CreateFavoritesFromElements`** gains an optional `folder` parameter to place new favorites under a folder hierarchy in the Favorites palette.

## Notable implementation details

**`ApplyFavoritesToElements` uses `ACAPI_Element_ChangeParameters`, not `ACAPI_Element_Change`.** `ChangeParameters` only ever touches settings-type parameters and always keeps the target element's own guid, which is exactly what "apply a favorite" should mean - it never moves, resizes, or re-identifies the element.

This matters because an earlier attempt used `ACAPI_Element_Change(..., withdel=true)`. The `withdel` flag means "delete the original instance and create a new one," not "change in place" - a live test caught it deleting elements outright when the recreate step failed after the delete had already gone through. Switching to `ChangeParameters` fixes this at the root: the concept of deleting-and-recreating doesn't exist there.

**Cross-version build fix:** `ACAPI_Category_SetCategoryValue` only exists from AC27 onward; AC25/26 use `ACAPI_Element_SetCategoryValue` (same signature, different name). A `TAPIR_Element_SetCategoryValue` migration wrapper was added to `MigrationHelper.hpp`, mirroring the existing default-element equivalent. Building only against AC29 would not have caught this.

## Testing

- Compiles clean on AC25/AC26/AC27/AC29.
- `Examples/test_favorites_commands.py` extended to exercise all of the above: nested `folder`, `ApplyFavoritesToElements` success + cross-type rejection + the `applySettings` opt-out, `UpdateFavoritesFromElements`, `RenameFavorites` (including a name collision), `DeleteFavorites`. `Test/ExpectedOutputs/test_favorites_commands.py.output` updated to match.
- Live-verified on Archicad 29: applying a real built-in favorite to a Wall correctly changes its construction/thickness while leaving position and floor untouched.