### PR TITLE
GetConnectedElements: make connectedElementType optional

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -304,7 +304,7 @@ GSErrCode Initialize (void)
         );
         err |= RegisterCommand<GetConnectedElementsCommand> (
             elementCommands, "1.1.4",
-            "Gets connected elements of the given elements."
+            "Gets connected elements of the given elements. The connected element type filter is optional; if omitted, connected elements of all types are returned."
         );
         err |= RegisterCommand<GetZoneBoundariesCommand> (
             elementCommands, "1.2.3",

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -1859,13 +1859,13 @@ GS::Optional<GS::UniString> GetConnectedElementsCommand::GetInputParametersSchem
                 "$ref": "#/Elements"
             },
             "connectedElementType": {
-                "$ref": "#/ElementType"
+                "$ref": "#/ElementType",
+                "description": "Optional filter for the type of the connected elements. If omitted, connected elements of all types are returned."
             }
         },
         "additionalProperties": false,
         "required": [
-            "elements",
-            "connectedElementType"
+            "elements"
         ]
     })";
 }

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetConnectedElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetConnectedElementsComponent.cs
@@ -27,7 +27,9 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
             InText(
                 "ConnectedElementType",
-                "Type of connected elements.");
+                "Type of connected elements. Optional; if not set, connected elements of all types are returned.");
+
+            SetOptionality(1);
         }
 
         protected override void AddOutputs()
@@ -58,12 +60,9 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 return;
             }
 
-            if (!da.TryGet(
-                    1,
-                    out string elementType))
-            {
-                return;
-            }
+            da.TryGet(
+                1,
+                out string elementType);
 
             if (!TryGetConvertedCadValues(
                     CommandName,

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Types/Element/ConnectedElements.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Types/Element/ConnectedElements.cs
@@ -8,7 +8,7 @@ namespace TapirGrasshopperPlugin.Types.Element
         [JsonProperty("elements")]
         public List<ElementGuidWrapper> Elements;
 
-        [JsonProperty("connectedElementType")]
+        [JsonProperty("connectedElementType", NullValueHandling = NullValueHandling.Ignore)]
         public string ConnectedElementType;
     }
 


### PR DESCRIPTION
## Summary

Makes the `connectedElementType` input parameter of the `GetConnectedElements` command **optional**.

The command's `Execute` already handled the parameter being absent — `if (parameters.Get ("connectedElementType", …))` with an `API_ZombieElemID` fallback, the same "all element types" convention `GetElements` uses — but the input schema declared it `required`, and the Grasshopper component refused to run without it. Only the declarations were over-strict; no behavior change for callers that pass the type.

### Changes

- **Input schema** (`ElementCommands.cpp`): `connectedElementType` removed from `required` and documented as "Optional filter for the type of the connected elements. If omitted, connected elements of all types are returned."
- **Grasshopper component**: the `ConnectedElementType` input is now optional (`SetOptionality`); when unset, the field is omitted from the request entirely (`NullValueHandling.Ignore` on the parameter DTO, so no `null` is sent against the `$ref ElementType` string schema)
- **Registered description** mentions the optional filter

## Test plan

- [x] AC29 add-on build clean
- [x] Grasshopper net48 build clean
- [ ] Live check: call `GetConnectedElements` without `connectedElementType` and verify connected elements of all types are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)
