### PR TITLE
Fix compilation for Archicad 30

### DIFF
--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -2221,7 +2221,11 @@ GS::ObjectState GetCollisionsCommand::Execute (const GS::ObjectState& parameters
             "elementId1", CreateGuidObjectState (collisionElement.first.collidedElemGuid),
             "elementId2", CreateGuidObjectState (collisionElement.second.collidedElemGuid),
             "hasBodyCollision", collisionElement.first.hasBodyCollision,
+#ifdef ServerMainVers_3000
+            "hasClearanceCollision", collisionElement.second.hasClearanceCollision));
+#else
             "hasClearenceCollision", collisionElement.second.hasClearenceCollision));
+#endif
     }
 
     return response;

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -275,6 +275,9 @@ GS::ObjectState CreateProjectInfoFieldsCommand::Execute (const GS::ObjectState& 
             GS::UniString projectInfoValue;
             projectInfoField.Get ("projectInfoValue", projectInfoValue);
 
+#ifdef ServerMainVers_3000
+            fieldsAdder (CreateErrorResponse (APIERR_NOTSUPPORTED, "TODO: this function was not migrated to AC30 yet. Failed to create project information field."));
+#else
             GS::Guid guid;
             guid.Generate ();
             API_Guid dbKey = GSGuid2APIGuid (guid);
@@ -299,6 +302,7 @@ GS::ObjectState CreateProjectInfoFieldsCommand::Execute (const GS::ObjectState& 
             createdField.Add ("projectInfoName", projectInfoName);
             createdField.Add ("projectInfoValue", projectInfoValue);
             fieldsAdder (createdField);
+#endif
         }
 
         return NoError;
@@ -365,6 +369,10 @@ GS::ObjectState DeleteProjectInfoFieldsCommand::Execute (const GS::ObjectState& 
 
     ACAPI_CallUndoableCommand ("DeleteProjectInfoFields", [&]() -> GSErrCode {
         for (const GS::UniString& projectInfoId : projectInfoIds) {
+#ifdef ServerMainVers_3000
+            (void) projectInfoId; // suppress unused variable warning
+            executionResults (CreateFailedExecutionResult (APIERR_NOTSUPPORTED, "TODO: this function was not migrated to AC30 yet. Failed to delete project info field."));
+#else
             if (!projectInfoId.BeginsWith ("autotext-")) {
                 executionResults (CreateFailedExecutionResult (APIERR_BADPARS,
                     "Only custom project info fields (ids starting with 'autotext-') can be deleted."));
@@ -377,6 +385,7 @@ GS::ObjectState DeleteProjectInfoFieldsCommand::Execute (const GS::ObjectState& 
             } else {
                 executionResults (CreateSuccessfulExecutionResult ());
             }
+#endif
         }
         return NoError;
     });

--- a/archicad-addon/Sources/ScriptUIPalette.cpp
+++ b/archicad-addon/Sources/ScriptUIPalette.cpp
@@ -88,7 +88,11 @@ static GS::UniString InjectAutoHeightScript (const GS::UniString& htmlContent)
         "})();</script>";
 
     // Find "</body>" case-insensitively; fall back to appending at the end when absent/malformed.
+#ifdef ServerMainVers_3000
+    const GS::UniString lowerContent = htmlContent.GetLowerCased ();
+#else
     const GS::UniString lowerContent = htmlContent.ToLowerCase ();
+#endif
     if (!lowerContent.Contains (GS::UniString ("</body>"))) {
         return htmlContent + observerScript;
     }

--- a/archicad-addon/Sources/TapirPalette.cpp
+++ b/archicad-addon/Sources/TapirPalette.cpp
@@ -691,7 +691,11 @@ void TapirPalette::ExecuteScript (const PopUpItemData& popUpItemData)
                 return;
             }
 
+#ifdef ServerMainVers_3000
+            const GS::UniString lowerContent = stderrContent.GetLowerCased ();
+#else
             const GS::UniString lowerContent = stderrContent.ToLowerCase ();
+#endif
 
             if (lowerContent.Contains ("error:") || lowerContent.Contains ("failed") || lowerContent.Contains ("traceback (most recent call last)")) {
                 GS::MessageLoopExecutor ().Execute (new OutputUpdateTask (DG_ERROR, stderrContent));
@@ -865,7 +869,11 @@ void TapirPalette::AddScriptsFromRepositories ()
                 IO::Name fileName;
                 if (relLoc.GetLength () != (1 + repoFolderRelativeLoc.GetLength ()) ||
                     fileLoc.GetLastLocalName (&fileName) != NoError ||
+#ifdef ServerMainVers_3000
+                    fileName.GetExtension ().GetLowerCased () != "py") {
+#else
                     fileName.GetExtension ().ToLowerCase () != "py") {
+#endif
                     continue;
                 }
             }


### PR DESCRIPTION
## Summary

Compatibility fixes that make the add-on compile against the **Archicad 30 DevKit** (`ServerMainVers_3000` guards; behavior on AC29 and older is unchanged).

### Changes

- **`GetCollisions`**: AC30 fixed the `hasClearenceCollision` → `hasClearanceCollision` typo in `API_CollisionElem`. The command follows the corrected field spelling on AC30 (note: the JSON response key changes accordingly on AC30 — `hasClearanceCollision` instead of `hasClearenceCollision`).
- **`CreateProjectInfoFields` / `DeleteProjectInfoFields`**: the custom-autotext APIs these commands use were not migrated to AC30 yet; on AC30 they report a per-item `APIERR_NOTSUPPORTED` with a TODO note until the migration is done.
- **`GS::UniString::ToLowerCase` → `GetLowerCased`**: the AC30 GSRoot renamed the method; three call sites updated (`ScriptUIPalette`, `TapirPalette` ×2).

## Test plan

- [x] **AC30 build clean** — configured `Build/AC30` from scratch against the AC30 DevKit and produced `TapirAddOn_AC30_Win.apx`
- [x] **AC29 build clean** — the `#else` branches keep the current behavior on existing versions
- [ ] Follow-up: migrate Create/DeleteProjectInfoFields to the AC30 autotext API and remove the TODO stubs; decide whether the AC29-and-older `hasClearenceCollision` response key should also be renamed (schema currently documents the old spelling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
