### PR TITLE
feat: implement ShowAlert command with various dialog types

### DIFF
--- a/archicad-addon/Examples/show_alert.py
+++ b/archicad-addon/Examples/show_alert.py
@@ -1,0 +1,39 @@
+import aclib
+
+# Test: ShowAlert
+# Shows blocking dialogs in Archicad and evaluates the response.
+
+# 1) Pure info dialog (OK only)
+result = aclib.RunTapirCommand('ShowAlert', {
+    'alertType': 'information',
+    'title': 'DeftTools Info',
+    'message': 'Hello! I am a info!.',
+    'button1': 'OK'
+})
+print('Clicked:', result['clickedButton'])  # always 1
+
+# 2) Confirmation dialog (OK / Cancel)
+result = aclib.RunTapirCommand('ShowAlert', {
+    'alertType': 'warning',
+    'title': 'Attention! Something is happening!',
+    'message': 'Some elements will be modified.',
+    'subMessage': 'This operation cannot be undone.',
+    'button1': 'Delete',
+    'button2': 'Cancel'
+})
+if result['clickedButton'] == 1:
+    print('User confirmed --> doing some action on elements...')
+else:
+    print('User cancelled.')
+
+# 3) Three-button dialog
+result = aclib.RunTapirCommand('ShowAlert', {
+    'alertType': 'error',
+    'title': 'Unsaved Changes',
+    'message': 'The project has unsaved changes.',
+    'button1': 'Save',
+    'button2': 'Don\'t Save',
+    'button3': 'Cancel'
+})
+print('Clicked:', result['clickedButton'])
+# 1 = Save, 2 = Don't Save, 3 = Cancel

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -185,6 +185,11 @@ GSErrCode Initialize (void)
             applicationCommands, "1.3.1",
             "Changes the current (active) window to the given window."
         );
+        err |= RegisterCommand<ShowAlertCommand>(
+            applicationCommands,"1.5.6",
+            "Display a dialog with up to three buttons."
+        )
+
         AddCommandGroup (applicationCommands);
     }
 

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -188,7 +188,7 @@ GSErrCode Initialize (void)
         err |= RegisterCommand<ShowAlertCommand>(
             applicationCommands,"1.5.6",
             "Display a dialog with up to three buttons."
-        )
+        );
 
         AddCommandGroup (applicationCommands);
     }

--- a/archicad-addon/Sources/ApplicationCommands.cpp
+++ b/archicad-addon/Sources/ApplicationCommands.cpp
@@ -3,6 +3,7 @@
 #include "FileSystem.hpp"
 #include "AddOnVersion.hpp"
 #include "MigrationHelper.hpp"
+#include "DGModule.hpp"
 
 GetAddOnVersionCommand::GetAddOnVersionCommand () :
     CommandBase (CommonSchema::NotUsed)

--- a/archicad-addon/Sources/ApplicationCommands.cpp
+++ b/archicad-addon/Sources/ApplicationCommands.cpp
@@ -360,3 +360,92 @@ GS::ObjectState ChangeWindowCommand::Execute (const GS::ObjectState& parameters,
         : CreateErrorResponse (err, "Failed to change the window!");
 }
 
+
+ShowAlertCommand::ShowAlertCommand () :
+    CommandBase (CommonSchema::NotUsed)
+{}
+
+GS::String ShowAlertCommand::GetName () const
+{
+    return "ShowAlert";
+}
+
+GS::Optional<GS::UniString> ShowAlertCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "alertType": {
+                "type": "string",
+                "enum": ["information", "warning", "error"],
+                "description": "The type of the alert dialog."
+            },
+            "title": {
+                "type": "string",
+                "description": "The title of the alert dialog."
+            },
+            "message": {
+                "type": "string",
+                "description": "The main message text."
+            },
+            "subMessage": {
+                "type": "string",
+                "description": "Optional smaller sub-message text below the main message."
+            },
+            "button1": {
+                "type": "string",
+                "description": "Label for the first (default) button."
+            },
+            "button2": {
+                "type": "string",
+                "description": "Label for the second button (e.g. Cancel)."
+            },
+            "button3": {
+                "type": "string",
+                "description": "Label for the optional third button."
+            }
+        },
+        "additionalProperties": false,
+        "required": ["alertType", "title", "message", "button1"]
+    })";
+}
+
+GS::Optional<GS::UniString> ShowAlertCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "clickedButton": {
+                "type": "integer",
+                "description": "Index of the button the user clicked: 1 = button1, 2 = button2, 3 = button3."
+            }
+        },
+        "additionalProperties": false,
+        "required": ["clickedButton"]
+    })";
+}
+
+GS::ObjectState ShowAlertCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::UniString alertTypeStr;
+    parameters.Get ("alertType", alertTypeStr);
+
+    short alertType = DG_INFORMATION;
+    if (alertTypeStr == "warning") {
+        alertType = DG_WARNING;
+    } else if (alertTypeStr == "error") {
+        alertType = DG_ERROR;
+    }
+
+    GS::UniString title, message, subMessage, button1, button2, button3;
+    parameters.Get ("title", title);
+    parameters.Get ("message", message);
+    parameters.Get ("subMessage", subMessage);
+    parameters.Get ("button1", button1);
+    parameters.Get ("button2", button2);
+    parameters.Get ("button3", button3);
+
+    short clicked = DGAlert (alertType, title, message, subMessage, button1, button2, button3);
+
+    return GS::ObjectState ("clickedButton", static_cast<Int32> (clicked));
+}

--- a/archicad-addon/Sources/ApplicationCommands.hpp
+++ b/archicad-addon/Sources/ApplicationCommands.hpp
@@ -48,3 +48,12 @@ public:
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
+class ShowAlertCommand : public CommandBase
+{
+public:
+    ShowAlertCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};


### PR DESCRIPTION
Hello!
I would like to introduce a new command to tapirs collection:
ShowAlert. It utilizes "DG_Alert". The user can display a dialog, with up to 3 buttons (hard-limited in DG_Alert). The alertType can be information, warning, error. It could be very useful for confirmations dialog in custom workflows for example.

Hope it is a good contribution!

Tested with AC 29. It should also work with AC27.
Greetings,
FBumaye