### PR TITLE
Split the Elements Grasshopper group into more focused groups

### DIFF
--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateAssociativeDimensionsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateAssociativeDimensionsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateAssociativeDimensions",
                 "Create associative linear dimensions from explicit witness point references. Each input item is a JSON object matching the command's documented item schema, e.g. {\"witnessPoints\":[...],\"lineCoordinate\":{\"x\":0,\"y\":0}}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "dimensionsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateAssociativeDimensionsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateAssociativeDimensionsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateAssociativeDimensions",
                 "Create associative linear dimensions from explicit witness point references. Each input item is a JSON object matching the command's documented item schema, e.g. {\"witnessPoints\":[...],\"lineCoordinate\":{\"x\":0,\"y\":0}}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "dimensionsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateAssociativeDimensionsOnSectionComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateAssociativeDimensionsOnSectionComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateAssociativeDimensionsOnSection",
                 "Create associative linear dimensions on section elements using common wall, slab, beam, column and opening presets. Each input item is a JSON object matching the command's documented item schema, e.g. {\"databaseId\":{\"guid\":\"...\"},\"elements\":[...]}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "dimensionsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateAssociativeDimensionsOnSectionComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateAssociativeDimensionsOnSectionComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateAssociativeDimensionsOnSection",
                 "Create associative linear dimensions on section elements using common wall, slab, beam, column and opening presets. Each input item is a JSON object matching the command's documented item schema, e.g. {\"databaseId\":{\"guid\":\"...\"},\"elements\":[...]}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "dimensionsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateBeamsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateBeamsComponent.cs
@@ -16,7 +16,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "CreateBeams",
                 "Create Beam elements based on the given parameters. " +
                 "The Z coordinate of each line's start point is used as the beam's Z coordinate.",
-                GroupNames.CreateElements)
+                GroupNames.ElementCreation)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateBeamsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateBeamsComponent.cs
@@ -16,7 +16,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "CreateBeams",
                 "Create Beam elements based on the given parameters. " +
                 "The Z coordinate of each line's start point is used as the beam's Z coordinate.",
-                GroupNames.Elements)
+                GroupNames.CreateElements)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateColumnsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateColumnsComponent.cs
@@ -15,7 +15,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateColumns",
                 "Create Column elements based on the given parameters.",
-                GroupNames.CreateElements)
+                GroupNames.ElementCreation)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateColumnsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateColumnsComponent.cs
@@ -15,7 +15,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateColumns",
                 "Create Column elements based on the given parameters.",
-                GroupNames.Elements)
+                GroupNames.CreateElements)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateDoorsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateDoorsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateDoors",
                 "Create Door elements in host walls based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"wallId\":{\"guid\":\"...\"},\"libraryPartName\":\"Door 26\",\"position\":1.0}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "doorsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateDoorsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateDoorsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateDoors",
                 "Create Door elements in host walls based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"wallId\":{\"guid\":\"...\"},\"libraryPartName\":\"Door 26\",\"position\":1.0}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "doorsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateGroupsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateGroupsComponent.cs
@@ -18,7 +18,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateGroups",
                 "Create groups of the passed elements (one branch per group, at least two elements each).",
-                GroupNames.Elements)
+                GroupNames.ElementGrouping)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMeshesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMeshesComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateMeshes",
                 "Create Mesh elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"level\":0,\"polygonCoordinates\":[{\"x\":0,\"y\":0,\"z\":0},...]}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "meshesData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMeshesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMeshesComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateMeshes",
                 "Create Mesh elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"level\":0,\"polygonCoordinates\":[{\"x\":0,\"y\":0,\"z\":0},...]}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "meshesData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMorphsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMorphsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateMorphs",
                 "Create Morph elements from simple box definitions. Each input item is a JSON object matching the command's documented item schema, e.g. {\"boxBegCoordinate\":{\"x\":0,\"y\":0,\"z\":0},\"boxEndCoordinate\":{\"x\":1,\"y\":1,\"z\":1}}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "morphsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMorphsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMorphsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateMorphs",
                 "Create Morph elements from simple box definitions. Each input item is a JSON object matching the command's documented item schema, e.g. {\"boxBegCoordinate\":{\"x\":0,\"y\":0,\"z\":0},\"boxEndCoordinate\":{\"x\":1,\"y\":1,\"z\":1}}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "morphsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateOpeningsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateOpeningsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateOpenings",
                 "Create Opening elements in the given host elements. Each input item is a JSON object matching the command's documented item schema, e.g. {\"hostElementId\":{\"guid\":\"...\"},\"position\":{\"x\":0,\"y\":0,\"z\":1.0}}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "openingsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateOpeningsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateOpeningsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateOpenings",
                 "Create Opening elements in the given host elements. Each input item is a JSON object matching the command's documented item schema, e.g. {\"hostElementId\":{\"guid\":\"...\"},\"position\":{\"x\":0,\"y\":0,\"z\":1.0}}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "openingsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreatePolylinesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreatePolylinesComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreatePolylines",
                 "Create Polyline elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"coordinates\":[{\"x\":0,\"y\":0},...],\"floorIndex\":0}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "polylinesData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreatePolylinesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreatePolylinesComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreatePolylines",
                 "Create Polyline elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"coordinates\":[{\"x\":0,\"y\":0},...],\"floorIndex\":0}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "polylinesData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateRoofsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateRoofsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateRoofs",
                 "Create multi-plane Roof elements based on footprint, level and roof profile data. Each input item is a JSON object matching the command's documented item schema, e.g. {\"level\":3.0,\"polygonCoordinates\":[{\"x\":0,\"y\":0},...]}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "roofsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateRoofsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateRoofsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateRoofs",
                 "Create multi-plane Roof elements based on footprint, level and roof profile data. Each input item is a JSON object matching the command's documented item schema, e.g. {\"level\":3.0,\"polygonCoordinates\":[{\"x\":0,\"y\":0},...]}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "roofsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateSlabsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateSlabsComponent.cs
@@ -18,7 +18,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Create Slab elements based on the given parameters. " +
                 "The polygon points are given as a tree with one branch per slab; " +
                 "if no Levels are given, the Z coordinate of each branch's first point is used as the slab level.",
-                GroupNames.CreateElements)
+                GroupNames.ElementCreation)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateSlabsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateSlabsComponent.cs
@@ -18,7 +18,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Create Slab elements based on the given parameters. " +
                 "The polygon points are given as a tree with one branch per slab; " +
                 "if no Levels are given, the Z coordinate of each branch's first point is used as the slab level.",
-                GroupNames.Elements)
+                GroupNames.CreateElements)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateStairsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateStairsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateStairs",
                 "Create Stair elements based on the given baseline and parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"baseline\":[{\"x\":0,\"y\":0},...],\"width\":1.2}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "stairsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateStairsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateStairsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateStairs",
                 "Create Stair elements based on the given baseline and parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"baseline\":[{\"x\":0,\"y\":0},...],\"width\":1.2}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "stairsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateTextsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateTextsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateTexts",
                 "Create standalone Text elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"text\":\"Hello\",\"coordinate\":{\"x\":0,\"y\":0},\"height\":2.0}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "textsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateTextsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateTextsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateTexts",
                 "Create standalone Text elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"text\":\"Hello\",\"coordinate\":{\"x\":0,\"y\":0},\"height\":2.0}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "textsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWallThicknessDimensionsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWallThicknessDimensionsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateWallThicknessDimensions",
                 "Create associative wall thickness dimensions for the given walls. Each input item is a JSON object matching the command's documented item schema, e.g. {\"wallId\":{\"guid\":\"...\"},\"linePosition\":{\"x\":0,\"y\":0}}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "dimensionsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWallThicknessDimensionsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWallThicknessDimensionsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateWallThicknessDimensions",
                 "Create associative wall thickness dimensions for the given walls. Each input item is a JSON object matching the command's documented item schema, e.g. {\"wallId\":{\"guid\":\"...\"},\"linePosition\":{\"x\":0,\"y\":0}}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "dimensionsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWallsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWallsComponent.cs
@@ -16,7 +16,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "CreateWalls",
                 "Create Wall elements based on the given parameters. " +
                 "The Z coordinate of each line's start point is used as the wall's Z coordinate.",
-                GroupNames.CreateElements)
+                GroupNames.ElementCreation)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWallsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWallsComponent.cs
@@ -16,7 +16,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "CreateWalls",
                 "Create Wall elements based on the given parameters. " +
                 "The Z coordinate of each line's start point is used as the wall's Z coordinate.",
-                GroupNames.Elements)
+                GroupNames.CreateElements)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWindowsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWindowsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateWindows",
                 "Create Window elements in host walls based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"wallId\":{\"guid\":\"...\"},\"libraryPartName\":\"Window 26\",\"position\":1.0}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "windowsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWindowsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWindowsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateWindows",
                 "Create Window elements in host walls based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"wallId\":{\"guid\":\"...\"},\"libraryPartName\":\"Window 26\",\"position\":1.0}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "windowsData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateZonesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateZonesComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateZones",
                 "Create Zone elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"name\":\"Room\",\"numberStr\":\"01\",\"polygonCoordinates\":[{\"x\":0,\"y\":0},...]}.",
-                GroupNames.CreateElements,
+                GroupNames.ElementCreation,
                 "zonesData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateZonesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateZonesComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateZones",
                 "Create Zone elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"name\":\"Room\",\"numberStr\":\"01\",\"polygonCoordinates\":[{\"x\":0,\"y\":0},...]}.",
-                GroupNames.Elements,
+                GroupNames.CreateElements,
                 "zonesData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/Get3DBoundingBoxesOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/Get3DBoundingBoxesOfElementsComponent.cs
@@ -15,7 +15,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "Element3DBoundingBoxes",
                 "Gets the 3D BoundingBoxes of elements.",
-                GroupNames.Elements)
+                GroupNames.ElementDetails)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetConnectedElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetConnectedElementsComponent.cs
@@ -15,7 +15,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ConnectedElements",
                 "Gets the connected elements of the given elements.",
-                GroupNames.Elements)
+                GroupNames.ElementDetails)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetDetailsOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetDetailsOfElementsComponent.cs
@@ -24,7 +24,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 name,
                 "Get details of elements.",
-                GroupNames.Elements)
+                GroupNames.ElementDetails)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetDimensionDataComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetDimensionDataComponent.cs
@@ -18,7 +18,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "GetDimensionData",
                 "Get witness point data (coordinates, measured values) from existing dimension chains. " +
                 "Witness point outputs have one branch per queried dimension element.",
-                GroupNames.Elements)
+                GroupNames.ElementDetails)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetElementsOfGroupsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetElementsOfGroupsComponent.cs
@@ -19,7 +19,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "GetElementsOfGroups",
                 "Get the elements directly contained by each given group.",
-                GroupNames.Elements)
+                GroupNames.ElementGrouping)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetGDLParametersComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetGDLParametersComponent.cs
@@ -15,7 +15,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ElementGDLParameters",
                 "Get GDL parameter values of elements.",
-                GroupNames.Elements)
+                GroupNames.ElementDetails)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetGroupsOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetGroupsOfElementsComponent.cs
@@ -16,7 +16,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "GetGroupsOfElements",
                 "Get the identifier of the group that directly contains each given element. " +
                 "The GroupGuids output holds null for elements that are not part of any group.",
-                GroupNames.Elements)
+                GroupNames.ElementGrouping)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetSubelementsOfHierarchicalElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetSubelementsOfHierarchicalElementsComponent.cs
@@ -18,7 +18,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "Subelements",
                 "Gets the subelements of the given hierarchical elements.",
-                GroupNames.Elements)
+                GroupNames.ElementDetails)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetSuspendGroupsModeComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetSuspendGroupsModeComponent.cs
@@ -13,7 +13,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "GetSuspendGroupsMode",
                 "Get the current state of the Suspend Groups mode.",
-                GroupNames.Elements)
+                GroupNames.ElementGrouping)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetZoneBoundariesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetZoneBoundariesComponent.cs
@@ -17,7 +17,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ZoneBoundaries",
                 "Gets the boundaries of the given Zone (connected elements, neighbour zones, etc.).",
-                GroupNames.Elements)
+                GroupNames.ElementDetails)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/LabelElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/LabelElementsComponent.cs
@@ -14,7 +14,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "LabelElements",
                 "Label elements",
-                GroupNames.Elements)
+                GroupNames.CreateElements)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/LabelElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/LabelElementsComponent.cs
@@ -1,4 +1,4 @@
-﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel;
 using System;
 using System.Linq;
 using TapirGrasshopperPlugin.Helps;
@@ -14,7 +14,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "LabelElements",
                 "Label elements",
-                GroupNames.CreateElements)
+                GroupNames.ElementCreation)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/LibraryPartCreatorComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/LibraryPartCreatorComponent.cs
@@ -21,7 +21,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 name,
                 description,
-                GroupNames.CreateElements)
+                GroupNames.ElementCreation)
         {
             _dataArrayKey = dataArrayKey;
         }

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/LibraryPartCreatorComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/LibraryPartCreatorComponent.cs
@@ -21,7 +21,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 name,
                 description,
-                GroupNames.Elements)
+                GroupNames.CreateElements)
         {
             _dataArrayKey = dataArrayKey;
         }

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyBeamsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyBeamsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyBeams",
                 "Modify Beam elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"width\":0.3}.",
-                GroupNames.ModifyElements,
+                GroupNames.ElementModification,
                 "beamsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyBeamsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyBeamsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyBeams",
                 "Modify Beam elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"width\":0.3}.",
-                GroupNames.Elements,
+                GroupNames.ModifyElements,
                 "beamsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyColumnsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyColumnsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyColumns",
                 "Modify Column elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"height\":3.0}.",
-                GroupNames.ModifyElements,
+                GroupNames.ElementModification,
                 "columnsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyColumnsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyColumnsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyColumns",
                 "Modify Column elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"height\":3.0}.",
-                GroupNames.Elements,
+                GroupNames.ModifyElements,
                 "columnsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyDoorsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyDoorsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyDoors",
                 "Modify Door elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"position\":1.5}.",
-                GroupNames.ModifyElements,
+                GroupNames.ElementModification,
                 "doorsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyDoorsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyDoorsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyDoors",
                 "Modify Door elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"position\":1.5}.",
-                GroupNames.Elements,
+                GroupNames.ModifyElements,
                 "doorsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMeshesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMeshesComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyMeshes",
                 "Modify the attributes of Mesh elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},...}.",
-                GroupNames.Elements,
+                GroupNames.ModifyElements,
                 "meshesData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMeshesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMeshesComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyMeshes",
                 "Modify the attributes of Mesh elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},...}.",
-                GroupNames.ModifyElements,
+                GroupNames.ElementModification,
                 "meshesData",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMorphsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMorphsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyMorphs",
                 "Modify Morph elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},...}.",
-                GroupNames.ModifyElements,
+                GroupNames.ElementModification,
                 "morphsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMorphsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMorphsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyMorphs",
                 "Modify Morph elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},...}.",
-                GroupNames.Elements,
+                GroupNames.ModifyElements,
                 "morphsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyRoofsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyRoofsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyRoofs",
                 "Modify multi-plane Roof elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},...}.",
-                GroupNames.Elements,
+                GroupNames.ModifyElements,
                 "roofsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyRoofsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyRoofsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyRoofs",
                 "Modify multi-plane Roof elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},...}.",
-                GroupNames.ModifyElements,
+                GroupNames.ElementModification,
                 "roofsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifySlabsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifySlabsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifySlabs",
                 "Modify Slab elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"level\":0.0}.",
-                GroupNames.ModifyElements,
+                GroupNames.ElementModification,
                 "slabsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifySlabsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifySlabsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifySlabs",
                 "Modify Slab elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"level\":0.0}.",
-                GroupNames.Elements,
+                GroupNames.ModifyElements,
                 "slabsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWallsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWallsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyWalls",
                 "Modify Wall elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"height\":3.0}.",
-                GroupNames.Elements,
+                GroupNames.ModifyElements,
                 "wallsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWallsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWallsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyWalls",
                 "Modify Wall elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"height\":3.0}.",
-                GroupNames.ModifyElements,
+                GroupNames.ElementModification,
                 "wallsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWindowsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWindowsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyWindows",
                 "Modify Window elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"position\":1.5}.",
-                GroupNames.ModifyElements,
+                GroupNames.ElementModification,
                 "windowsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWindowsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWindowsComponent.cs
@@ -10,7 +10,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyWindows",
                 "Modify Window elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"position\":1.5}.",
-                GroupNames.Elements,
+                GroupNames.ModifyElements,
                 "windowsWithDetails",
                 "ItemsData",
                 "One JSON object per item, matching the command's documented item schema (see component description).")

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/MoveElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/MoveElementsComponent.cs
@@ -1,4 +1,4 @@
-﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel;
 using Rhino.Geometry;
 using System;
 using System.Collections.Generic;
@@ -15,7 +15,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "MoveElements",
                 "Move elements",
-                GroupNames.ModifyElements)
+                GroupNames.ElementModification)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/MoveElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/MoveElementsComponent.cs
@@ -15,7 +15,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "MoveElements",
                 "Move elements",
-                GroupNames.Elements)
+                GroupNames.ModifyElements)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/RotateElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/RotateElementsComponent.cs
@@ -15,7 +15,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "RotateElements",
                 "Rotate elements",
-                GroupNames.ModifyElements)
+                GroupNames.ElementModification)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/RotateElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/RotateElementsComponent.cs
@@ -15,7 +15,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "RotateElements",
                 "Rotate elements",
-                GroupNames.Elements)
+                GroupNames.ModifyElements)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/SetDetailsOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/SetDetailsOfElementsComponent.cs
@@ -15,7 +15,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "SetWallDetails",
                 "Set details of Wall elements.",
-                GroupNames.Elements)
+                GroupNames.ModifyElements)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/SetDetailsOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/SetDetailsOfElementsComponent.cs
@@ -1,4 +1,4 @@
-﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel;
 using System;
 using System.Collections.Generic;
 using TapirGrasshopperPlugin.Helps;
@@ -15,7 +15,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "SetWallDetails",
                 "Set details of Wall elements.",
-                GroupNames.ModifyElements)
+                GroupNames.ElementModification)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/SetGDLParametersComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/SetGDLParametersComponent.cs
@@ -1,4 +1,4 @@
-﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,7 +17,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "SetElementGDLs",
                 "Sets the given GDL parameters of the given elements.",
-                GroupNames.ModifyElements)
+                GroupNames.ElementModification)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/SetGDLParametersComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/SetGDLParametersComponent.cs
@@ -17,7 +17,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "SetElementGDLs",
                 "Sets the given GDL parameters of the given elements.",
-                GroupNames.Elements)
+                GroupNames.ModifyElements)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/SetSuspendGroupsModeComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/SetSuspendGroupsModeComponent.cs
@@ -15,7 +15,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Turn the Suspend Groups mode on or off. " +
                 "Suspend groups to perform operations on elements that are part of a group; " +
                 "remember to restore the previous state afterwards.",
-                GroupNames.Elements)
+                GroupNames.ElementGrouping)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/GroupNames.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/GroupNames.cs
@@ -20,6 +20,7 @@
         public static string Project => nameof(Project);
         public static string Properties => nameof(Properties);
         public static string Revision => nameof(Revision);
+        public static string SolidOperations => "Solid Operations";
         public static string Utilities => nameof(Utilities);
         public static string Teamwork => nameof(Teamwork);
     }

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/GroupNames.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/GroupNames.cs
@@ -4,12 +4,13 @@
     {
         public static string Attributes => nameof(Attributes);
         public static string Classifications => nameof(Classifications);
-        public static string CreateElements => "Create Elements";
         public static string DesignOptions => nameof(DesignOptions);
+        public static string ElementCreation => "Element Creation";
         public static string ElementDetails => "Element Details";
         public static string ElementGrouping => "Element Grouping";
+        public static string ElementModification => "Element Modification";
         public static string Elements => nameof(Elements);
-        public static string ModifyElements => "Modify Elements";
+        public static string ElementSolidOperations => "Element Solid Operations";
         public static string Favorites => nameof(Favorites);
         public static string General => nameof(General);
         public static string IFC => nameof(IFC);
@@ -21,7 +22,6 @@
         public static string Project => nameof(Project);
         public static string Properties => nameof(Properties);
         public static string Revision => nameof(Revision);
-        public static string SolidOperations => "Solid Operations";
         public static string Utilities => nameof(Utilities);
         public static string Teamwork => nameof(Teamwork);
     }

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/GroupNames.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/GroupNames.cs
@@ -7,6 +7,7 @@
         public static string CreateElements => "Create Elements";
         public static string DesignOptions => nameof(DesignOptions);
         public static string ElementDetails => "Element Details";
+        public static string ElementGrouping => "Element Grouping";
         public static string Elements => nameof(Elements);
         public static string ModifyElements => "Modify Elements";
         public static string Favorites => nameof(Favorites);

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/GroupNames.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/GroupNames.cs
@@ -4,8 +4,11 @@
     {
         public static string Attributes => nameof(Attributes);
         public static string Classifications => nameof(Classifications);
+        public static string CreateElements => "Create Elements";
         public static string DesignOptions => nameof(DesignOptions);
+        public static string ElementDetails => "Element Details";
         public static string Elements => nameof(Elements);
+        public static string ModifyElements => "Modify Elements";
         public static string Favorites => nameof(Favorites);
         public static string General => nameof(General);
         public static string IFC => nameof(IFC);

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/CreateSolidElementLinksComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/CreateSolidElementLinksComponent.cs
@@ -17,7 +17,7 @@ namespace TapirGrasshopperPlugin.Components.SolidOperationComponents
             : base(
                 "CreateSolidElementLinks",
                 "Create solid element operation links between target and operator elements.",
-                GroupNames.SolidOperations)
+                GroupNames.ElementSolidOperations)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/CreateSolidElementLinksComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/CreateSolidElementLinksComponent.cs
@@ -17,7 +17,7 @@ namespace TapirGrasshopperPlugin.Components.SolidOperationComponents
             : base(
                 "CreateSolidElementLinks",
                 "Create solid element operation links between target and operator elements.",
-                GroupNames.Elements)
+                GroupNames.SolidOperations)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/GetSolidElementLinksComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/GetSolidElementLinksComponent.cs
@@ -18,7 +18,7 @@ namespace TapirGrasshopperPlugin.Components.SolidOperationComponents
                 "GetSolidElementLinks",
                 "Get solid element operation links for each queried element, grouped by role (target or operator). " +
                 "All outputs have one branch per queried element.",
-                GroupNames.Elements)
+                GroupNames.SolidOperations)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/GetSolidElementLinksComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/GetSolidElementLinksComponent.cs
@@ -18,7 +18,7 @@ namespace TapirGrasshopperPlugin.Components.SolidOperationComponents
                 "GetSolidElementLinks",
                 "Get solid element operation links for each queried element, grouped by role (target or operator). " +
                 "All outputs have one branch per queried element.",
-                GroupNames.SolidOperations)
+                GroupNames.ElementSolidOperations)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/RemoveSolidElementLinksComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/RemoveSolidElementLinksComponent.cs
@@ -17,7 +17,7 @@ namespace TapirGrasshopperPlugin.Components.SolidOperationComponents
             : base(
                 "RemoveSolidElementLinks",
                 "Remove solid element operation links between target and operator elements.",
-                GroupNames.SolidOperations)
+                GroupNames.ElementSolidOperations)
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/RemoveSolidElementLinksComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/RemoveSolidElementLinksComponent.cs
@@ -17,7 +17,7 @@ namespace TapirGrasshopperPlugin.Components.SolidOperationComponents
             : base(
                 "RemoveSolidElementLinks",
                 "Remove solid element operation links between target and operator elements.",
-                GroupNames.Elements)
+                GroupNames.SolidOperations)
         {
         }
 


### PR DESCRIPTION
## Summary

The **Elements** group in the Grasshopper plugin had grown to 67 components in a single ribbon panel. This PR splits it into six focused groups (the group name is used verbatim as the Grasshopper subcategory/panel name). All element-related groups share the **Element** prefix, so alphabetical panel ordering keeps them next to each other:

- **Element Creation** (20): CreateWalls/Columns/Beams/Slabs/Roofs/Meshes/Morphs/Stairs/Zones/Doors/Windows/Openings/Objects/Lamps/Polylines/Texts, the three dimension creators and LabelElements.
- **Element Details** (13): GetDetailsOfElements and the typed variants, GetGDLParameters, GetDimensionData, Get3DBoundingBoxesOfElements, GetZoneBoundaries, GetSubelementsOfHierarchicalElements and GetConnectedElements.
- **Element Grouping** (5): CreateGroups, GetGroupsOfElements, GetElementsOfGroups, GetSuspendGroupsMode and SetSuspendGroupsMode, matching the add-on's Element Grouping command group.
- **Element Modification** (13): the Modify* components, SetDetailsOfWalls, SetGDLParameters, MoveElements and RotateElements.
- **Element Solid Operations** (3): CreateSolidElementLinks, GetSolidElementLinks and RemoveSolidElementLinks, matching the add-on's Solid Element Operation command group.
- **Elements** (15 remain): element listing/selection/filtering, delete/lock, highlight/zoom, collisions, preview images and the two value lists.

No component names, GUIDs or behavior change - only the subcategory string passed to the component constructors, so existing Grasshopper definitions are unaffected.

## Changes

- `Components/GroupNames.cs`: added `ElementCreation`, `ElementDetails`, `ElementGrouping`, `ElementModification` and `ElementSolidOperations` group names.
- 47 component files under `Components/ElementsComponents/` and `Components/SolidOperationComponents/`: group reassignment in the constructor (incl. the `LibraryPartCreatorComponent` and `GetDetailsOfElementsComponent`/`SetDetailsOfElementsComponent` base classes, which move all their subclasses).

## Test plan

- [x] `dotnet build TapirGrasshopperPlugin.sln` succeeds with 0 warnings/errors
- [x] Load the plugin in Grasshopper and check the Tapir tab shows the new panels with the expected components

🤖 Generated with [Claude Code](https://claude.com/claude-code)
