### PR TITLE
Add keyboard-shortcut-able + toolbar script slots to Tapir

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -101,6 +101,14 @@ static GSErrCode MenuCommandHandler (const API_MenuParams* menuParams)
                     break;
             }
             break;
+        // Each shortcut slot is its own top-level menu group (see ResourceIds.hpp) —
+        // RunShortcutSlot takes a 0-based slot index.
+        case ID_ADDON_MENU_RUNSCRIPT_1: TapirPalette::Instance ().RunShortcutSlot (0); break;
+        case ID_ADDON_MENU_RUNSCRIPT_2: TapirPalette::Instance ().RunShortcutSlot (1); break;
+        case ID_ADDON_MENU_RUNSCRIPT_3: TapirPalette::Instance ().RunShortcutSlot (2); break;
+        case ID_ADDON_MENU_RUNSCRIPT_4: TapirPalette::Instance ().RunShortcutSlot (3); break;
+        case ID_ADDON_MENU_RUNSCRIPT_5: TapirPalette::Instance ().RunShortcutSlot (4); break;
+        case ID_ADDON_MENU_RUNSCRIPT_6: TapirPalette::Instance ().RunShortcutSlot (5); break;
     }
 
     return NoError;
@@ -122,6 +130,12 @@ GSErrCode RegisterInterface (void)
     err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_FOR_PALETTE, 0, MenuCode_UserDef, MenuFlag_Default);
     err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_FOR_UPDATE, 0, MenuCode_UserDef, MenuFlag_Default);
     err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU, 0, MenuCode_UserDef, MenuFlag_Default);
+    err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_RUNSCRIPT_1, 0, MenuCode_UserDef, MenuFlag_Default);
+    err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_RUNSCRIPT_2, 0, MenuCode_UserDef, MenuFlag_Default);
+    err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_RUNSCRIPT_3, 0, MenuCode_UserDef, MenuFlag_Default);
+    err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_RUNSCRIPT_4, 0, MenuCode_UserDef, MenuFlag_Default);
+    err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_RUNSCRIPT_5, 0, MenuCode_UserDef, MenuFlag_Default);
+    err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_RUNSCRIPT_6, 0, MenuCode_UserDef, MenuFlag_Default);
 
     return err;
 }
@@ -133,7 +147,18 @@ GSErrCode Initialize (void)
     err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_FOR_PALETTE, MenuCommandHandler);
     err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_FOR_UPDATE, MenuCommandHandler);
     err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU, MenuCommandHandler);
+    err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_RUNSCRIPT_1, MenuCommandHandler);
+    err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_RUNSCRIPT_2, MenuCommandHandler);
+    err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_RUNSCRIPT_3, MenuCommandHandler);
+    err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_RUNSCRIPT_4, MenuCommandHandler);
+    err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_RUNSCRIPT_5, MenuCommandHandler);
+    err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_RUNSCRIPT_6, MenuCommandHandler);
     err |= TapirPalette::RegisterPaletteControlCallBack ();
+
+    // Forces the palette singleton (and its saved shortcut-slot preferences) to load immediately,
+    // so custom shortcut menu labels are applied at startup rather than only after the user first
+    // opens the palette or triggers a shortcut.
+    TapirPalette::Instance ();
 
     { // Application Commands
         CommandGroup applicationCommands ("Application Commands");

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -14,6 +14,7 @@
 #define ACAPI_MenuItem_InstallMenuHandler ACAPI_Install_MenuHandler
 #define ACAPI_MenuItem_GetMenuItemFlags(par1, par2) ACAPI_Interface (APIIo_GetMenuItemFlagsID, par1, par2);
 #define ACAPI_MenuItem_SetMenuItemFlags(par1, par2) ACAPI_Interface (APIIo_SetMenuItemFlagsID, par1, par2);
+#define ACAPI_MenuItem_SetMenuItemText(par1, par2, par3) ACAPI_Interface (APIIo_SetMenuItemTextID, par1, par2, par3);
 
 #define ACAPI_Markup_Create ACAPI_MarkUp_Create
 #define ACAPI_Markup_Delete ACAPI_MarkUp_Delete

--- a/archicad-addon/Sources/RFIX/AddOnFix.grc
+++ b/archicad-addon/Sources/RFIX/AddOnFix.grc
@@ -41,6 +41,10 @@
     "RunWithUpdate"
 }
 
+'GICN' ID_SHORTCUTS_BUTTON_ICON "Shortcuts" {
+    "Shortcuts"
+}
+
 'FILE' ID_COMMON_SCHEMA_DEFINITIONS_FILE "" {
     "CommonSchemaDefinitions.json"
 }

--- a/archicad-addon/Sources/RFIX/Images/Shortcuts_24x24.svg
+++ b/archicad-addon/Sources/RFIX/Images/Shortcuts_24x24.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   version="1.1"
+   enable-background="new 0 0 24.00 24.00"
+   xml:space="preserve"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+<path d="M0 0h24v24H0z" fill="none" />
+<path
+   fill="#263238"
+   d="M18 15.5v-2h-2v-1h2v-2h1v2h2v1h-2v2zm-3.462 5.52q-2.751-1.162-4.375-3.614t-1.624-5.429q0-2.39 1.102-4.495Q10.742 5.377 12.7 4H8.462V3h6.077v6.077h-1V4.589q-1.887 1.217-2.944 3.17t-1.057 4.199q0 2.569 1.35 4.707t3.65 3.256z"
+   id="path1" />
+</svg>

--- a/archicad-addon/Sources/RINT/AddOn.grc
+++ b/archicad-addon/Sources/RINT/AddOn.grc
@@ -21,6 +21,36 @@
 /* [  1] */        "Check for Updates...^E3^ES^EE^EI^ED^EL^EW^ET^EM^32510"
 }
 
+'STR#' ID_ADDON_MENU_RUNSCRIPT_1 "Add-On Menu" {
+/* [   ] */        "Tapir"
+/* [  1] */        "Run Script Shortcut 1^E3^ES^EE^EI^ED^EL^EW^ET^EM"
+}
+
+'STR#' ID_ADDON_MENU_RUNSCRIPT_2 "Add-On Menu" {
+/* [   ] */        "Tapir"
+/* [  1] */        "Run Script Shortcut 2^E3^ES^EE^EI^ED^EL^EW^ET^EM"
+}
+
+'STR#' ID_ADDON_MENU_RUNSCRIPT_3 "Add-On Menu" {
+/* [   ] */        "Tapir"
+/* [  1] */        "Run Script Shortcut 3^E3^ES^EE^EI^ED^EL^EW^ET^EM"
+}
+
+'STR#' ID_ADDON_MENU_RUNSCRIPT_4 "Add-On Menu" {
+/* [   ] */        "Tapir"
+/* [  1] */        "Run Script Shortcut 4^E3^ES^EE^EI^ED^EL^EW^ET^EM"
+}
+
+'STR#' ID_ADDON_MENU_RUNSCRIPT_5 "Add-On Menu" {
+/* [   ] */        "Tapir"
+/* [  1] */        "Run Script Shortcut 5^E3^ES^EE^EI^ED^EL^EW^ET^EM"
+}
+
+'STR#' ID_ADDON_MENU_RUNSCRIPT_6 "Add-On Menu" {
+/* [   ] */        "Tapir"
+/* [  1] */        "Run Script Shortcut 6^E3^ES^EE^EI^ED^EL^EW^ET^EM"
+}
+
 'STR#' ID_PALETTE_STRINGS "Tapir Palette Strings" {
 /* [  1] */ "Select Python Scripts"
 /* [  2] */ "Add"
@@ -51,13 +81,14 @@
 4    ""        VersionText
 }
 
-'GDLG' ID_PALETTE Palette | leftCaption | close   0   0  400  28  "Tapir Palette"  {
+'GDLG' ID_PALETTE Palette | leftCaption | close   0   0  428  28  "Tapir Palette"  {
 /* [  1] */ IconButton                 0   0  28  28    ID_TAPIR_LOGO_MINI noFrame
 /* [  2] */ PopupControl              28   3 260  22    80  3
 /* [  3] */ IconButton               288   0  28  28    ID_RUN_BUTTON_ICON noFrame
 /* [  4] */ IconButton               316   0  28  28    ID_OPENSCRIPT_BUTTON_ICON noFrame
 /* [  5] */ IconButton               344   0  28  28    ID_ADDSCRIPT_BUTTON_ICON noFrame
 /* [  6] */ IconButton               372   0  28  28    ID_DELSCRIPT_BUTTON_ICON noFrame
+/* [  7] */ IconButton               400   0  28  28    ID_SHORTCUTS_BUTTON_ICON noFrame
 }
 
 'DLGH' ID_PALETTE Tapir_Palette {
@@ -67,4 +98,53 @@
 4    ""        OpenButton
 5    ""        AddButton
 6    ""        DelButton
+7    ""        ManageShortcutsButton
+}
+
+'GDLG' ID_SHORTCUTS_DIALOG Modal | noGrow    80   80  500  270  "Script Shortcuts" {
+/* [  1] */ LeftText     110    6  210   16    SmallPlain  vCenter  "Script"
+/* [  2] */ LeftText     330    6  150   16    SmallPlain  vCenter  "Toolbar label (optional)"
+/* [  3] */ LeftText      10   32   90   18    SmallPlain  vCenter  "Shortcut 1:"
+/* [  4] */ PopupControl 110   30  210   22    80  3
+/* [  5] */ TextEdit     330   30  150   22    SmallPlain  60
+/* [  6] */ LeftText      10   62   90   18    SmallPlain  vCenter  "Shortcut 2:"
+/* [  7] */ PopupControl 110   60  210   22    80  3
+/* [  8] */ TextEdit     330   60  150   22    SmallPlain  60
+/* [  9] */ LeftText      10   92   90   18    SmallPlain  vCenter  "Shortcut 3:"
+/* [ 10] */ PopupControl 110   90  210   22    80  3
+/* [ 11] */ TextEdit     330   90  150   22    SmallPlain  60
+/* [ 12] */ LeftText      10  122   90   18    SmallPlain  vCenter  "Shortcut 4:"
+/* [ 13] */ PopupControl 110  120  210   22    80  3
+/* [ 14] */ TextEdit     330  120  150   22    SmallPlain  60
+/* [ 15] */ LeftText      10  152   90   18    SmallPlain  vCenter  "Shortcut 5:"
+/* [ 16] */ PopupControl 110  150  210   22    80  3
+/* [ 17] */ TextEdit     330  150  150   22    SmallPlain  60
+/* [ 18] */ LeftText      10  182   90   18    SmallPlain  vCenter  "Shortcut 6:"
+/* [ 19] */ PopupControl 110  180  210   22    80  3
+/* [ 20] */ TextEdit     330  180  150   22    SmallPlain  60
+/* [ 21] */ Button       410  224   70   24    LargePlain  "Close"
+}
+
+'DLGH' ID_SHORTCUTS_DIALOG Tapir_Shortcuts_Dialog {
+1    ""        ScriptColumnHeader
+2    ""        LabelColumnHeader
+3    ""        ShortcutLabel1
+4    ""        ShortcutPopUp1
+5    ""        ShortcutLabelEdit1
+6    ""        ShortcutLabel2
+7    ""        ShortcutPopUp2
+8    ""        ShortcutLabelEdit2
+9    ""        ShortcutLabel3
+10   ""        ShortcutPopUp3
+11   ""        ShortcutLabelEdit3
+12   ""        ShortcutLabel4
+13   ""        ShortcutPopUp4
+14   ""        ShortcutLabelEdit4
+15   ""        ShortcutLabel5
+16   ""        ShortcutPopUp5
+17   ""        ShortcutLabelEdit5
+18   ""        ShortcutLabel6
+19   ""        ShortcutPopUp6
+20   ""        ShortcutLabelEdit6
+21   ""        CloseButton
 }

--- a/archicad-addon/Sources/ResourceIds.hpp
+++ b/archicad-addon/Sources/ResourceIds.hpp
@@ -13,6 +13,31 @@
 #define ID_ADDON_MENU_FOR_UPDATE        32003
 #define ID_ADDON_MENU_UPDATE                1
 
+// Each shortcut slot is its own top-level menu group (own resID, exactly one item) — confirmed
+// working end to end (menu display AND click dispatch running the assigned script).
+#define ID_ADDON_MENU_RUNSCRIPT_1       32020
+#define ID_ADDON_MENU_RUNSCRIPT_2       32021
+#define ID_ADDON_MENU_RUNSCRIPT_3       32022
+#define ID_ADDON_MENU_RUNSCRIPT_4       32023
+#define ID_ADDON_MENU_RUNSCRIPT_5       32024
+#define ID_ADDON_MENU_RUNSCRIPT_6       32025
+#define ID_ADDON_MENU_RUNSCRIPT_ITEM        1
+
+#define ID_SHORTCUTS_DIALOG                  32030
+#define ID_SHORTCUTS_DIALOG_POPUP_1               4
+#define ID_SHORTCUTS_DIALOG_LABELEDIT_1           5
+#define ID_SHORTCUTS_DIALOG_POPUP_2               7
+#define ID_SHORTCUTS_DIALOG_LABELEDIT_2           8
+#define ID_SHORTCUTS_DIALOG_POPUP_3              10
+#define ID_SHORTCUTS_DIALOG_LABELEDIT_3          11
+#define ID_SHORTCUTS_DIALOG_POPUP_4              13
+#define ID_SHORTCUTS_DIALOG_LABELEDIT_4          14
+#define ID_SHORTCUTS_DIALOG_POPUP_5              16
+#define ID_SHORTCUTS_DIALOG_LABELEDIT_5          17
+#define ID_SHORTCUTS_DIALOG_POPUP_6              19
+#define ID_SHORTCUTS_DIALOG_LABELEDIT_6          20
+#define ID_SHORTCUTS_DIALOG_CLOSE_BUTTON         21
+
 #define ID_PALETTE_STRINGS              32010
 #define ID_PALETTE_STRINGS_SELECT_SCRIPTS_TITLE  1
 #define ID_PALETTE_STRINGS_SELECT_SCRIPTS_BUTTON 2
@@ -38,6 +63,7 @@
 #define ID_DELSCRIPT_BUTTON_ICON        32508
 #define ID_RUNWITHUPDATE_BUTTON_ICON    32509
 #define ID_UPDATE_ICON                  32510
+#define ID_SHORTCUTS_BUTTON_ICON        32511
 
 #define ID_ABOUT_DIALOG                 32003
 #define ID_PALETTE                      32004

--- a/archicad-addon/Sources/TapirPalette.cpp
+++ b/archicad-addon/Sources/TapirPalette.cpp
@@ -142,6 +142,7 @@ TapirPalette::TapirPalette ()
     , openScriptButton (GetReference (), 4)
     , addScriptButton (GetReference (), 5)
     , delScriptButton (GetReference (), 6)
+    , manageShortcutsButton (GetReference (), 7)
 {
     Attach (*this);
     AttachToAllItems (*this);
@@ -216,6 +217,7 @@ void TapirPalette::PanelOpened (const DG::PanelOpenEvent&)
         }
     }
     scriptSelectionPopUp.SelectItem (itemToSelect);
+    RefreshScriptListShortcutLabels ();
 }
 
 static void OpenWebpage (const GS::UniString& webpage)
@@ -277,6 +279,8 @@ void TapirPalette::ButtonClicked (const DG::ButtonClickEvent& ev)
         AddNewScript ();
     } else if (ev.GetSource () == &delScriptButton) {
         DeleteScriptFromPopUp ();
+    } else if (ev.GetSource () == &manageShortcutsButton) {
+        OpenShortcutsDialog ();
     }
 }
 
@@ -314,6 +318,297 @@ void TapirPalette::PopUpChanged (const DG::PopUpChangeEvent& ev)
         SaveScriptsToPreferences ();
         SetDeleteScriptButtonStatus ();
     }
+}
+
+void TapirPalette::RunShortcutSlot (short slotIndex)
+{
+    // Uses DG_ERROR (pops an alert) rather than DG_WARNING (silently logged) for every failure
+    // path here on purpose: a keyboard-shortcut-triggered action needs to be impossible to miss —
+    // a report-log-only warning looks identical to "nothing happened" if the Report window isn't open.
+    if (slotIndex < 0 || slotIndex >= ScriptShortcutSlotCount || scriptShortcutSlots[slotIndex].IsEmpty ()) {
+        WriteReport (DG_ERROR, "No script assigned to shortcut slot %d.", (int) (slotIndex + 1));
+        return;
+    }
+    if (IsProcessRunning ()) {
+        WriteReport (DG_ERROR, "A script is already running - wait for it to finish before using a shortcut slot.");
+        return;
+    }
+    if (Config::Instance ().AskUpdatingAddOnBeforeEachExecution () && UpdateAddOn ()) {
+        return;
+    }
+
+    for (short i = 1; i <= scriptSelectionPopUp.GetItemCount () - 1; ++i) {
+        if (scriptSelectionPopUp.IsSeparator (i)) {
+            continue;
+        }
+        GS::Ref<PopUpItemData> popUpItemData = GS::DynamicCast<PopUpItemData> (scriptSelectionPopUp.GetItemObjectData (i));
+        if (popUpItemData != nullptr && popUpItemData->fileLocation == scriptShortcutSlots[slotIndex]) {
+            ExecuteScript (*popUpItemData);
+            return;
+        }
+    }
+    WriteReport (DG_ERROR, "Script assigned to shortcut slot %d could not be found (%d scripts currently listed).",
+        (int) (slotIndex + 1), (int) (scriptSelectionPopUp.GetItemCount () - 1));
+}
+
+void TapirPalette::GetAvailableScripts (GS::Array<std::pair<GS::UniString, IO::Location>>& outScripts)
+{
+    outScripts.Clear ();
+    for (short i = 1; i <= scriptSelectionPopUp.GetItemCount () - 1; ++i) {
+        if (scriptSelectionPopUp.IsSeparator (i)) {
+            continue;
+        }
+        GS::Ref<PopUpItemData> popUpItemData = GS::DynamicCast<PopUpItemData> (scriptSelectionPopUp.GetItemObjectData (i));
+        if (popUpItemData != nullptr) {
+            outScripts.Push ({ scriptSelectionPopUp.GetItemText (i), popUpItemData->fileLocation });
+        }
+    }
+}
+
+IO::Location TapirPalette::GetShortcutSlot (short slotIndex) const
+{
+    if (slotIndex < 0 || slotIndex >= ScriptShortcutSlotCount) {
+        return IO::Location ();
+    }
+    return scriptShortcutSlots[slotIndex];
+}
+
+void TapirPalette::SetShortcutSlot (short slotIndex, const IO::Location& location)
+{
+    if (slotIndex < 0 || slotIndex >= ScriptShortcutSlotCount) {
+        return;
+    }
+    // A script only ever occupies one slot — clear it from any other slot first.
+    if (!location.IsEmpty ()) {
+        for (short slot = 0; slot < ScriptShortcutSlotCount; ++slot) {
+            if (scriptShortcutSlots[slot] == location) {
+                scriptShortcutSlots[slot] = IO::Location ();
+            }
+        }
+    }
+    scriptShortcutSlots[slotIndex] = location;
+    SaveScriptsToPreferences ();
+    RefreshScriptListShortcutLabels ();
+}
+
+GS::UniString TapirPalette::GetShortcutLabel (short slotIndex) const
+{
+    if (slotIndex < 0 || slotIndex >= ScriptShortcutSlotCount) {
+        return GS::EmptyUniString;
+    }
+    return scriptShortcutLabels[slotIndex];
+}
+
+void TapirPalette::SetShortcutLabel (short slotIndex, const GS::UniString& label)
+{
+    if (slotIndex < 0 || slotIndex >= ScriptShortcutSlotCount) {
+        return;
+    }
+    if (scriptShortcutLabels[slotIndex] == label) {
+        return;
+    }
+    scriptShortcutLabels[slotIndex] = label;
+    ApplyShortcutMenuItemText (slotIndex);
+    SaveScriptsToPreferences ();
+}
+
+// scriptSelectionPopUp items get "  [Shortcut N]" appended when the script backing them is assigned
+// to a slot, so both "which slot is this" and "what's already taken" are visible while just browsing
+// the normal script dropdown, not only inside the dedicated Shortcuts dialog.
+void TapirPalette::RefreshScriptListShortcutLabels ()
+{
+    for (short i = 1; i <= scriptSelectionPopUp.GetItemCount () - 1; ++i) {
+        if (scriptSelectionPopUp.IsSeparator (i)) {
+            continue;
+        }
+        GS::Ref<PopUpItemData> popUpItemData = GS::DynamicCast<PopUpItemData> (scriptSelectionPopUp.GetItemObjectData (i));
+        if (popUpItemData == nullptr) {
+            continue;
+        }
+        GS::UniString label = popUpItemData->baseDisplayText;
+        for (short slot = 0; slot < ScriptShortcutSlotCount; ++slot) {
+            if (!scriptShortcutSlots[slot].IsEmpty () && scriptShortcutSlots[slot] == popUpItemData->fileLocation) {
+                label += GS::UniString::Printf ("   [Shortcut %d]", (int) (slot + 1));
+                break;
+            }
+        }
+        scriptSelectionPopUp.SetItemText (i, label);
+    }
+}
+
+void TapirPalette::ApplyShortcutMenuItemText (short slotIndex)
+{
+    static const short menuResIds[ScriptShortcutSlotCount] = {
+        ID_ADDON_MENU_RUNSCRIPT_1, ID_ADDON_MENU_RUNSCRIPT_2, ID_ADDON_MENU_RUNSCRIPT_3,
+        ID_ADDON_MENU_RUNSCRIPT_4, ID_ADDON_MENU_RUNSCRIPT_5, ID_ADDON_MENU_RUNSCRIPT_6
+    };
+    if (slotIndex < 0 || slotIndex >= ScriptShortcutSlotCount) {
+        return;
+    }
+
+    GS::UniString label = scriptShortcutLabels[slotIndex];
+    if (label.IsEmpty ()) {
+        label = GS::UniString::Printf ("Run Script Shortcut %d", (int) (slotIndex + 1));
+    }
+
+    API_MenuItemRef itemRef = {};
+    itemRef.menuResID = menuResIds[slotIndex];
+    itemRef.itemIndex = ID_ADDON_MENU_RUNSCRIPT_ITEM;
+    ACAPI_MenuItem_SetMenuItemText (&itemRef, nullptr, &label);
+}
+
+void TapirPalette::ApplyAllShortcutMenuItemTexts ()
+{
+    for (short slot = 0; slot < ScriptShortcutSlotCount; ++slot) {
+        ApplyShortcutMenuItemText (slot);
+    }
+}
+
+namespace {
+
+// Dedicated dialog for assigning scripts to shortcut slots: each row shows the slot's currently
+// assigned script directly in its own popup (and "(unassigned)" when empty), plus an editable label
+// for the text shown in Archicad's menu/toolbar for that shortcut, so both "which slot is this" and
+// "what's already taken" are visible in one screen, instead of blind slot numbers.
+class TapirShortcutsDialog : public DG::ModalDialog,
+    public DG::ButtonItemObserver,
+    public DG::PopUpObserver,
+    public DG::TextEditBaseObserver
+{
+public:
+    TapirShortcutsDialog ()
+        : DG::ModalDialog (ACAPI_GetOwnResModule (), ID_SHORTCUTS_DIALOG, ACAPI_GetOwnResModule ())
+        , slotPopUp1 (GetReference (), ID_SHORTCUTS_DIALOG_POPUP_1)
+        , slotPopUp2 (GetReference (), ID_SHORTCUTS_DIALOG_POPUP_2)
+        , slotPopUp3 (GetReference (), ID_SHORTCUTS_DIALOG_POPUP_3)
+        , slotPopUp4 (GetReference (), ID_SHORTCUTS_DIALOG_POPUP_4)
+        , slotPopUp5 (GetReference (), ID_SHORTCUTS_DIALOG_POPUP_5)
+        , slotPopUp6 (GetReference (), ID_SHORTCUTS_DIALOG_POPUP_6)
+        , labelEdit1 (GetReference (), ID_SHORTCUTS_DIALOG_LABELEDIT_1)
+        , labelEdit2 (GetReference (), ID_SHORTCUTS_DIALOG_LABELEDIT_2)
+        , labelEdit3 (GetReference (), ID_SHORTCUTS_DIALOG_LABELEDIT_3)
+        , labelEdit4 (GetReference (), ID_SHORTCUTS_DIALOG_LABELEDIT_4)
+        , labelEdit5 (GetReference (), ID_SHORTCUTS_DIALOG_LABELEDIT_5)
+        , labelEdit6 (GetReference (), ID_SHORTCUTS_DIALOG_LABELEDIT_6)
+        , closeButton (GetReference (), ID_SHORTCUTS_DIALOG_CLOSE_BUTTON)
+    {
+        slotPopUps[0] = &slotPopUp1;
+        slotPopUps[1] = &slotPopUp2;
+        slotPopUps[2] = &slotPopUp3;
+        slotPopUps[3] = &slotPopUp4;
+        slotPopUps[4] = &slotPopUp5;
+        slotPopUps[5] = &slotPopUp6;
+
+        labelEdits[0] = &labelEdit1;
+        labelEdits[1] = &labelEdit2;
+        labelEdits[2] = &labelEdit3;
+        labelEdits[3] = &labelEdit4;
+        labelEdits[4] = &labelEdit5;
+        labelEdits[5] = &labelEdit6;
+
+        closeButton.Attach (*this);
+        for (short row = 0; row < TapirPalette::ScriptShortcutSlotCount; ++row) {
+            slotPopUps[row]->Attach (*this);
+            labelEdits[row]->Attach (*this);
+        }
+
+        TapirPalette::Instance ().GetAvailableScripts (scripts);
+        for (short row = 0; row < TapirPalette::ScriptShortcutSlotCount; ++row) {
+            BuildRowItems (*slotPopUps[row]);
+        }
+        RefreshAllRows ();
+    }
+
+    ~TapirShortcutsDialog ()
+    {
+        closeButton.Detach (*this);
+        for (short row = 0; row < TapirPalette::ScriptShortcutSlotCount; ++row) {
+            slotPopUps[row]->Detach (*this);
+            labelEdits[row]->Detach (*this);
+        }
+    }
+
+private:
+    DG::PopUp    slotPopUp1, slotPopUp2, slotPopUp3, slotPopUp4, slotPopUp5, slotPopUp6;
+    DG::TextEdit labelEdit1, labelEdit2, labelEdit3, labelEdit4, labelEdit5, labelEdit6;
+    DG::Button   closeButton;
+    DG::PopUp*     slotPopUps[TapirPalette::ScriptShortcutSlotCount];
+    DG::TextEdit*  labelEdits[TapirPalette::ScriptShortcutSlotCount];
+    GS::Array<std::pair<GS::UniString, IO::Location>> scripts;
+
+    void BuildRowItems (DG::PopUp& popUp)
+    {
+        popUp.AppendItem ();
+        popUp.SetItemText (DG::PopUp::BottomItem, "(unassigned)");
+        for (const auto& script : scripts) {
+            popUp.AppendItem ();
+            popUp.SetItemText (DG::PopUp::BottomItem, script.first);
+        }
+    }
+
+    void RefreshAllRows ()
+    {
+        for (short row = 0; row < TapirPalette::ScriptShortcutSlotCount; ++row) {
+            const IO::Location assigned = TapirPalette::Instance ().GetShortcutSlot (row);
+            short itemToSelect = 1;   // "(unassigned)"
+            if (!assigned.IsEmpty ()) {
+                for (UIndex i = 0; i < scripts.GetSize (); ++i) {
+                    if (scripts[i].second == assigned) {
+                        itemToSelect = (short) (i + 2);
+                        break;
+                    }
+                }
+            }
+            slotPopUps[row]->SelectItem (itemToSelect);
+
+            GS::UniString label = TapirPalette::Instance ().GetShortcutLabel (row);
+            if (label.IsEmpty ()) {
+                label = GS::UniString::Printf ("Run Script Shortcut %d", (int) (row + 1));
+            }
+            labelEdits[row]->SetText (label);
+        }
+    }
+
+    virtual void ButtonClicked (const DG::ButtonClickEvent& ev) override
+    {
+        if (ev.GetSource () == &closeButton) {
+            PostCloseRequest (DG::ModalDialog::Accept);
+        }
+    }
+
+    virtual void PopUpChanged (const DG::PopUpChangeEvent& ev) override
+    {
+        for (short row = 0; row < TapirPalette::ScriptShortcutSlotCount; ++row) {
+            if (ev.GetSource () == slotPopUps[row]) {
+                const short selectedItem = slotPopUps[row]->GetSelectedItem ();
+                IO::Location newLocation;   // empty = unassigned
+                if (selectedItem >= 2 && (UIndex) (selectedItem - 2) < scripts.GetSize ()) {
+                    newLocation = scripts[selectedItem - 2].second;
+                }
+                TapirPalette::Instance ().SetShortcutSlot (row, newLocation);
+                RefreshAllRows ();   // another row may have just lost this script to the dedup rule
+                return;
+            }
+        }
+    }
+
+    virtual void TextEditChanged (const DG::TextEditChangeEvent& ev) override
+    {
+        for (short row = 0; row < TapirPalette::ScriptShortcutSlotCount; ++row) {
+            if (ev.GetSource () == labelEdits[row]) {
+                TapirPalette::Instance ().SetShortcutLabel (row, labelEdits[row]->GetText ());
+                return;
+            }
+        }
+    }
+};
+
+} // namespace
+
+void TapirPalette::OpenShortcutsDialog ()
+{
+    TapirShortcutsDialog dialog;
+    dialog.Invoke ();
 }
 
 GSErrCode TapirPalette::PaletteControlCallBack (Int32, API_PaletteMessageID messageID, GS::IntPtr param)
@@ -510,13 +805,14 @@ bool TapirPalette::AddScriptToPopUp (GS::Ref<PopUpItemData> popUpData, short ind
     if (popUpData->repo) {
         auto* repo = popUpData->repo;
         if (repo->displayName.IsEmpty ()) {
-            scriptSelectionPopUp.SetItemText (index, name.ToString () + " (" + repo->repoOwner + "/" + repo->repoName + ")");
+            popUpData->baseDisplayText = name.ToString () + " (" + repo->repoOwner + "/" + repo->repoName + ")";
         } else {
-            scriptSelectionPopUp.SetItemText (index, name.ToString () + " (" + repo->displayName + ")");
+            popUpData->baseDisplayText = name.ToString () + " (" + repo->displayName + ")";
         }
     } else {
-        scriptSelectionPopUp.SetItemText (index, name.ToString ());
+        popUpData->baseDisplayText = name.ToString ();
     }
+    scriptSelectionPopUp.SetItemText (index, popUpData->baseDisplayText);
     scriptSelectionPopUp.SetItemObjectData (index, popUpData);
 
     return true;
@@ -625,6 +921,7 @@ void TapirPalette::LoadScriptsToPopUp ()
     }
     scriptSelectionPopUp.SelectItem (itemToSelect);
 
+    RefreshScriptListShortcutLabels ();
     SetDeleteScriptButtonStatus ();
 }
 
@@ -699,7 +996,11 @@ bool TapirPalette::UpdateAddOn ()
     return true;
 }
 
-#define PREFERENCES_VERSION 10
+#define PREFERENCES_VERSION 12
+#define PREFERENCES_VERSION_BEFORE_SHORTCUT_LABELS 11
+#define PREFERENCES_VERSION_BEFORE_SHORTCUT_SLOTS 10
+static const GS::UniString ShortcutSlotEmptyMarker ("(unassigned)");   // never a valid file path; "" would be dropped by SkipEmptyParts
+static const GS::UniString ShortcutLabelDefaultMarker ("(default)");   // means "use the default 'Run Script Shortcut N' text"; "" would be dropped by SkipEmptyParts
 
 void TapirPalette::SaveScriptsToPreferences ()
 {
@@ -717,6 +1018,17 @@ void TapirPalette::SaveScriptsToPreferences ()
         }
     }
     preferencesStr += GS::ValueToUniString (scriptSelectionPopUp.GetSelectedItem ());
+    for (short slot = 0; slot < ScriptShortcutSlotCount; ++slot) {
+        GS::UniString slotPathStr = ShortcutSlotEmptyMarker;
+        if (!scriptShortcutSlots[slot].IsEmpty ()) {
+            scriptShortcutSlots[slot].ToPath (&slotPathStr);
+        }
+        preferencesStr += '\n' + slotPathStr;
+    }
+    for (short slot = 0; slot < ScriptShortcutSlotCount; ++slot) {
+        const GS::UniString& labelStr = scriptShortcutLabels[slot].IsEmpty () ? ShortcutLabelDefaultMarker : scriptShortcutLabels[slot];
+        preferencesStr += '\n' + labelStr;
+    }
     auto cStr = preferencesStr.ToCStr ();
     ACAPI_SetPreferences (PREFERENCES_VERSION, (GSSize)strlen (cStr.Get()), cStr.Get());
 }
@@ -739,12 +1051,16 @@ short TapirPalette::AddScriptsFromPreferences ()
             scriptSelectionPopUp.DeleteItem (DG::PopUp::TopItem);
         }
     }
+    for (short slot = 0; slot < ScriptShortcutSlotCount; ++slot) {
+        scriptShortcutSlots[slot] = IO::Location ();
+        scriptShortcutLabels[slot] = GS::EmptyUniString;
+    }
 
     Int32 version;
     GSSize nBytes;
 
     ACAPI_GetPreferences (&version, &nBytes, nullptr);
-    if (version != PREFERENCES_VERSION || nBytes <= 0) {
+    if (nBytes <= 0 || (version != PREFERENCES_VERSION && version != PREFERENCES_VERSION_BEFORE_SHORTCUT_LABELS && version != PREFERENCES_VERSION_BEFORE_SHORTCUT_SLOTS)) {
         return DG::PopUp::TopItem;
     }
 
@@ -752,8 +1068,37 @@ short TapirPalette::AddScriptsFromPreferences ()
     ACAPI_GetPreferences (&version, &nBytes, data.get ());
     GS::Array<GS::UniString> scriptPathArray;
     GS::UniString (data.get ()).Split ("\n", GS::UniString::SkipEmptyParts, &scriptPathArray);
+
+    if (version == PREFERENCES_VERSION && scriptPathArray.GetSize () >= 2 * ScriptShortcutSlotCount) {
+        // Labels were appended last, so they must be popped first.
+        for (short slot = ScriptShortcutSlotCount - 1; slot >= 0; --slot) {
+            GS::UniString labelStr = scriptPathArray.GetLast ();
+            scriptPathArray.DeleteLast ();
+            if (labelStr != ShortcutLabelDefaultMarker) {
+                scriptShortcutLabels[slot] = labelStr;
+            }
+        }
+        for (short slot = ScriptShortcutSlotCount - 1; slot >= 0; --slot) {
+            GS::UniString slotPathStr = scriptPathArray.GetLast ();
+            scriptPathArray.DeleteLast ();
+            if (slotPathStr != ShortcutSlotEmptyMarker) {
+                scriptShortcutSlots[slot] = IO::Location (slotPathStr);
+            }
+        }
+    } else if (version == PREFERENCES_VERSION_BEFORE_SHORTCUT_LABELS && scriptPathArray.GetSize () >= ScriptShortcutSlotCount) {
+        for (short slot = ScriptShortcutSlotCount - 1; slot >= 0; --slot) {
+            GS::UniString slotPathStr = scriptPathArray.GetLast ();
+            scriptPathArray.DeleteLast ();
+            if (slotPathStr != ShortcutSlotEmptyMarker) {
+                scriptShortcutSlots[slot] = IO::Location (slotPathStr);
+            }
+        }
+    }
+
+    ApplyAllShortcutMenuItemTexts ();
+
     short selectedItemBeforeClose = -1;
-    if (GS::UniStringToValue<short> (scriptPathArray.GetLast (), selectedItemBeforeClose, GS::ToValueMode::Strict)) {
+    if (!scriptPathArray.IsEmpty () && GS::UniStringToValue<short> (scriptPathArray.GetLast (), selectedItemBeforeClose, GS::ToValueMode::Strict)) {
         scriptPathArray.DeleteLast();
     }
     for (auto&& scriptPath : scriptPathArray) {

--- a/archicad-addon/Sources/TapirPalette.hpp
+++ b/archicad-addon/Sources/TapirPalette.hpp
@@ -8,6 +8,8 @@
 #include "Config.hpp"
 #include "UvManager.hpp"
 
+#include <utility>
+
 class TapirPalette final : public DG::Palette,
     public DG::PanelObserver,
     public DG::ButtonItemObserver,
@@ -25,6 +27,16 @@ public:
 
     bool UpdateAddOn ();
 
+    static constexpr short ScriptShortcutSlotCount = 6;
+    void RunShortcutSlot (short slotIndex);   // 0-based, 0..ScriptShortcutSlotCount-1
+
+    void GetAvailableScripts (GS::Array<std::pair<GS::UniString, IO::Location>>& outScripts);
+    IO::Location GetShortcutSlot (short slotIndex) const;   // 0-based; empty location = unassigned
+    void SetShortcutSlot (short slotIndex, const IO::Location& location);   // empty location clears it
+    GS::UniString GetShortcutLabel (short slotIndex) const;   // 0-based; empty = using the default "Run Script Shortcut N" text
+    void SetShortcutLabel (short slotIndex, const GS::UniString& label);   // empty resets to the default text
+    void OpenShortcutsDialog ();
+
     static GSErrCode RegisterPaletteControlCallBack ();
 
 private:
@@ -33,6 +45,7 @@ private:
         IO::Location fileLocation;
         const GS::UniString repoRelLoc;
         const Config::Repository* repo = nullptr;
+        GS::UniString baseDisplayText;   // label as computed by AddScriptToPopUp, before any shortcut-slot suffix
 
         explicit PopUpItemData (
             const IO::Location& _fileLocation,
@@ -47,12 +60,15 @@ private:
     DG::IconButton openScriptButton;
     DG::IconButton addScriptButton;
     DG::IconButton delScriptButton;
+    DG::IconButton manageShortcutsButton;
 
     GS::Process process;
     GS::ThreadedExecutor executor;
     bool hasCustomScript = false;
     bool hasAddedScript = false;
     UvManager uvManager;
+    IO::Location scriptShortcutSlots[ScriptShortcutSlotCount];    // empty = unassigned
+    GS::UniString scriptShortcutLabels[ScriptShortcutSlotCount];  // empty = using the default menu text
 
     void SetMenuItemCheckedState (bool);
     void ExecuteScript (const PopUpItemData& popUpItemData);
@@ -69,6 +85,9 @@ private:
     bool IsSelectedScriptFromGitHub () const;
     void SetDeleteScriptButtonStatus ();
     void SetRunButtonIcon ();
+    void RefreshScriptListShortcutLabels ();   // appends "  [Shortcut N]" to scripts assigned to a slot
+    void ApplyShortcutMenuItemText (short slotIndex);   // pushes scriptShortcutLabels[slotIndex] to the real Archicad menu item
+    void ApplyAllShortcutMenuItemTexts ();
     bool IsProcessRunning () {
         return process.IsValid ();
     }


### PR DESCRIPTION
Lets users assign up to 6 scripts to slots via a new "Shortcuts" palette button opening a dedicated management dialog (one popup + editable menu label per slot). Each slot registers its own Add-On menu command (Run Script Shortcut 1-6) that Archicad's native Keyboard Shortcuts editor can bind a key to, running the assigned script directly via the existing ExecuteScript path. Assignments and custom labels persist through the palette's preferences blob (bumped to version 12) and are re-applied to the real menu items on Archicad startup via ACAPI_MenuItem_SetMenuItemText.

The main script dropdown also now shows "[Shortcut N]" next to any script that is assigned to a slot.