### PR TITLE
Make GDL Array Parameters editable

### DIFF
--- a/archicad-addon/Examples/change_gdlparameters.py
+++ b/archicad-addon/Examples/change_gdlparameters.py
@@ -12,4 +12,54 @@ aclib.RunTapirCommand ('SetGDLParametersOfElements', { 'elementsWithGDLParameter
         'gdlParameters' : [newGDLParameterNameAndValue]
     } for element in elements] })
 
-gdlParametersResponse = aclib.RunTapirCommand ('GetGDLParametersOfElements', { 'elements' : elements })
+gdlParametersResponse = aclib.RunTapirCommand(
+    "GetGDLParametersOfElements", {"elements": elements}
+)
+
+
+# Array (1D/2D) GDL parameters can be changed in two ways:
+# - a list value resizes the array to match the given values
+#     1D: 'value': [1, 2, 3]
+#     2D: 'value': [[11, 12], [21, 22]]
+# - 'index1' (and 'index2' for 2D arrays, both 1-based) changes a single item without resizing
+#     'index1': 2, 'value': 5
+# This example sets the first array parameter of each element to its current value.
+elementsWithArrayParameters = []
+for element, gdlParameters in zip(
+    elements, gdlParametersResponse["gdlParametersOfElements"]
+):
+    arrayParameters = [
+        p
+        for p in gdlParameters.get("parameters", [])
+        if "dimension1" in p and "value" in p and not p["isLocked"]
+    ]
+    if not arrayParameters:
+        continue
+    arrayParameter = arrayParameters[0]
+    dim1: int = arrayParameter["dimension1"]
+    dim2: int = arrayParameter["dimension2"]
+    flatValues = arrayParameter["value"]
+    if dim2 == 1:
+        newValue = flatValues
+    else:
+        newValue = [flatValues[i * dim2 : (i + 1) * dim2] for i in range(dim1)]
+    elementsWithArrayParameters.append(
+        {
+            "elementId": element["elementId"],
+            "gdlParameters": [
+                {
+                    "name": arrayParameter["name"],
+                    "index1": 1,
+                    "index2": 1,
+                    "value": flatValues[0],
+                },
+                {"name": arrayParameter["name"], "value": newValue},
+            ],
+        }
+    )
+
+if elementsWithArrayParameters:
+    aclib.RunTapirCommand(
+        "SetGDLParametersOfElements",
+        {"elementsWithGDLParameters": elementsWithArrayParameters},
+    )

--- a/archicad-addon/Sources/ElementGDLParameterCommands.cpp
+++ b/archicad-addon/Sources/ElementGDLParameterCommands.cpp
@@ -153,6 +153,56 @@ static bool SetParamValueBool (API_ChangeParamType& changeParam,
     return false;
 }
 
+static const API_AddParType* FindParameterByName (const API_GetParamsType& getParams, const char* name)
+{
+    const GSSize nParams = BMGetHandleSize ((GSHandle) getParams.params) / sizeof (API_AddParType);
+    for (GSIndex ii = 0; ii < nParams; ++ii) {
+        const API_AddParType& actParam = (*getParams.params)[ii];
+        if (actParam.typeID != APIParT_Separator && CHCompareCStrings (actParam.name, name) == 0) {
+            return &actParam;
+        }
+    }
+    return nullptr;
+}
+
+template<typename T>
+static bool GetArrayValueField (const GS::ObjectState& parameter, GS::Array<T>& flatValues, Int32& dim1, Int32& dim2)
+{
+    GS::Array<GS::Array<T>> valuesIn2D;
+    if (parameter.Get (ParameterValueFieldName, valuesIn2D)) {
+        dim1 = static_cast<Int32> (valuesIn2D.GetSize ());
+        if (dim1 == 0) {
+            return false;
+        }
+        dim2 = static_cast<Int32> (valuesIn2D[0].GetSize ());
+        if (dim2 == 0) {
+            return false;
+        }
+        for (const GS::Array<T>& row : valuesIn2D) {
+            if (static_cast<Int32> (row.GetSize ()) != dim2) {
+                return false;
+            }
+            for (const T& value : row) {
+                flatValues.Push (value);
+            }
+        }
+        return true;
+    }
+
+    GS::Array<T> valuesIn1D;
+    if (parameter.Get (ParameterValueFieldName, valuesIn1D)) {
+        dim1 = static_cast<Int32> (valuesIn1D.GetSize ());
+        if (dim1 == 0) {
+            return false;
+        }
+        dim2 = 1;
+        flatValues = valuesIn1D;
+        return true;
+    }
+
+    return false;
+}
+
 static bool SetParamValueString (API_ChangeParamType& changeParam,
                                  const GS::ObjectState& parameterDetails)
 {
@@ -541,13 +591,13 @@ GS::ObjectState	SetGDLParametersOfElementsCommand::Execute (const GS::ObjectStat
                         }
                     }
 
+                    GS::Array<ArrayParameterChange> pendingArrayChanges;
                     for (const GS::ObjectState& elemGdlParametersItem : elemGdlParameters) {
-                        API_ChangeParamType changeParam = {};
                         GS::Array<GS::ObjectState> parameters;
                         if (elemGdlParametersItem.Get ("parameters", parameters)) {
                             // Legacy mode: old schema had nested list for parameters
                             for (const GS::ObjectState& parameter : parameters) {
-                                err = SetOneGDLParameter (parameter, elemGuid, changeParam, gdlParametersTypeDictionary, gdlParametersIndexNameDictionary, errMessage);
+                                err = SetOneGDLParameter (parameter, elemGuid, getParams, gdlParametersTypeDictionary, gdlParametersIndexNameDictionary, pendingArrayChanges, errMessage);
                                 if (err != NoError) {
                                     break;
                                 }
@@ -555,8 +605,11 @@ GS::ObjectState	SetGDLParametersOfElementsCommand::Execute (const GS::ObjectStat
                                 ACAPI_DisposeAddParHdl (&getParams.params);
                                 ACAPI_LibraryPart_GetActParameters (&getParams);
                             }
+                            if (err != NoError) {
+                                break;
+                            }
                         } else {
-                            err = SetOneGDLParameter (elemGdlParametersItem, elemGuid, changeParam, gdlParametersTypeDictionary, gdlParametersIndexNameDictionary, errMessage);
+                            err = SetOneGDLParameter (elemGdlParametersItem, elemGuid, getParams, gdlParametersTypeDictionary, gdlParametersIndexNameDictionary, pendingArrayChanges, errMessage);
                             if (err != NoError) {
                                 break;
                             }
@@ -564,6 +617,10 @@ GS::ObjectState	SetGDLParametersOfElementsCommand::Execute (const GS::ObjectStat
                             ACAPI_DisposeAddParHdl (&getParams.params);
                             ACAPI_LibraryPart_GetActParameters (&getParams);
                         }
+                    }
+
+                    if (err == NoError && !pendingArrayChanges.IsEmpty ()) {
+                        err = ApplyArrayParameterChanges (getParams, pendingArrayChanges, elemGuid, errMessage);
                     }
 
                     if (err == NoError) {
@@ -631,11 +688,13 @@ GSErrCode
 SetGDLParametersOfElementsCommand::SetOneGDLParameter (
     const GS::ObjectState& parameter,
     const API_Guid& elemGuid,
-    API_ChangeParamType& changeParam,
+    const API_GetParamsType& getParams,
     const GS::HashTable<GS::String, API_AddParID>& gdlParametersTypeDictionary,
     const GS::HashTable<short, GS::String>& gdlParametersIndexNameDictionary,
+    GS::Array<ArrayParameterChange>& pendingArrayChanges,
     GS::UniString& errMessage)
 {
+    API_ChangeParamType changeParam = {};
     GS::String name;
     if (parameter.Get ("name", name)) {
         CHTruncate (name.ToCStr (), changeParam.name, API_NameLen);
@@ -660,6 +719,56 @@ SetGDLParametersOfElementsCommand::SetOneGDLParameter (
 
     if (!parameter.Contains (ParameterValueFieldName)) {
         errMessage = GS::UniString::Printf ("Invalid input: value is missing for parameter %s of element %T", changeParam.name, APIGuidToString (elemGuid).ToPrintf ());
+        return APIERR_BADPARS;
+    }
+
+    const API_AddParType* actParam = FindParameterByName (getParams, changeParam.name);
+    if (actParam == nullptr) {
+        errMessage = GS::UniString::Printf ("Invalid input: %s is not a GDL parameter of element %T", changeParam.name, APIGuidToString (elemGuid).ToPrintf ());
+        return APIERR_BADPARS;
+    }
+    const bool isArrayParameter = (actParam->typeMod == API_ParArray);
+
+    if (parameter.IsList (ParameterValueFieldName)) {
+        if (!isArrayParameter) {
+            errMessage = GS::UniString::Printf ("Invalid input: %s is not an array parameter of element %T, provide a single value", changeParam.name, APIGuidToString (elemGuid).ToPrintf ());
+            return APIERR_BADPARS;
+        }
+        ArrayParameterChange change;
+        change.name = changeParam.name;
+        change.typeID = gdlParametersTypeDictionary[changeParam.name];
+        if (!ParseArrayParameterValue (parameter, change.typeID, change)) {
+            errMessage = GS::UniString::Printf ("Invalid input: the given value is not a valid array for parameter %s of element %T (use [v1, v2, ...] for one-dimensional and [[v11, v12], [v21, v22]] for two-dimensional arrays)", changeParam.name, APIGuidToString (elemGuid).ToPrintf ());
+            return APIERR_BADPARS;
+        }
+        pendingArrayChanges.Push (change);
+        return NoError;
+    }
+
+    if (parameter.Contains ("index1")) {
+        if (!isArrayParameter) {
+            errMessage = GS::UniString::Printf ("Invalid input: %s is not an array parameter of element %T, index1 and index2 are not allowed", changeParam.name, APIGuidToString (elemGuid).ToPrintf ());
+            return APIERR_BADPARS;
+        }
+        Int32 index1 = 0;
+        if (!parameter.Get ("index1", index1) || index1 < 1 || index1 > actParam->dim1) {
+            errMessage = GS::UniString::Printf ("Invalid input: index1 must be an integer between 1 and %d for array parameter %s of element %T", actParam->dim1, changeParam.name, APIGuidToString (elemGuid).ToPrintf ());
+            return APIERR_BADPARS;
+        }
+        Int32 index2 = 1;
+        if (parameter.Contains ("index2")) {
+            if (!parameter.Get ("index2", index2) || index2 < 1 || index2 > actParam->dim2) {
+                errMessage = GS::UniString::Printf ("Invalid input: index2 must be an integer between 1 and %d for array parameter %s of element %T", actParam->dim2, changeParam.name, APIGuidToString (elemGuid).ToPrintf ());
+                return APIERR_BADPARS;
+            }
+        }
+        changeParam.ind1 = index1;
+        changeParam.ind2 = index2;
+    } else if (parameter.Contains ("index2")) {
+        errMessage = GS::UniString::Printf ("Invalid input: index2 is given without index1 for parameter %s of element %T", changeParam.name, APIGuidToString (elemGuid).ToPrintf ());
+        return APIERR_BADPARS;
+    } else if (isArrayParameter) {
+        errMessage = GS::UniString::Printf ("Invalid input: %s is an array parameter of element %T, provide a list value to resize the array or use index1/index2 to change a single item", changeParam.name, APIGuidToString (elemGuid).ToPrintf ());
         return APIERR_BADPARS;
     }
 
@@ -718,4 +827,122 @@ SetGDLParametersOfElementsCommand::SetOneGDLParameter (
     }
 
     return err;
+}
+
+bool SetGDLParametersOfElementsCommand::ParseArrayParameterValue (
+    const GS::ObjectState& parameter,
+    API_AddParID typeID,
+    ArrayParameterChange& change)
+{
+    switch (typeID) {
+        case APIParT_Integer:
+        case APIParT_PenCol:
+        case APIParT_LineTyp:
+        case APIParT_Mater:
+        case APIParT_FillPat:
+        case APIParT_BuildingMaterial:
+        case APIParT_Profile: {
+            GS::Array<Int32> values;
+            if (!GetArrayValueField (parameter, values, change.dim1, change.dim2)) {
+                return false;
+            }
+            for (Int32 value : values) {
+                change.numberValues.Push (static_cast<double> (value));
+            }
+            return true;
+        }
+        case APIParT_ColRGB:
+        case APIParT_Intens:
+        case APIParT_Length:
+        case APIParT_RealNum:
+        case APIParT_Angle:
+            return GetArrayValueField (parameter, change.numberValues, change.dim1, change.dim2);
+        case APIParT_LightSw: {
+            GS::Array<GS::String> values;
+            if (!GetArrayValueField (parameter, values, change.dim1, change.dim2)) {
+                return false;
+            }
+            for (const GS::String& value : values) {
+                change.numberValues.Push (value == "Off" ? 0.0 : 1.0);
+            }
+            return true;
+        }
+        case APIParT_Boolean: {
+            GS::Array<bool> values;
+            if (!GetArrayValueField (parameter, values, change.dim1, change.dim2)) {
+                return false;
+            }
+            for (bool value : values) {
+                change.numberValues.Push (value ? 1.0 : 0.0);
+            }
+            return true;
+        }
+        case APIParT_CString:
+        case APIParT_Title:
+            return GetArrayValueField (parameter, change.stringValues, change.dim1, change.dim2);
+        default:
+        case APIParT_Dictionary:
+            // Not supported by the Archicad API yet
+            return false;
+    }
+}
+
+GSErrCode SetGDLParametersOfElementsCommand::ApplyArrayParameterChanges (
+    const API_GetParamsType& getParams,
+    const GS::Array<ArrayParameterChange>& changes,
+    const API_Guid& elemGuid,
+    GS::UniString& errMessage)
+{
+    const GSSize nParams = BMGetHandleSize ((GSHandle) getParams.params) / sizeof (API_AddParType);
+    for (const ArrayParameterChange& change : changes) {
+        API_AddParType* actParam = nullptr;
+        for (GSIndex ii = 0; ii < nParams; ++ii) {
+            if (CHCompareCStrings ((*getParams.params)[ii].name, change.name.ToCStr ()) == 0) {
+                actParam = &(*getParams.params)[ii];
+                break;
+            }
+        }
+
+        if (actParam == nullptr || actParam->typeMod != API_ParArray) {
+            errMessage = GS::UniString::Printf ("Invalid input: %s is not an array parameter of element %T", change.name.ToCStr (), APIGuidToString (elemGuid).ToPrintf ());
+            return APIERR_BADPARS;
+        }
+
+        GSHandle newArrayHandle = nullptr;
+        if (change.typeID == APIParT_CString || change.typeID == APIParT_Title) {
+            GSSize totalLength = 0;
+            for (const GS::UniString& value : change.stringValues) {
+                totalLength += value.GetLength () + 1;
+            }
+            newArrayHandle = BMAllocateHandle (totalLength * sizeof (GS::uchar_t), ALLOCATE_CLEAR, 0);
+            if (newArrayHandle == nullptr) {
+                return APIERR_MEMFULL;
+            }
+            GS::uchar_t* strPos = reinterpret_cast<GS::uchar_t*> (*newArrayHandle);
+            for (const GS::UniString& value : change.stringValues) {
+                GS::ucscpy (strPos, value.ToUStr ().Get ());
+                strPos += value.GetLength () + 1;
+            }
+        } else {
+            newArrayHandle = BMAllocateHandle (change.numberValues.GetSize () * sizeof (double), ALLOCATE_CLEAR, 0);
+            if (newArrayHandle == nullptr) {
+                return APIERR_MEMFULL;
+            }
+            double* arrayValues = reinterpret_cast<double*> (*newArrayHandle);
+            for (UIndex ii = 0; ii < change.numberValues.GetSize (); ++ii) {
+                arrayValues[ii] = change.numberValues[ii];
+            }
+        }
+
+        if (actParam->dim1 != change.dim1 || actParam->dim2 != change.dim2) {
+            // The stored value descriptions would no longer match the new dimensions
+            BMKillHandle (&actParam->arrayDescriptions);
+        }
+        BMKillHandle (&actParam->value.array);
+        actParam->value.array = newArrayHandle;
+        actParam->dim1 = change.dim1;
+        actParam->dim2 = change.dim2;
+    }
+
+    return NoError;
 }

--- a/archicad-addon/Sources/ElementGDLParameterCommands.cpp
+++ b/archicad-addon/Sources/ElementGDLParameterCommands.cpp
@@ -165,6 +165,120 @@ static const API_AddParType* FindParameterByName (const API_GetParamsType& getPa
     return nullptr;
 }
 
+// Retrieving a list of numbers via ObjectState::Get<GS::Array<double>> does not convert integer items
+// (their bit pattern is reinterpreted as double), so numbers are collected item by item instead.
+class NumberArrayValueCollector : public GS::ObjectState::Processor
+{
+public:
+    virtual void IntFound (const GS::String&, Int64 value) override
+    {
+        AddNumber (static_cast<double> (value));
+    }
+
+    virtual void UIntFound (const GS::String&, UInt64 value) override
+    {
+        AddNumber (static_cast<double> (value));
+    }
+
+    virtual void RealFound (const GS::String&, double value) override
+    {
+        AddNumber (value);
+    }
+
+    virtual void BoolFound (const GS::String&, bool) override
+    {
+        failed = true;
+    }
+
+    virtual void StringFound (const GS::String&, const GS::UniString&) override
+    {
+        failed = true;
+    }
+
+    virtual bool ObjectFound (const GS::String&, const GS::ObjectState&) override
+    {
+        failed = true;
+        return false;
+    }
+
+    virtual bool ListFound (const GS::String&) override
+    {
+        return !failed;
+    }
+
+    virtual void ListEntered (const GS::String&) override
+    {
+        ++depth;
+        if (depth > 2) {
+            failed = true;
+        } else if (depth == 2) {
+            rows.Push (GS::Array<double> ());
+        }
+    }
+
+    virtual void ListExited (const GS::String&) override
+    {
+        --depth;
+    }
+
+    bool GetCollectedValues (GS::Array<double>& outFlatValues, Int32& outDim1, Int32& outDim2) const
+    {
+        if (failed || (!rows.IsEmpty () && !flatValues.IsEmpty ())) {
+            return false;
+        }
+        if (!rows.IsEmpty ()) {
+            outDim1 = static_cast<Int32> (rows.GetSize ());
+            outDim2 = static_cast<Int32> (rows[0].GetSize ());
+            if (outDim2 == 0) {
+                return false;
+            }
+            for (const GS::Array<double>& row : rows) {
+                if (static_cast<Int32> (row.GetSize ()) != outDim2) {
+                    return false;
+                }
+                for (double value : row) {
+                    outFlatValues.Push (value);
+                }
+            }
+            return true;
+        }
+        if (!flatValues.IsEmpty ()) {
+            outDim1 = static_cast<Int32> (flatValues.GetSize ());
+            outDim2 = 1;
+            outFlatValues = flatValues;
+            return true;
+        }
+        return false;
+    }
+
+private:
+    void AddNumber (double value)
+    {
+        if (depth == 1) {
+            flatValues.Push (value);
+        } else if (depth == 2) {
+            rows.GetLast ().Push (value);
+        } else {
+            failed = true;
+        }
+    }
+
+    GS::Array<double> flatValues;
+    GS::Array<GS::Array<double>> rows;
+    Int32 depth = 0;
+    bool failed = false;
+};
+
+static bool GetNumberArrayValueField (const GS::ObjectState& parameter, GS::Array<double>& flatValues, Int32& dim1, Int32& dim2)
+{
+    if (!parameter.IsList (ParameterValueFieldName)) {
+        return false;
+    }
+    NumberArrayValueCollector collector;
+    parameter.Enumerate (ParameterValueFieldName, collector);
+    return collector.GetCollectedValues (flatValues, dim1, dim2);
+}
+
 template<typename T>
 static bool GetArrayValueField (const GS::ObjectState& parameter, GS::Array<T>& flatValues, Int32& dim1, Int32& dim2)
 {
@@ -856,7 +970,7 @@ bool SetGDLParametersOfElementsCommand::ParseArrayParameterValue (
         case APIParT_Length:
         case APIParT_RealNum:
         case APIParT_Angle:
-            return GetArrayValueField (parameter, change.numberValues, change.dim1, change.dim2);
+            return GetNumberArrayValueField (parameter, change.numberValues, change.dim1, change.dim2);
         case APIParT_LightSw: {
             GS::Array<GS::String> values;
             if (!GetArrayValueField (parameter, values, change.dim1, change.dim2)) {

--- a/archicad-addon/Sources/ElementGDLParameterCommands.hpp
+++ b/archicad-addon/Sources/ElementGDLParameterCommands.hpp
@@ -22,11 +22,32 @@ public:
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 
 private:
+    struct ArrayParameterChange {
+        GS::String name;
+        API_AddParID typeID = APIParT_Integer;
+        Int32 dim1 = 0;
+        Int32 dim2 = 0;
+        GS::Array<double> numberValues;
+        GS::Array<GS::UniString> stringValues;
+    };
+
     static GSErrCode SetOneGDLParameter (
         const GS::ObjectState& parameter,
         const API_Guid& elemGuid,
-        API_ChangeParamType& changeParam,
+        const API_GetParamsType& getParams,
         const GS::HashTable<GS::String, API_AddParID>& gdlParametersTypeDictionary,
         const GS::HashTable<short, GS::String>& gdlParametersIndexNameDictionary,
+        GS::Array<ArrayParameterChange>& pendingArrayChanges,
+        GS::UniString& errMessage);
+
+    static bool ParseArrayParameterValue (
+        const GS::ObjectState& parameter,
+        API_AddParID typeID,
+        ArrayParameterChange& change);
+
+    static GSErrCode ApplyArrayParameterChanges (
+        const API_GetParamsType& getParams,
+        const GS::Array<ArrayParameterChange>& changes,
+        const API_Guid& elemGuid,
         GS::UniString& errMessage);
 };

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -414,8 +414,16 @@
                 "type": "string",
                 "description": "The name of the parameter."
             },
+            "index1": {
+                "type": "integer",
+                "description": "Optional 1-based first index for changing a single item of an array parameter without resizing it. Only valid for array parameters and only together with a single (non-list) value."
+            },
+            "index2": {
+                "type": "integer",
+                "description": "Optional 1-based second index for changing a single item of a two-dimensional array parameter. Only valid together with index1. Defaults to 1."
+            },
             "value": {
-                "description": "The value of the parameter."
+                "description": "The new value of the parameter. For array parameters provide a list of values for one-dimensional arrays (e.g. [1, 2, 3]) or a list of lists for two-dimensional arrays (e.g. [[11, 12], [21, 22]]); the array parameter is resized to match the given values. Alternatively provide index1 (and optionally index2) together with a single value to change one item of the array without resizing it. Within one command call whole-array (list) values are applied after all single-value changes."
             }
         },
         "additionalProperties": false,
@@ -432,8 +440,16 @@
                 "type": "integer",
                 "description": "The index of the parameter."
             },
+            "index1": {
+                "type": "integer",
+                "description": "Optional 1-based first index for changing a single item of an array parameter without resizing it. Only valid for array parameters and only together with a single (non-list) value."
+            },
+            "index2": {
+                "type": "integer",
+                "description": "Optional 1-based second index for changing a single item of a two-dimensional array parameter. Only valid together with index1. Defaults to 1."
+            },
             "value": {
-                "description": "The value of the parameter."
+                "description": "The new value of the parameter. For array parameters provide a list of values for one-dimensional arrays (e.g. [1, 2, 3]) or a list of lists for two-dimensional arrays (e.g. [[11, 12], [21, 22]]); the array parameter is resized to match the given values. Alternatively provide index1 (and optionally index2) together with a single value to change one item of the array without resizing it. Within one command call whole-array (list) values are applied after all single-value changes."
             }
         },
         "additionalProperties": false,


### PR DESCRIPTION
GDL parameters consisting of arrays are not yet editable through Tapir. This PR aims to close this gap.

Full Disclosure: The PR was largely written by Claude's Fable model.