### PR TITLE
Add GetMEPPreferenceTables command

### DIFF
--- a/archicad-addon/Examples/get_mep_preference_tables.py
+++ b/archicad-addon/Examples/get_mep_preference_tables.py
@@ -1,0 +1,28 @@
+import aclib
+
+# Requires Archicad 28 or newer.
+
+# List the circular cross section preference tables of the Piping domain
+# (referenceId, diameter and description per row). The referenceId of a row
+# can be passed as crossSectionReferenceId to CreateMEPRoutingElements /
+# ModifyMEPRoutingElements to pick that exact cross section.
+pipeTables = aclib.RunTapirCommand ('GetMEPPreferenceTables', {
+        'domain': 'Piping'
+    })['tables']
+
+for table in pipeTables:
+    print (f"Pipe preference table {table['guid']}:")
+    for row in table['rows']:
+        description = row.get ('description', '')
+        print (f"  referenceId={row['referenceId']} diameter={row['diameter']} {description}")
+
+# Same for the Ventilation (duct) domain
+ductTables = aclib.RunTapirCommand ('GetMEPPreferenceTables', {
+        'domain': 'Ventilation'
+    })['tables']
+
+for table in ductTables:
+    print (f"Duct preference table {table['guid']}:")
+    for row in table['rows']:
+        description = row.get ('description', '')
+        print (f"  referenceId={row['referenceId']} diameter={row['diameter']} {description}")

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -1168,6 +1168,10 @@ GSErrCode Initialize (void)
             mepCommands, "1.5.6",
             "Connects MEP routing elements to other MEP elements or routes. Merges routes, splits routes or creates branch elements as needed. Available from Archicad 28."
         );
+        err |= RegisterCommand<GetMEPPreferenceTablesCommand> (
+            mepCommands, "1.5.7",
+            "Gets the circular cross section preference tables (referenceId, diameter, description) of the Piping or Ventilation domain. Available from Archicad 28."
+        );
         AddCommandGroup (mepCommands);
     }
 

--- a/archicad-addon/Sources/MEPCommands.cpp
+++ b/archicad-addon/Sources/MEPCommands.cpp
@@ -18,7 +18,6 @@
 #include "ACAPI/MEPFittingDefault.hpp"
 #include "ACAPI/MEPDistributionSystemsGraph.hpp"
 #include "ACAPI/MEPDistributionSystem.hpp"
-#include "ACAPI/MEPUniqueID.hpp"
 #include "ACAPI/MEPPipeSegmentPreferenceTable.hpp"
 #include "ACAPI/MEPPipeSegmentPreferenceTableContainer.hpp"
 #include "ACAPI/MEPDuctCircularSegmentPreferenceTable.hpp"
@@ -1325,7 +1324,7 @@ GS::ObjectState GetMEPPreferenceTablesCommand::Execute (const GS::ObjectState& p
         if (container.IsErr ()) {
             return CreateErrorResponse (APIERR_GENERAL, GS::UniString ("Failed to get the pipe segment preference table container: ") + container.UnwrapErr ().text.c_str ());
         }
-        for (const UniqueID& id : container->GetPreferenceTables ()) {
+        for (const auto& id : container->GetPreferenceTables ()) {
             auto table = PipeSegmentPreferenceTable::Get (id);
             if (table.IsOk ()) {
                 tables (DumpPreferenceTable (*table, id.GetGuid ()));
@@ -1336,7 +1335,7 @@ GS::ObjectState GetMEPPreferenceTablesCommand::Execute (const GS::ObjectState& p
         if (container.IsErr ()) {
             return CreateErrorResponse (APIERR_GENERAL, GS::UniString ("Failed to get the duct segment preference table container: ") + container.UnwrapErr ().text.c_str ());
         }
-        for (const UniqueID& id : container->GetPreferenceTables ()) {
+        for (const auto& id : container->GetPreferenceTables ()) {
             auto table = DuctCircularSegmentPreferenceTable::Get (id);
             if (table.IsOk ()) {
                 tables (DumpPreferenceTable (*table, id.GetGuid ()));

--- a/archicad-addon/Sources/MEPCommands.cpp
+++ b/archicad-addon/Sources/MEPCommands.cpp
@@ -18,6 +18,11 @@
 #include "ACAPI/MEPFittingDefault.hpp"
 #include "ACAPI/MEPDistributionSystemsGraph.hpp"
 #include "ACAPI/MEPDistributionSystem.hpp"
+#include "ACAPI/MEPUniqueID.hpp"
+#include "ACAPI/MEPPipeSegmentPreferenceTable.hpp"
+#include "ACAPI/MEPPipeSegmentPreferenceTableContainer.hpp"
+#include "ACAPI/MEPDuctCircularSegmentPreferenceTable.hpp"
+#include "ACAPI/MEPDuctSegmentPreferenceTableContainer.hpp"
 
 #include <optional>
 
@@ -1214,3 +1219,137 @@ GS::ObjectState ConnectMEPElementsCommand::Execute (const GS::ObjectState& param
     return CreateErrorResponse (APIERR_NOTSUPPORTED, "This command requires Archicad 28 or newer.");
 #endif
 }
+
+GetMEPPreferenceTablesCommand::GetMEPPreferenceTablesCommand () :
+    CommandBase (CommonSchema::NotUsed)
+{
+}
+
+GS::String GetMEPPreferenceTablesCommand::GetName () const
+{
+    return "GetMEPPreferenceTables";
+}
+
+GS::Optional<GS::UniString> GetMEPPreferenceTablesCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "domain": {
+                "type": "string",
+                "description": "The MEP domain of the segment preference tables.",
+                "enum": ["Piping", "Ventilation"]
+            }
+        },
+        "additionalProperties": false,
+        "required": ["domain"]
+    })";
+}
+
+GS::Optional<GS::UniString> GetMEPPreferenceTablesCommand::GetResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "tables": {
+                "type": "array",
+                "description": "The circular segment preference tables of the domain.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "guid": { "type": "string" },
+                        "rows": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "referenceId": { "type": "integer" },
+                                    "diameter": { "type": "number" },
+                                    "description": { "type": "string" }
+                                },
+                                "required": ["referenceId", "diameter"],
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "required": ["guid", "rows"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": ["tables"]
+    })";
+}
+
+#ifdef ServerMainVers_2800
+template <typename TableT>
+static GS::ObjectState DumpPreferenceTable (const TableT& table, const GS::Guid& tableGuid)
+{
+    GS::ObjectState tableOS;
+    tableOS.Add ("guid", tableGuid.ToUniString ());
+    const auto& rows = tableOS.AddList<GS::ObjectState> ("rows");
+    const uint32_t size = table.GetSize ();
+    for (uint32_t i = 0; i < size; ++i) {
+        auto rowDiameter = table.GetDiameter (i);
+        auto rowReferenceId = table.GetReferenceId (i);
+        if (rowDiameter.IsErr () || rowReferenceId.IsErr ()) {
+            continue;
+        }
+        GS::ObjectState rowOS;
+        rowOS.Add ("referenceId", static_cast<Int32> (*rowReferenceId));
+        rowOS.Add ("diameter", *rowDiameter);
+        auto rowDescription = table.GetDescription (i);
+        if (rowDescription.IsOk ()) {
+            rowOS.Add ("description", *rowDescription);
+        }
+        rows (rowOS);
+    }
+    return tableOS;
+}
+
+GS::ObjectState GetMEPPreferenceTablesCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::UniString domainStr;
+    parameters.Get ("domain", domainStr);
+    const std::optional<Domain> domain = DomainFromString (domainStr);
+    if (!domain.has_value () || *domain == Domain::CableCarrier) {
+        return CreateErrorResponse (APIERR_BADPARS, "Invalid MEP domain: " + domainStr);
+    }
+
+    GS::ObjectState response;
+    const auto& tables = response.AddList<GS::ObjectState> ("tables");
+
+    if (*domain == Domain::Piping) {
+        auto container = GetPipeSegmentPreferenceTableContainer ();
+        if (container.IsErr ()) {
+            return CreateErrorResponse (APIERR_GENERAL, GS::UniString ("Failed to get the pipe segment preference table container: ") + container.UnwrapErr ().text.c_str ());
+        }
+        for (const UniqueID& id : container->GetPreferenceTables ()) {
+            auto table = PipeSegmentPreferenceTable::Get (id);
+            if (table.IsOk ()) {
+                tables (DumpPreferenceTable (*table, id.GetGuid ()));
+            }
+        }
+    } else {
+        auto container = GetDuctSegmentPreferenceTableContainer ();
+        if (container.IsErr ()) {
+            return CreateErrorResponse (APIERR_GENERAL, GS::UniString ("Failed to get the duct segment preference table container: ") + container.UnwrapErr ().text.c_str ());
+        }
+        for (const UniqueID& id : container->GetPreferenceTables ()) {
+            auto table = DuctCircularSegmentPreferenceTable::Get (id);
+            if (table.IsOk ()) {
+                tables (DumpPreferenceTable (*table, id.GetGuid ()));
+            }
+        }
+    }
+
+    return response;
+}
+#else
+GS::ObjectState GetMEPPreferenceTablesCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    UNUSED_PARAMETER (parameters);
+    return CreateErrorResponse (APIERR_NOTSUPPORTED, "This command requires Archicad 28 or newer.");
+}
+#endif

--- a/archicad-addon/Sources/MEPCommands.hpp
+++ b/archicad-addon/Sources/MEPCommands.hpp
@@ -80,3 +80,13 @@ public:
     virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
+
+class GetMEPPreferenceTablesCommand : public CommandBase
+{
+public:
+    GetMEPPreferenceTablesCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};


### PR DESCRIPTION
Adds a GetMEPPreferenceTables command to the MEP Commands group, which lists the circular cross section preference tables (referenceId, diameter, description) of the Piping or Ventilation domain. This lets a client resolve a target pipe/duct diameter to the referenceId that CreateMEPRoutingElements / ModifyMEPRoutingElements expect for crossSectionReferenceId, instead of only being able to set an explicit width/height cross section.

Requires Archicad 28 or newer (same availability as the rest of the MEP Commands group); registers on earlier versions but returns APIERR_NOTSUPPORTED, matching the existing pattern.