### PR TITLE
Shortcut menu: disable unassigned items and add a Manage Script Shortcuts item

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -161,8 +161,8 @@ GSErrCode Initialize (void)
     err |= ScriptUIPalette::RegisterPaletteControlCallBack ();
 
     // Forces the palette singleton (and its saved shortcut-slot preferences) to load immediately,
-    // so custom shortcut menu labels are applied at startup rather than only after the user first
-    // opens the palette or triggers a shortcut.
+    // so custom shortcut menu labels and the enabled state of the shortcut menu items are applied
+    // at startup rather than only after the user first opens the palette or triggers a shortcut.
     TapirPalette::Instance ();
 
     { // Application Commands

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -105,6 +105,13 @@ static GSErrCode MenuCommandHandler (const API_MenuParams* menuParams)
                     break;
             }
             break;
+        case ID_ADDON_MENU_FOR_SHORTCUTS:
+            switch (menuParams->menuItemRef.itemIndex) {
+                case ID_ADDON_MENU_MANAGE_SHORTCUTS:
+                    TapirPalette::Instance ().OpenShortcutsDialog ();
+                    break;
+            }
+            break;
         // Each shortcut slot is its own top-level menu group (see ResourceIds.hpp) —
         // RunShortcutSlot takes a 0-based slot index.
         case ID_ADDON_MENU_RUNSCRIPT_1: TapirPalette::Instance ().RunShortcutSlot (0); break;
@@ -134,6 +141,7 @@ GSErrCode RegisterInterface (void)
     err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_FOR_PALETTE, 0, MenuCode_UserDef, MenuFlag_Default);
     err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_FOR_UPDATE, 0, MenuCode_UserDef, MenuFlag_Default);
     err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU, 0, MenuCode_UserDef, MenuFlag_Default);
+    err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_FOR_SHORTCUTS, 0, MenuCode_UserDef, MenuFlag_SeparatorBefore);
     err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_RUNSCRIPT_1, 0, MenuCode_UserDef, MenuFlag_Default);
     err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_RUNSCRIPT_2, 0, MenuCode_UserDef, MenuFlag_Default);
     err |= ACAPI_MenuItem_RegisterMenu (ID_ADDON_MENU_RUNSCRIPT_3, 0, MenuCode_UserDef, MenuFlag_Default);
@@ -151,6 +159,7 @@ GSErrCode Initialize (void)
     err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_FOR_PALETTE, MenuCommandHandler);
     err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_FOR_UPDATE, MenuCommandHandler);
     err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU, MenuCommandHandler);
+    err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_FOR_SHORTCUTS, MenuCommandHandler);
     err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_RUNSCRIPT_1, MenuCommandHandler);
     err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_RUNSCRIPT_2, MenuCommandHandler);
     err |= ACAPI_MenuItem_InstallMenuHandler (ID_ADDON_MENU_RUNSCRIPT_3, MenuCommandHandler);

--- a/archicad-addon/Sources/RINT/AddOn.grc
+++ b/archicad-addon/Sources/RINT/AddOn.grc
@@ -21,6 +21,11 @@
 /* [  1] */        "Check for Updates...^E3^ES^EE^EI^ED^EL^EW^ET^EM^32510"
 }
 
+'STR#' ID_ADDON_MENU_FOR_SHORTCUTS "Add-On Menu" {
+/* [   ] */        "Tapir"
+/* [  1] */        "Manage Script Shortcuts...^E3^ES^EE^EI^ED^EL^EW^ET^EM"
+}
+
 'STR#' ID_ADDON_MENU_RUNSCRIPT_1 "Add-On Menu" {
 /* [   ] */        "Tapir"
 /* [  1] */        "Run Script Shortcut 1^E3^ES^EE^EI^ED^EL^EW^ET^EM"

--- a/archicad-addon/Sources/RINT/AddOn.grc
+++ b/archicad-addon/Sources/RINT/AddOn.grc
@@ -99,11 +99,11 @@
 'DLGH' ID_PALETTE Tapir_Palette {
 1    ""        TapirButton
 2    ""        ScriptSelection
-3    ""        RunButton
-4    ""        OpenButton
-5    ""        AddButton
-6    ""        DelButton
-7    ""        ManageShortcutsButton
+3    "Run Script"          RunButton
+4    "Open in Browser"     OpenButton
+5    "Add Script"          AddButton
+6    "Remove Script"       DelButton
+7    "Manage Shortcuts"    ManageShortcutsButton
 }
 
 'GDLG' ID_SCRIPTUI_PALETTE Palette | leftCaption | close | grow   0   0  600  450  "Tapir Script UI"  {

--- a/archicad-addon/Sources/ResourceIds.hpp
+++ b/archicad-addon/Sources/ResourceIds.hpp
@@ -15,6 +15,9 @@
 
 #define ID_SCRIPTUI_PALETTE             32041
 
+#define ID_ADDON_MENU_FOR_SHORTCUTS     32026
+#define ID_ADDON_MENU_MANAGE_SHORTCUTS      1
+
 // Each shortcut slot is its own top-level menu group (own resID, exactly one item) — confirmed
 // working end to end (menu display AND click dispatch running the assigned script).
 #define ID_ADDON_MENU_RUNSCRIPT_1       32020

--- a/archicad-addon/Sources/TapirPalette.cpp
+++ b/archicad-addon/Sources/TapirPalette.cpp
@@ -389,6 +389,8 @@ void TapirPalette::SetShortcutSlot (short slotIndex, const IO::Location& locatio
     scriptShortcutSlots[slotIndex] = location;
     SaveScriptsToPreferences ();
     RefreshScriptListShortcutLabels ();
+    // Refresh every slot: the dedup loop above may have cleared another one.
+    ApplyAllShortcutMenuItemTexts ();
 }
 
 GS::UniString TapirPalette::GetShortcutLabel (short slotIndex) const
@@ -455,6 +457,17 @@ void TapirPalette::ApplyShortcutMenuItemText (short slotIndex)
     itemRef.menuResID = menuResIds[slotIndex];
     itemRef.itemIndex = ID_ADDON_MENU_RUNSCRIPT_ITEM;
     ACAPI_MenuItem_SetMenuItemText (&itemRef, nullptr, &label);
+
+    // The API offers no way to hide add-on menu items, so slots without an
+    // assigned script are disabled (greyed out) instead.
+    GSFlags itemFlags = {};
+    ACAPI_MenuItem_GetMenuItemFlags (&itemRef, &itemFlags);
+    if (scriptShortcutSlots[slotIndex].IsEmpty ()) {
+        itemFlags |= API_MenuItemDisabled;
+    } else {
+        itemFlags &= ~API_MenuItemDisabled;
+    }
+    ACAPI_MenuItem_SetMenuItemFlags (&itemRef, &itemFlags);
 }
 
 void TapirPalette::ApplyAllShortcutMenuItemTexts ()


### PR DESCRIPTION
## Summary

The six **Run Script Shortcut** menu items were always enabled — clicking an unassigned one only popped an error alert. They are now **disabled (greyed out) whenever no script is assigned** to the slot, and enable/disable live as slots change.

> Note: the Archicad API offers no way to *hide* add-on menu items (`APIdefs_Interface.h` exposes only `API_MenuItemDisabled` and `API_MenuItemChecked`), so greying out is the closest achievable behavior to the requested "disable or hide".

### Changes (`TapirPalette.cpp`)

- `ApplyShortcutMenuItemText` — after setting the item text, it now also syncs the `API_MenuItemDisabled` flag from the slot state (`scriptShortcutSlots[slot].IsEmpty ()`), using the same Get/modify/Set round trip as the existing palette check-mark code. The flag calls use the 2-argument form required by the pre-AC27 `MigrationHelper` macros.
- `SetShortcutSlot` — now ends with `ApplyAllShortcutMenuItemTexts ()`, refreshing **all six** items, because assigning a script to one slot can implicitly clear it from another (the dedup loop).
- Startup state comes free: `AddScriptsFromPreferences` already ends with `ApplyAllShortcutMenuItemTexts ()` (forced at launch via `TapirPalette::Instance ()` in `Initialize`), so unassigned items are greyed out right after preferences load — including all six on a fresh install.
- The empty-slot alert in `RunShortcutSlot` stays as a defensive fallback.

### Manage Script Shortcuts menu item

A new **"Manage Script Shortcuts..."** item sits in the Tapir menu directly above the six shortcut slots, separated from the items above it (`MenuFlag_SeparatorBefore`). It opens the same shortcuts dialog as the palette's Manage Shortcuts button (`TapirPalette::OpenShortcutsDialog`), so shortcuts can be assigned without opening the palette first — which also gives greyed-out slots an obvious path to becoming useful.

## Test plan

- [x] AC29 build clean
- [x] AC30 build attempted: the only errors are the pre-existing AC30 incompatibilities fixed by #477 (`ToLowerCase`, `hasClearenceCollision`, ProjectCommands) — this change introduces none
- [ ] Live check: the Tapir menu shows separator + "Manage Script Shortcuts..." above the slots and the item opens the dialog; fresh start → all six shortcut items greyed out; assign a script in the Manage Shortcuts dialog → the item enables immediately; reassign the same script to another slot → the old slot's item greys out; clear a slot → greys out; restart Archicad → persisted state honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)
