### PR TITLE
Fix CA1416 warning in ImageHelp; graceful fallback without a drawing backend

### DIFF
--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetElementPreviewImageComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetElementPreviewImageComponent.cs
@@ -105,9 +105,17 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 return;
             }
 
+            var bitmap = ImageHelp.FromBase64(base64);
+            if (bitmap == null)
+            {
+                AddRuntimeMessage(
+                    GH_RuntimeMessageLevel.Remark,
+                    "Bitmap decoding is not available on this platform; use the Base64 output.");
+            }
+
             da.SetData(
                 0,
-                ImageHelp.FromBase64(base64));
+                bitmap);
 
             da.SetData(
                 1,

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetRoomImageComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetRoomImageComponent.cs
@@ -125,9 +125,17 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 return;
             }
 
+            var bitmap = ImageHelp.FromBase64(base64);
+            if (bitmap == null)
+            {
+                AddRuntimeMessage(
+                    GH_RuntimeMessageLevel.Remark,
+                    "Bitmap decoding is not available on this platform; use the Base64 output.");
+            }
+
             da.SetData(
                 0,
-                ImageHelp.FromBase64(base64));
+                bitmap);
 
             da.SetData(
                 1,

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/FavoritesComponents/GetFavoritePreviewImageComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/FavoritesComponents/GetFavoritePreviewImageComponent.cs
@@ -97,9 +97,17 @@ namespace TapirGrasshopperPlugin.Components.FavoritesComponents
                 return;
             }
 
+            var bitmap = ImageHelp.FromBase64(base64);
+            if (bitmap == null)
+            {
+                AddRuntimeMessage(
+                    GH_RuntimeMessageLevel.Remark,
+                    "Bitmap decoding is not available on this platform; use the Base64 output.");
+            }
+
             da.SetData(
                 0,
-                ImageHelp.FromBase64(base64));
+                bitmap);
 
             da.SetData(
                 1,

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Helps/ImageHelp.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Helps/ImageHelp.cs
@@ -6,6 +6,15 @@ namespace TapirGrasshopperPlugin.Helps
 {
     public static class ImageHelp
     {
+        // System.Drawing.Common is flagged by the analyzer as Windows-only
+        // (CA1416), but Rhino ships a working System.Drawing implementation on
+        // every platform it supports (the project references the package with
+        // ExcludeAssets="runtime" and uses Rhino's copy at runtime) - the same
+        // mechanism that renders the component icons on macOS. The runtime
+        // fallback below covers any environment where the drawing backend is
+        // genuinely unavailable: the method returns null and callers keep
+        // working with the base64 output.
+#pragma warning disable CA1416
         public static Bitmap FromBase64(
             string base64)
         {
@@ -14,11 +23,23 @@ namespace TapirGrasshopperPlugin.Helps
                 return null;
             }
 
-            var bytes = System.Convert.FromBase64String(base64);
-            using (var stream = new MemoryStream(bytes))
+            try
             {
-                return new Bitmap(stream);
+                var bytes = System.Convert.FromBase64String(base64);
+                using (var stream = new MemoryStream(bytes))
+                {
+                    return new Bitmap(stream);
+                }
+            }
+            catch (Exception ex) when (
+                ex is PlatformNotSupportedException ||
+                ex is TypeInitializationException ||
+                ex is DllNotFoundException)
+            {
+                // No usable System.Drawing backend on this platform.
+                return null;
             }
         }
+#pragma warning restore CA1416
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #457: fixes the `CA1416` compilation warning in `ImageHelp.cs` and makes the preview-image components degrade gracefully on platforms without a `System.Drawing` backend.

```
warning CA1416: This call site is reachable on all platforms. 'Bitmap' is only supported on: 'windows'.
```

### Why suppress rather than gate to Windows

`System.Drawing.Common` is flagged as Windows-only by the platform analyzer on the plain `net7.0` target (Rhino 8 Mac), but Rhino ships a working `System.Drawing` implementation on every platform it supports — the same mechanism that renders all component icons on macOS (the project references the package with `ExcludeAssets="runtime"`, so Rhino's copy is used). Gating bitmap decoding to Windows would needlessly break Mac.

### Changes

- `ImageHelp.FromBase64`: local, documented `#pragma warning disable CA1416` plus a runtime fallback — `PlatformNotSupportedException` / `TypeInitializationException` / `DllNotFoundException` are caught and `null` is returned when the drawing backend is genuinely unavailable
- `GetElementPreviewImage`, `GetRoomImage`, `GetFavoritePreviewImage`: when the bitmap cannot be decoded, the component emits a remark ("use the Base64 output") instead of failing — the Base64 output always works

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors on all three target frameworks (net48, net7.0, net7.0-windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
