### PR TITLE
Expose Drawing title settings via Get/SetDetailsOfElements

### DIFF
--- a/archicad-addon/Examples/test_drawing_title.py
+++ b/archicad-addon/Examples/test_drawing_title.py
@@ -1,0 +1,190 @@
+import json
+import aclib
+
+# Never runs against an arbitrary layout it happens to find - this script can be pointed at a
+# real, in-use project, so it only ever touches a layout with this exact name, and refuses to run
+# otherwise. Create a layout with this name and place any drawing on it before running.
+TEST_LAYOUT_NAME = 'TAPIR_TEST_DRAWING_TITLE'
+
+
+def find_layout_by_name(item, name):
+    navItem = item.get('navigatorItem', item)
+    if navItem.get('type') == 'LayoutItem' and navItem.get('name') == name:
+        return navItem['navigatorItemId']
+    for c in navItem.get('children', []):
+        found = find_layout_by_name(c, name)
+        if found:
+            return found
+    return None
+
+
+print('Looking for the "{}" test layout...'.format(TEST_LAYOUT_NAME))
+lb = aclib.RunCommand('API.GetNavigatorItemTree', {'navigatorTreeId': {'type': 'LayoutBook'}})
+layoutNavId = find_layout_by_name(lb['navigatorTree']['rootItem'], TEST_LAYOUT_NAME)
+if layoutNavId is None:
+    print('No layout named "{}" found - create one (with any drawing placed on it) and rerun.'.format(TEST_LAYOUT_NAME))
+    raise SystemExit
+
+aclib.RunTapirCommand('ChangeWindow', {'windowType': 'Layout', 'navigatorItemId': layoutNavId}, debug=False)
+
+print('Looking for a Drawing element on the test layout...')
+resp = aclib.RunTapirCommand('GetElementsByType', {'elementType': 'Drawing'}, debug=False)
+drawings = resp['elements'] if resp else []
+print('Found {} drawing(s).'.format(len(drawings)))
+
+if not drawings:
+    print('No drawings on the test layout - place one and rerun.')
+    raise SystemExit
+
+drawingId = drawings[0]['elementId']
+print('Using drawing: {}'.format(drawingId))
+
+# --- Part 1: name/numbering fields (round trip on the test drawing, restored afterwards) ---
+
+beforeResp = aclib.RunTapirCommand('GetDetailsOfElements', {'elements': [{'elementId': drawingId}]}, debug=False)
+beforeDetails = beforeResp['detailsOfElements'][0]['details']
+print('Before: nameType={}, customName={}, numberingType={}, customNumber={}, isInNumbering={}'.format(
+    beforeDetails.get('nameType'), beforeDetails.get('customName'),
+    beforeDetails.get('numberingType'), beforeDetails.get('customNumber'),
+    beforeDetails.get('isInNumbering')))
+
+setResp = aclib.RunTapirCommand('SetDetailsOfElements', {
+    'elementsWithDetails': [{
+        'elementId': drawingId,
+        'details': {
+            'typeSpecificDetails': {
+                'nameType': 'CustomName',
+                'customName': 'SALE PLAN TEST',
+                'numberingType': 'CustomNumber',
+                'customNumber': '99',
+                'isInNumbering': False
+            }
+        }
+    }]
+}, debug=False)
+print('SetDetailsOfElements response: {}'.format(json.dumps(setResp)))
+
+afterResp = aclib.RunTapirCommand('GetDetailsOfElements', {'elements': [{'elementId': drawingId}]}, debug=False)
+afterDetails = afterResp['detailsOfElements'][0]['details']
+print('After: nameType={}, customName={}, numberingType={}, customNumber={}, isInNumbering={}'.format(
+    afterDetails.get('nameType'), afterDetails.get('customName'),
+    afterDetails.get('numberingType'), afterDetails.get('customNumber'),
+    afterDetails.get('isInNumbering')))
+
+namingOk = (afterDetails.get('nameType') == 'CustomName' and afterDetails.get('customName') == 'SALE PLAN TEST'
+            and afterDetails.get('numberingType') == 'CustomNumber' and afterDetails.get('customNumber') == '99'
+            and afterDetails.get('isInNumbering') is False)
+
+print('Restoring original name/numbering fields...')
+restoreDetails = {
+    'nameType': beforeDetails.get('nameType'),
+    'numberingType': beforeDetails.get('numberingType'),
+    'isInNumbering': beforeDetails.get('isInNumbering'),
+}
+if beforeDetails.get('customName') is not None:
+    restoreDetails['customName'] = beforeDetails['customName']
+if beforeDetails.get('customNumber') is not None:
+    restoreDetails['customNumber'] = beforeDetails['customNumber']
+aclib.RunTapirCommand('SetDetailsOfElements', {
+    'elementsWithDetails': [{'elementId': drawingId, 'details': {'typeSpecificDetails': restoreDetails}}]
+}, debug=False)
+
+print('\n{}'.format('NAME/NUMBERING TEST PASSED' if namingOk else 'NAME/NUMBERING TEST FAILED'))
+
+# --- Part 2: title object (titleLibraryPartIndex / titleElementId / its own GDL parameters) ---
+# The drawing title is a separate placed GDL object (API_DrawingTitle) - a negative/missing
+# titleLibraryPartIndex means no title object exists yet. If any OTHER drawing in the project
+# already has one, copy its library part index and GDL parameters onto our test drawing to
+# verify both the read side and the write side of that mechanism. The test drawing's own
+# previous title state (if any) is restored afterwards.
+
+print('\nLooking for a drawing (other than the test one) that already has a title object...')
+allDrawingsResp = aclib.RunTapirCommand('GetElementsByType', {'elementType': 'Drawing'}, debug=False)
+beforeTitleLibInd = beforeDetails.get('titleLibraryPartIndex')
+
+referenceTitleLibInd = None
+referenceTitleElementId = None
+# Search across all layouts, since a suitable reference title is unlikely to be on the test
+# layout itself.
+lbTree = aclib.RunCommand('API.GetNavigatorItemTree', {'navigatorTreeId': {'type': 'LayoutBook'}})
+
+
+def collect_layouts(item, result):
+    navItem = item.get('navigatorItem', item)
+    if navItem.get('type') == 'LayoutItem':
+        result.append(navItem)
+    for c in navItem.get('children', []):
+        collect_layouts(c, result)
+    return result
+
+
+for layoutItem in collect_layouts(lbTree['navigatorTree']['rootItem'], []):
+    if layoutItem['name'] == TEST_LAYOUT_NAME:
+        continue
+    aclib.RunTapirCommand('ChangeWindow', {'windowType': 'Layout', 'navigatorItemId': layoutItem['navigatorItemId']},
+                           debug=False)
+    otherDrawings = aclib.RunTapirCommand('GetElementsByType', {'elementType': 'Drawing'}, debug=False).get('elements', [])
+    if not otherDrawings:
+        continue
+    otherDetails = aclib.RunTapirCommand('GetDetailsOfElements', {'elements': otherDrawings}, debug=False)['detailsOfElements']
+    found = next((d['details'] for d in otherDetails if d.get('details', {}).get('titleElementId')), None)
+    if found:
+        referenceTitleLibInd = found['titleLibraryPartIndex']
+        referenceTitleElementId = found['titleElementId']
+        break
+
+aclib.RunTapirCommand('ChangeWindow', {'windowType': 'Layout', 'navigatorItemId': layoutNavId}, debug=False)
+
+if referenceTitleElementId is None:
+    print('No other drawing with an existing title object found in this project - skipping title object test.')
+else:
+    print('Reference title: libraryPartIndex={}, elementId={}'.format(referenceTitleLibInd, referenceTitleElementId))
+
+    refGdlResp = aclib.RunTapirCommand('GetGDLParametersOfElements',
+                                        {'elements': [{'elementId': referenceTitleElementId}]}, debug=False)
+    refParams = refGdlResp['gdlParametersOfElements'][0].get('parameters', [])
+    print('Reference title has {} GDL parameter(s).'.format(len(refParams)))
+
+    # AC_BackReference* is an internal link specific to the instance it came from (which drawing
+    # it annotates) and must not be copied; array-valued parameters aren't accepted by
+    # SetGDLParametersOfElements (it expects a single scalar value per parameter).
+    copyableParams = [
+        {'name': p['name'], 'value': p['value']} for p in refParams
+        if 'value' in p and not isinstance(p['value'], list) and not p['name'].startswith('AC_BackReference')
+    ]
+    print('{} parameter(s) are copyable.'.format(len(copyableParams)))
+
+    setTitleResp = aclib.RunTapirCommand('SetDetailsOfElements', {
+        'elementsWithDetails': [{
+            'elementId': drawingId,
+            'details': {'typeSpecificDetails': {'titleLibraryPartIndex': referenceTitleLibInd}}
+        }]
+    }, debug=False)
+    print('SetDetailsOfElements (titleLibraryPartIndex) response: {}'.format(json.dumps(setTitleResp)))
+
+    afterTitleResp = aclib.RunTapirCommand('GetDetailsOfElements', {'elements': [{'elementId': drawingId}]}, debug=False)
+    afterTitleDetails = afterTitleResp['detailsOfElements'][0]['details']
+    newTitleElementId = afterTitleDetails.get('titleElementId')
+    print('Test drawing now has titleElementId: {}'.format(newTitleElementId))
+
+    titleObjectCreated = newTitleElementId is not None
+    gdlCopyOk = False
+    if titleObjectCreated and copyableParams:
+        setGdlResp = aclib.RunTapirCommand('SetGDLParametersOfElements', {
+            'elementsWithGDLParameters': [{
+                'elementId': newTitleElementId,
+                'gdlParameters': copyableParams
+            }]
+        }, debug=False)
+        gdlCopyOk = (setGdlResp.get('executionResults') or [{}])[0].get('success', False)
+        print('SetGDLParametersOfElements on new title response: {}'.format(json.dumps(setGdlResp)))
+
+    print('Restoring test drawing title library part index...')
+    aclib.RunTapirCommand('SetDetailsOfElements', {
+        'elementsWithDetails': [{
+            'elementId': drawingId,
+            'details': {'typeSpecificDetails': {'titleLibraryPartIndex': beforeTitleLibInd if beforeTitleLibInd is not None else -1}}
+        }]
+    }, debug=False)
+
+    print('\n{}'.format('TITLE OBJECT TEST PASSED' if titleObjectCreated and gdlCopyOk else 'TITLE OBJECT TEST FAILED'))

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -62,6 +62,44 @@ static API_ElemFilterFlags ConvertFilterStringToFlag (const GS::UniString& filte
     return APIFilt_None;
 }
 
+static GS::UniString DrawingNameTypeToString (API_NameTypeValues nameType)
+{
+    switch (nameType) {
+        case APIName_ViewIdAndName:  return "ViewIdAndName";
+        case APIName_CustomName:     return "CustomName";
+        default:
+        case APIName_ViewOrSrcFileName: return "ViewOrSourceFileName";
+    }
+}
+
+static API_NameTypeValues DrawingNameTypeFromString (const GS::UniString& str)
+{
+    if (str == "ViewIdAndName")
+        return APIName_ViewIdAndName;
+    if (str == "CustomName")
+        return APIName_CustomName;
+    return APIName_ViewOrSrcFileName;
+}
+
+static GS::UniString DrawingNumberingTypeToString (API_NumberingTypeValues numberingType)
+{
+    switch (numberingType) {
+        case APINumbering_ByViewId:   return "ByViewId";
+        case APINumbering_CustomNum:  return "CustomNumber";
+        default:
+        case APINumbering_ByLayout:   return "ByLayout";
+    }
+}
+
+static API_NumberingTypeValues DrawingNumberingTypeFromString (const GS::UniString& str)
+{
+    if (str == "ByViewId")
+        return APINumbering_ByViewId;
+    if (str == "CustomNumber")
+        return APINumbering_CustomNum;
+    return APINumbering_ByLayout;
+}
+
 static API_Guid GetParentElemOfSectElem (const API_Guid& elemGuid)
 {
     API_Element element = {};
@@ -876,6 +914,27 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                 if (elem.drawing.isCutWithFrame) {
                     AddPolygonFromMemoCoords (elem.header.guid, typeSpecificDetails, "clipPolygon");
                 }
+                typeSpecificDetails.Add ("nameType",      DrawingNameTypeToString (elem.drawing.nameType));
+                if (elem.drawing.nameType == APIName_CustomName) {
+                    typeSpecificDetails.Add ("customName", GS::UniString (elem.drawing.name));
+                }
+                typeSpecificDetails.Add ("numberingType",  DrawingNumberingTypeToString (elem.drawing.numberingType));
+                if (elem.drawing.numberingType == APINumbering_CustomNum) {
+                    typeSpecificDetails.Add ("customNumber", GS::UniString (elem.drawing.customNumber));
+                }
+                typeSpecificDetails.Add ("isInNumbering", elem.drawing.isInNumbering);
+                // Library part index of the title (API_DrawingTitle::libInd) - a negative/invalid
+                // index here means no title object is instantiated at all (nothing to show); setting
+                // it to a valid index (e.g. copied from another drawing) is what makes Archicad
+                // create the title's own placed element.
+                typeSpecificDetails.Add ("titleLibraryPartIndex", elem.drawing.title.libInd);
+                if (elem.drawing.title.guid != APINULLGuid) {
+                    // The drawing title is itself a placed, GDL-parameterized library part
+                    // element (API_DrawingTitle::guid, "object based elements from Archicad 10")
+                    // - its own settings (font/pen/size aside) are reachable like any other
+                    // element via this id, e.g. with Get/SetGDLParametersOfElements.
+                    typeSpecificDetails.Add ("titleElementId", CreateGuidObjectState (elem.drawing.title.guid));
+                }
             } break;
 
             case API_MorphID:
@@ -1303,6 +1362,28 @@ GS::ObjectState SetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                         if (modelOffsetState != nullptr) {
                             elem.drawing.modelOffset = Get2DCoordinateFromObjectState (*modelOffsetState);
                             ACAPI_ELEMENT_MASK_SET (mask, API_DrawingType, modelOffset);
+                        }
+                        GS::UniString nameTypeStr;
+                        if (typeSpecificDetails->Get ("nameType", nameTypeStr)) {
+                            elem.drawing.nameType = DrawingNameTypeFromString (nameTypeStr);
+                            ACAPI_ELEMENT_MASK_SET (mask, API_DrawingType, nameType);
+                        }
+                        if (SetCharProperty (typeSpecificDetails, "customName", elem.drawing.name)) {
+                            ACAPI_ELEMENT_MASK_SET (mask, API_DrawingType, name);
+                        }
+                        GS::UniString numberingTypeStr;
+                        if (typeSpecificDetails->Get ("numberingType", numberingTypeStr)) {
+                            elem.drawing.numberingType = DrawingNumberingTypeFromString (numberingTypeStr);
+                            ACAPI_ELEMENT_MASK_SET (mask, API_DrawingType, numberingType);
+                        }
+                        if (SetCharProperty (typeSpecificDetails, "customNumber", elem.drawing.customNumber)) {
+                            ACAPI_ELEMENT_MASK_SET (mask, API_DrawingType, customNumber);
+                        }
+                        if (typeSpecificDetails->Get ("isInNumbering", elem.drawing.isInNumbering)) {
+                            ACAPI_ELEMENT_MASK_SET (mask, API_DrawingType, isInNumbering);
+                        }
+                        if (typeSpecificDetails->Get ("titleLibraryPartIndex", elem.drawing.title.libInd)) {
+                            ACAPI_ELEMENT_MASK_SET (mask, API_DrawingType, title.libInd);
                         }
                     } break;
                     default:

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -4846,6 +4846,36 @@
                     "$ref": "#/Coordinate2D"
                 },
                 "minItems": 3
+            },
+            "nameType": {
+                "type": "string",
+                "enum": ["ViewOrSourceFileName", "ViewIdAndName", "CustomName"],
+                "description": "How the drawing's title name is assembled (Identification tabpage of the Drawing Settings dialog)."
+            },
+            "customName": {
+                "type": "string",
+                "description": "The drawing's custom title name. Present only when nameType is CustomName."
+            },
+            "numberingType": {
+                "type": "string",
+                "enum": ["ByLayout", "ByViewId", "CustomNumber"],
+                "description": "How the drawing's title ID is assigned (Identification tabpage of the Drawing Settings dialog)."
+            },
+            "customNumber": {
+                "type": "string",
+                "description": "The drawing's custom title ID. Present only when numberingType is CustomNumber."
+            },
+            "isInNumbering": {
+                "type": "boolean",
+                "description": "Whether the drawing is included in the automatic drawing numbering sequence."
+            },
+            "titleLibraryPartIndex": {
+                "type": "number",
+                "description": "Library part index of the drawing title (API_DrawingTitle::libInd). A negative/invalid index means no title object is instantiated; setting it to a valid index (e.g. copied from another drawing) makes Archicad create the title's own placed element."
+            },
+            "titleElementId": {
+                "$ref": "#/ElementId",
+                "description": "Id of the drawing title, itself a placed GDL object element (font/pen/size aside, its own settings are reachable like any other element, e.g. with GetGDLParametersOfElements/SetGDLParametersOfElements). Absent if the drawing has no title object."
             }
         },
         "additionalProperties": false,
@@ -4856,7 +4886,11 @@
             "drawingScale",
             "modelOffset",
             "isCutWithFrame",
-            "bounds"
+            "bounds",
+            "nameType",
+            "numberingType",
+            "isInNumbering",
+            "titleLibraryPartIndex"
         ]
     },
     "LabelDetails": {
@@ -5430,6 +5464,32 @@
                     "$ref": "#/Coordinate2D"
                 },
                 "minItems": 3
+            },
+            "nameType": {
+                "type": "string",
+                "enum": ["ViewOrSourceFileName", "ViewIdAndName", "CustomName"],
+                "description": "How the drawing's title name is assembled (Identification tabpage of the Drawing Settings dialog)."
+            },
+            "customName": {
+                "type": "string",
+                "description": "The drawing's custom title name. Only used when nameType is CustomName."
+            },
+            "numberingType": {
+                "type": "string",
+                "enum": ["ByLayout", "ByViewId", "CustomNumber"],
+                "description": "How the drawing's title ID is assigned (Identification tabpage of the Drawing Settings dialog)."
+            },
+            "customNumber": {
+                "type": "string",
+                "description": "The drawing's custom title ID. Only used when numberingType is CustomNumber."
+            },
+            "isInNumbering": {
+                "type": "boolean",
+                "description": "Whether the drawing is included in the automatic drawing numbering sequence."
+            },
+            "titleLibraryPartIndex": {
+                "type": "number",
+                "description": "Library part index of the drawing title (API_DrawingTitle::libInd). A negative/invalid index means no title object is instantiated; setting it to a valid index (e.g. copied from another drawing) makes Archicad create the title's own placed element."
             }
         },
         "additionalProperties": false


### PR DESCRIPTION
## Context

Drawings placed on a layout have their own "title" — a name, an ID, and (since Archicad 10) a real placed GDL object showing that information. None of this was previously reachable through Tapir: `GetDetailsOfElements`/`SetDetailsOfElements` only exposed geometry-level fields for a Drawing (position, scale, clip polygon), with no way to read or replicate how a drawing's title is configured. This came up while automating batch generation of sale-plan layouts, where every generated drawing needs to match a reference drawing's title setup.

## What's added

- **`nameType` / `customName`** — how the title's displayed name is assembled (from the source view/file, from the view's ID+name, or a custom string)
- **`numberingType` / `customNumber`** — how the title's ID is assigned (from the layout, from the source view, or a custom string)
- **`isInNumbering`** — whether the drawing participates in the project's automatic drawing numbering sequence
- **`titleLibraryPartIndex`** (read/write) — the title object's own library part index
- **`titleElementId`** (read-only) — the id of the title object itself, once instantiated

All on the existing `DrawingDetails`/`DrawingSettings` schemas — no new command, no version bump.

## Implementation notes

- The title is a genuine placed GDL library part element (`API_DrawingTitle`, "object based elements from Archicad 10"), not just plain struct fields — its own guid is exposed as `titleElementId`, so its parameters (beyond the basic font/pen/size fields already on `API_DrawingTitle`) are reachable through the existing `GetGDLParametersOfElements`/`SetGDLParametersOfElements` commands, the same way as any other element.
- A negative/invalid `titleLibraryPartIndex` means no title object exists at all for that drawing. Writing a valid index (e.g. copied from another drawing that already has a title) is what makes Archicad instantiate the title's placed element — this is the mechanism a script needs to use before it can read/write that title's own GDL parameters.

## Test plan

- [x] `test_drawing_title.py` (included) — round-trips `nameType`/`customName`/`numberingType`/`customNumber`/`isInNumbering` on a drawing and restores the original values; separately, locates another drawing in the project that already has a title, copies its `titleLibraryPartIndex` and GDL parameters onto the test drawing, and verifies the title object gets created and populated
- [x] Only ever touches a layout named `TAPIR_TEST_DRAWING_TITLE`, restores every value it changes — safe to run against a real, in-use project
- [x] Verified live end-to-end on a real project (test layout created, both checks passed, layout deleted afterward)