### PR TITLE
Fix two ScriptUI palette lifecycle bugs: reappearing after close, and a quit-time crash

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -1200,5 +1200,9 @@ GSErrCode Initialize (void)
 
 GSErrCode FreeData (void)
 {
+    // Must run here, not left to the static GS::Ref's destructor at DLL/dylib unload time - see
+    // ScriptUIPalette::Release for why (real macOS crash on quit, EXC_BAD_ACCESS tearing down the
+    // browser control after Archicad's own environment had already begun shutting down).
+    ScriptUIPalette::Release ();
     return NoError;
 }

--- a/archicad-addon/Sources/ScriptUIPalette.cpp
+++ b/archicad-addon/Sources/ScriptUIPalette.cpp
@@ -130,6 +130,11 @@ ScriptUIPalette& ScriptUIPalette::Instance ()
     return *instance;
 }
 
+void ScriptUIPalette::Release ()
+{
+    instance = nullptr;
+}
+
 void ScriptUIPalette::Show ()
 {
     DG::Palette::Show ();
@@ -184,6 +189,7 @@ bool ScriptUIPalette::ConsumeResult (GS::UniString* outResult)
 
 void ScriptUIPalette::PanelCloseRequested (const DG::PanelCloseRequestEvent&, bool* accepted)
 {
+    hiddenByForcedHideBegin = false;
     Hide ();
     *accepted = true;
 }
@@ -212,7 +218,9 @@ void ScriptUIPalette::RegisterACAPIJavaScriptObject ()
 
     jsACAPI->AddItem (new JS::Function ("ClosePalette", [] (GS::Ref<JS::Base>) {
         if (ScriptUIPalette::HasInstance ()) {
-            ScriptUIPalette::Instance ().Hide ();
+            ScriptUIPalette& palette = ScriptUIPalette::Instance ();
+            palette.hiddenByForcedHideBegin = false;
+            palette.Hide ();
         }
         return GS::Ref<JS::Base> (new JS::Value (true));
     }));
@@ -246,13 +254,21 @@ GSErrCode ScriptUIPalette::PaletteControlCallBack (Int32, API_PaletteMessageID m
             break;
 
         case APIPalMsg_HidePalette_Begin:
-            if (HasInstance () && Instance ().IsVisible ())
-                Instance ().Hide ();
+            if (HasInstance ()) {
+                ScriptUIPalette& palette = Instance ();
+                palette.hiddenByForcedHideBegin = palette.IsVisible ();
+                if (palette.hiddenByForcedHideBegin)
+                    palette.Hide ();
+            }
             break;
 
         case APIPalMsg_HidePalette_End:
-            if (HasInstance () && !Instance ().IsVisible ())
-                Instance ().Show ();
+            if (HasInstance ()) {
+                ScriptUIPalette& palette = Instance ();
+                if (palette.hiddenByForcedHideBegin)
+                    palette.Show ();
+                palette.hiddenByForcedHideBegin = false;
+            }
             break;
 
         case APIPalMsg_IsPaletteVisible:

--- a/archicad-addon/Sources/ScriptUIPalette.hpp
+++ b/archicad-addon/Sources/ScriptUIPalette.hpp
@@ -54,6 +54,13 @@ public:
     static bool            HasInstance ();
     static ScriptUIPalette& Instance ();
 
+    // Explicitly tears down the browser control while Archicad's own environment (including its
+    // CEF/browser subsystem) is still fully alive - must be called from FreeData, not left to run
+    // via the static GS::Ref's destructor at DLL/dylib unload time (confirmed via a real macOS
+    // crash report: EXC_BAD_ACCESS in the DG::Browser destructor when it ran during add-on
+    // finalization, after Archicad had already begun tearing down its own browser subsystem).
+    static void             Release ();
+
     void ShowWithHTML (const GS::UniString& htmlContent, const ScriptUIOptions& options = ScriptUIOptions ());
     void Hide ();
 
@@ -73,6 +80,11 @@ private:
     // page was opened with options.autoHeight = true (and therefore has the auto-height observer
     // script injected - see InjectAutoHeightScript in ScriptUIPalette.cpp).
     bool autoHeightEnabled = false;
+
+    // Set only when APIPalMsg_HidePalette_Begin itself hid a visible palette. Guards
+    // APIPalMsg_HidePalette_End so it only restores visibility it took away - not a palette the
+    // user (or the script, via ClosePalette) had already explicitly closed beforehand.
+    bool hiddenByForcedHideBegin = false;
 
     // Used only by PaletteControlCallBack, e.g. when Archicad restores a saved window layout that
     // had this palette open - just redisplays whatever HTML was last loaded (or a blank palette).


### PR DESCRIPTION
Fixes two issues reported against the ScriptUI palette (#485, #486).

**#485** - the palette reappeared with stale content after being explicitly closed (close button or `window.ACAPI.ClosePalette()`), whenever the user then navigated away from a Schedule or an open GDL object tab. Archicad sends `APIPalMsg_HidePalette_Begin`/`_End` around those contexts to temporarily declutter the screen, and the old handler unconditionally re-showed the palette on `_End` if it happened to be hidden - not distinguishing "we hid it via `_Begin`" from "the user already closed it". A `hiddenByForcedHideBegin` flag now tracks that distinction, cleared whenever the palette is closed explicitly, and only consulted (then reset) by `_End`. Live-verified: close the palette, open/leave a schedule, confirm it stays closed.

**#486** - Archicad crashed on quit on macOS (`EXC_BAD_ACCESS` in the `DG::Browser` destructor, per the reporter's crash log) after `ShowScriptUI` had been used. `ScriptUIPalette::instance` is a static `GS::Ref`, so its destructor was running at DLL/dylib unload time - after Archicad's own browser subsystem may have already begun tearing down, which a Chromium-based control does not tolerate. `FreeData` (called by Archicad while its environment is still fully alive, unlike static destruction order at unload) now explicitly releases the instance via a new `ScriptUIPalette::Release()`, so the browser is torn down deterministically before Archicad's own shutdown proceeds. Not reproducible on Windows; fix addresses the exact crash site and timing described in the report.

## Test plan
- [x] Builds clean on AC27.
- [x] Live-verified #485: opened the palette, closed it via the close button, opened/left a Schedule window, confirmed it stayed closed (previously reopened).
- [ ] #486 is macOS-only and could not be reproduced/re-tested on this Windows dev machine - fix targets the exact destructor/timing described in the crash report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
