### PR TITLE
Add UpdateZones command

### DIFF
--- a/archicad-addon/Examples/update_zones.py
+++ b/archicad-addon/Examples/update_zones.py
@@ -1,0 +1,8 @@
+import aclib
+
+aclib.RunTapirCommand (
+    'UpdateZones', {
+        'keepStampPosition': True,
+        'undoTopTrim': False,
+        'undoBottomTrim': False
+    })

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -300,6 +300,10 @@ GSErrCode Initialize (void)
             elementCommands, "1.2.3",
             "Gets the boundaries of the given Zone (connected elements, neighbour zones, etc.)."
         );
+        err |= RegisterCommand<UpdateZonesCommand> (
+            elementCommands, "1.5.4",
+            "Updates all Zones (recalculates their geometry and updates their Zone Stamps)."
+        );
         err |= RegisterCommand<GetCollisionsCommand> (
             elementCommands, "1.2.2",
             "Detect collisions between the given two groups of elements."

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -302,7 +302,7 @@ GSErrCode Initialize (void)
         );
         err |= RegisterCommand<UpdateZonesCommand> (
             elementCommands, "1.5.4",
-            "Updates all Zones (recalculates their geometry and updates their Zone Stamps)."
+            "Updates all Zones (recalculates their geometry, updates their Zone Stamps and the connected elements)."
         );
         err |= RegisterCommand<GetCollisionsCommand> (
             elementCommands, "1.2.2",

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -14,6 +14,25 @@
 
 #include <algorithm>
 
+struct API_RoomUpdateParams {
+    bool keepStampPos;
+    bool undoTopTrim;
+    bool undoBotTrim;
+    bool filler_1[5];
+
+    API_RoomUpdateParams() : keepStampPos(true), undoTopTrim(false), undoBotTrim(false)
+    {}
+};
+
+typedef enum {
+    APIInternal_UpdateRoomsID    = 'UPDR',
+    APIInternal_PostCommandIdID  = 'ESPC',
+} API_InternalID;
+
+extern "C" {
+    GSErrCode ACAPI_Internal (API_InternalID code, void* par1 = nullptr, void* par2 = nullptr, void* par3 = nullptr);
+}
+
 static API_ElemFilterFlags ConvertFilterStringToFlag (const GS::UniString& filter)
 {
     if (filter == "IsEditable")
@@ -1927,6 +1946,67 @@ GS::ObjectState GetZoneBoundariesCommand::Execute (
 #else
     return CreateErrorResponse (APIERR_NOTSUPPORTED, "This command is only supported in ArchiCAD 28 or later.");
 #endif
+}
+
+UpdateZonesCommand::UpdateZonesCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String UpdateZonesCommand::GetName () const
+{
+    return "UpdateZones";
+}
+
+GS::Optional<GS::UniString> UpdateZonesCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "keepStampPosition": {
+                "type": "boolean",
+                "description": "Keep the position of the Zone Stamps. The default is true."
+            },
+            "undoTopTrim": {
+                "type": "boolean",
+                "description": "Undo the trimming of the top of the Zones. The default is false."
+            },
+            "undoBottomTrim": {
+                "type": "boolean",
+                "description": "Undo the trimming of the bottom of the Zones. The default is false."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+        ]
+    })";
+}
+
+GS::Optional<GS::UniString> UpdateZonesCommand::GetResponseSchema () const
+{
+    return R"({
+        "$ref": "#/ExecutionResult"
+    })";
+}
+
+GS::ObjectState UpdateZonesCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    API_RoomUpdateParams roomUpdateParams;
+    parameters.Get ("keepStampPosition", roomUpdateParams.keepStampPos);
+    parameters.Get ("undoTopTrim", roomUpdateParams.undoTopTrim);
+    parameters.Get ("undoBottomTrim", roomUpdateParams.undoBotTrim);
+
+    GSErrCode err = NoError;
+
+    ACAPI_CallUndoableCommand ("UpdateZonesCommand", [&]() {
+        err = ACAPI_Internal (APIInternal_UpdateRoomsID, &roomUpdateParams);
+
+        return err;
+    });
+
+    return err == NoError
+        ? CreateSuccessfulExecutionResult ()
+        : CreateFailedExecutionResult (err, "Failed to update zones.");
 }
 
 GetCollisionsCommand::GetCollisionsCommand () :

--- a/archicad-addon/Sources/ElementCommands.hpp
+++ b/archicad-addon/Sources/ElementCommands.hpp
@@ -88,6 +88,16 @@ public:
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
+class UpdateZonesCommand : public CommandBase
+{
+public:
+    UpdateZonesCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
 class GetCollisionsCommand : public CommandBase
 {
 public:

--- a/archicad-addon/Test/ExpectedOutputs/update_zones.py.output
+++ b/archicad-addon/Test/ExpectedOutputs/update_zones.py.output
@@ -1,0 +1,11 @@
+Command: UpdateZones
+Parameters:
+{
+    "keepStampPosition": true,
+    "undoTopTrim": false,
+    "undoBottomTrim": false
+}
+Response:
+{
+    "success": true
+}


### PR DESCRIPTION
## Summary

Adds a new `UpdateZones` command to the Element Commands group. It updates all Zones in the project (recalculates their geometry and updates their Zone Stamps) by calling the internal `APIInternal_UpdateRoomsID` command via `ACAPI_Internal`, wrapped in an undoable command scope.

The command accepts three optional boolean input parameters mirroring the `API_RoomUpdateParams` struct:
- `keepStampPosition` (default `true`) - keep the position of the Zone Stamps
- `undoTopTrim` (default `false`) - undo the trimming of the top of the Zones
- `undoBottomTrim` (default `false`) - undo the trimming of the bottom of the Zones

Response is the common `ExecutionResult`.

## Changes
- `ElementCommands.hpp/cpp`: new `UpdateZonesCommand` + declaration of `ACAPI_Internal`, `API_RoomUpdateParams` and `API_InternalID`
- `AddOnMain.cpp`: command registered with version 1.5.4
- `Examples/update_zones.py` + `Test/ExpectedOutputs/update_zones.py.output`: example script and golden test output

## Test plan
- [x] Build the Add-On (AC25-AC29) via the CI build check
- [x] Run `Test/test_examples.py` against a running Archicad with the built Add-On (docs regeneration via `GenerateDocumentation` happens with the release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)