### PR TITLE
Give the Modify Grasshopper components typed input parameters

### DIFF
--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyBeamsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyBeamsComponent.cs
@@ -1,19 +1,28 @@
 using System;
+using System.Collections.Generic;
 
 namespace TapirGrasshopperPlugin.Components.ElementsComponents
 {
-    public class ModifyBeamsComponent : JsonItemsExecutorComponent
+    public class ModifyBeamsComponent : ModifyElementsComponentBase
     {
         public override string CommandName => "ModifyBeams";
 
         public ModifyBeamsComponent()
             : base(
                 "ModifyBeams",
-                "Modify Beam elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"width\":0.3}.",
+                "Modify Beam elements. Only the connected optional inputs are changed on the elements.",
                 GroupNames.ElementModification,
                 "beamsWithDetails",
-                "ItemsData",
-                "One JSON object per item, matching the command's documented item schema (see component description).")
+                new List<Field>
+                {
+                    new Field("BegPoints", "begCoordinate", FieldKind.Point2D, "New beginning point of the beam (only X and Y are used)."),
+                    new Field("EndPoints", "endCoordinate", FieldKind.Point2D, "New end point of the beam (only X and Y are used)."),
+                    new Field("Levels", "level", FieldKind.Number, "Base height of the beam relative to the home story."),
+                    new Field("Offsets", "offset", FieldKind.Number, "Offset of the beam from its reference line."),
+                    new Field("SlantAngles", "slantAngle", FieldKind.Number, "Slant angle of the beam in radians."),
+                    new Field("ArcAngles", "arcAngle", FieldKind.Number, "Arc angle in radians; a non-zero value makes the beam curved."),
+                    new Field("VerticalCurveHeights", "verticalCurveHeight", FieldKind.Number, "Height of the vertical curve of the beam.")
+                })
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyColumnsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyColumnsComponent.cs
@@ -1,19 +1,26 @@
 using System;
+using System.Collections.Generic;
 
 namespace TapirGrasshopperPlugin.Components.ElementsComponents
 {
-    public class ModifyColumnsComponent : JsonItemsExecutorComponent
+    public class ModifyColumnsComponent : ModifyElementsComponentBase
     {
         public override string CommandName => "ModifyColumns";
 
         public ModifyColumnsComponent()
             : base(
                 "ModifyColumns",
-                "Modify Column elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"height\":3.0}.",
+                "Modify Column elements. Only the connected optional inputs are changed on the elements.",
                 GroupNames.ElementModification,
                 "columnsWithDetails",
-                "ItemsData",
-                "One JSON object per item, matching the command's documented item schema (see component description).")
+                new List<Field>
+                {
+                    new Field("Origins", "origin", FieldKind.Point2D, "New origin of the column (only X and Y are used)."),
+                    new Field("ZCoordinates", "zCoordinate", FieldKind.Number, "Bottom level of the column."),
+                    new Field("Heights", "height", FieldKind.Number, "Height of the column."),
+                    new Field("BottomOffsets", "bottomOffset", FieldKind.Number, "Vertical offset of the column bottom from the home story level."),
+                    new Field("AxisRotationAngles", "axisRotationAngle", FieldKind.Number, "Rotation angle of the column axis in radians.")
+                })
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyDoorsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyDoorsComponent.cs
@@ -1,19 +1,28 @@
 using System;
+using System.Collections.Generic;
 
 namespace TapirGrasshopperPlugin.Components.ElementsComponents
 {
-    public class ModifyDoorsComponent : JsonItemsExecutorComponent
+    public class ModifyDoorsComponent : ModifyElementsComponentBase
     {
         public override string CommandName => "ModifyDoors";
 
         public ModifyDoorsComponent()
             : base(
                 "ModifyDoors",
-                "Modify Door elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"position\":1.5}.",
+                "Modify Door elements. Only the connected optional inputs are changed on the elements.",
                 GroupNames.ElementModification,
                 "doorsWithDetails",
-                "ItemsData",
-                "One JSON object per item, matching the command's documented item schema (see component description).")
+                new List<Field>
+                {
+                    new Field("Widths", "width", FieldKind.Number, "Width of the door."),
+                    new Field("Heights", "height", FieldKind.Number, "Height of the door."),
+                    new Field("SillHeights", "sillHeight", FieldKind.Number, "Sill height of the door."),
+                    new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the door center from the beginning point of the owner wall."),
+                    new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the door on its vertical axis."),
+                    new Field("RefSide", "refSide", FieldKind.Boolean, "Place the door on the reference line side of the owner wall."),
+                    new Field("OSide", "oSide", FieldKind.Boolean, "Place the door on the side opposite to the reference line of the owner wall.")
+                })
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMeshesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMeshesComponent.cs
@@ -1,19 +1,32 @@
 using System;
+using System.Collections.Generic;
 
 namespace TapirGrasshopperPlugin.Components.ElementsComponents
 {
-    public class ModifyMeshesComponent : JsonItemsExecutorComponent
+    public class ModifyMeshesComponent : ModifyElementsComponentBase
     {
         public override string CommandName => "ModifyMeshes";
 
         public ModifyMeshesComponent()
             : base(
                 "ModifyMeshes",
-                "Modify the attributes of Mesh elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},...}.",
+                "Modify Mesh elements. Only the connected optional inputs are changed on the elements. " +
+                "The boundary polygon, holes and sublines can be modified through the AdditionalSettings " +
+                "input (polygonCoordinates, polygonArcs, holes, sublines).",
                 GroupNames.ElementModification,
                 "meshesData",
-                "ItemsData",
-                "One JSON object per item, matching the command's documented item schema (see component description).")
+                new List<Field>
+                {
+                    new Field("Levels", "level", FieldKind.Number, "Z reference level of the mesh coordinates."),
+                    new Field("SkirtTypes", "skirtType", FieldKind.Text, "Skirt type: SurfaceOnlyWithoutSkirt, WithSkirt or SolidBodyWithSkirt."),
+                    new Field("SkirtLevels", "skirtLevel", FieldKind.Number, "Height of the mesh skirt."),
+                    new Field("Ridges", "ridges", FieldKind.Text, "Ridge type: AllSharp, AllSmooth or UserDefined."),
+                    new Field("ShowLines", "showLines", FieldKind.Boolean, "Show the secondary mesh lines on the floor plan."),
+                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the mesh."),
+                    new Field("ContourPens", "contourPen", FieldKind.Integer, "Pen index of the mesh contour."),
+                    new Field("LevelPens", "levelPen", FieldKind.Integer, "Pen index of the mesh level lines.")
+                },
+                itemWrapKey: "meshData")
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMorphsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMorphsComponent.cs
@@ -1,19 +1,30 @@
 using System;
+using System.Collections.Generic;
 
 namespace TapirGrasshopperPlugin.Components.ElementsComponents
 {
-    public class ModifyMorphsComponent : JsonItemsExecutorComponent
+    public class ModifyMorphsComponent : ModifyElementsComponentBase
     {
         public override string CommandName => "ModifyMorphs";
 
         public ModifyMorphsComponent()
             : base(
                 "ModifyMorphs",
-                "Modify Morph elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},...}.",
+                "Modify Morph elements. Only the connected optional inputs are changed on the elements. " +
+                "The body geometry, floor plan display and texture settings can be modified through the " +
+                "AdditionalSettings input (body, showContour, displayOption, coverFillType, etc.).",
                 GroupNames.ElementModification,
                 "morphsWithDetails",
-                "ItemsData",
-                "One JSON object per item, matching the command's documented item schema (see component description).")
+                new List<Field>
+                {
+                    new Field("Translations", "translation", FieldKind.Point3D, "Translation vector applied to the morph."),
+                    new Field("RotationDegreesZ", "rotationDegreesZ", FieldKind.Number, "Rotation around the vertical axis in degrees."),
+                    new Field("Levels", "level", FieldKind.Number, "Base level of the morph relative to the home story."),
+                    new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute of the morph body."),
+                    new Field("SurfaceGuids", "surfaceId", FieldKind.AttributeGuid, "Surface attribute override of the morph body."),
+                    new Field("CastShadows", "castShadow", FieldKind.Boolean, "The morph casts shadow in 3D."),
+                    new Field("ReceiveShadows", "receiveShadow", FieldKind.Boolean, "The morph receives shadow in 3D.")
+                })
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyRoofsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyRoofsComponent.cs
@@ -1,19 +1,29 @@
 using System;
+using System.Collections.Generic;
 
 namespace TapirGrasshopperPlugin.Components.ElementsComponents
 {
-    public class ModifyRoofsComponent : JsonItemsExecutorComponent
+    public class ModifyRoofsComponent : ModifyElementsComponentBase
     {
         public override string CommandName => "ModifyRoofs";
 
         public ModifyRoofsComponent()
             : base(
                 "ModifyRoofs",
-                "Modify multi-plane Roof elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},...}.",
+                "Modify multi-plane Roof elements. Only the connected optional inputs are changed on the elements. " +
+                "The roof levels, the outline polygon and holes can be modified through the AdditionalSettings " +
+                "input (levels, polygonOutline, polygonArcs, holes).",
                 GroupNames.ElementModification,
                 "roofsWithDetails",
-                "ItemsData",
-                "One JSON object per item, matching the command's documented item schema (see component description).")
+                new List<Field>
+                {
+                    new Field("Levels", "level", FieldKind.Number, "Reference level of the roof."),
+                    new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the roof."),
+                    new Field("EavesOverhangs", "eavesOverhang", FieldKind.Number, "Eaves overhang of the roof."),
+                    new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic or Composite."),
+                    new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
+                    new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure.")
+                })
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifySlabsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifySlabsComponent.cs
@@ -1,19 +1,28 @@
 using System;
+using System.Collections.Generic;
 
 namespace TapirGrasshopperPlugin.Components.ElementsComponents
 {
-    public class ModifySlabsComponent : JsonItemsExecutorComponent
+    public class ModifySlabsComponent : ModifyElementsComponentBase
     {
         public override string CommandName => "ModifySlabs";
 
         public ModifySlabsComponent()
             : base(
                 "ModifySlabs",
-                "Modify Slab elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"level\":0.0}.",
+                "Modify Slab elements. Only the connected optional inputs are changed on the elements. " +
+                "The outline polygon and holes can be modified through the AdditionalSettings input " +
+                "(polygonOutline, polygonArcs, holes).",
                 GroupNames.ElementModification,
                 "slabsWithDetails",
-                "ItemsData",
-                "One JSON object per item, matching the command's documented item schema (see component description).")
+                new List<Field>
+                {
+                    new Field("ZCoordinates", "zCoordinate", FieldKind.Number, "Reference level of the slab."),
+                    new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the slab."),
+                    new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic or Composite."),
+                    new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
+                    new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure.")
+                })
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWallsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWallsComponent.cs
@@ -1,19 +1,32 @@
 using System;
+using System.Collections.Generic;
 
 namespace TapirGrasshopperPlugin.Components.ElementsComponents
 {
-    public class ModifyWallsComponent : JsonItemsExecutorComponent
+    public class ModifyWallsComponent : ModifyElementsComponentBase
     {
         public override string CommandName => "ModifyWalls";
 
         public ModifyWallsComponent()
             : base(
                 "ModifyWalls",
-                "Modify Wall elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"height\":3.0}.",
+                "Modify Wall elements. Only the connected optional inputs are changed on the elements.",
                 GroupNames.ElementModification,
                 "wallsWithDetails",
-                "ItemsData",
-                "One JSON object per item, matching the command's documented item schema (see component description).")
+                new List<Field>
+                {
+                    new Field("BegPoints", "begCoordinate", FieldKind.Point2D, "New beginning point of the wall (only X and Y are used)."),
+                    new Field("EndPoints", "endCoordinate", FieldKind.Point2D, "New end point of the wall (only X and Y are used)."),
+                    new Field("ArcAngles", "arcAngle", FieldKind.Number, "Arc angle in radians; a non-zero value makes the wall curved."),
+                    new Field("Heights", "height", FieldKind.Number, "Height of the wall."),
+                    new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the wall."),
+                    new Field("BottomOffsets", "bottomOffset", FieldKind.Number, "Vertical offset of the wall bottom from the home story level."),
+                    new Field("Offsets", "offset", FieldKind.Number, "Offset of the wall from its reference line."),
+                    new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic, Composite or Profile."),
+                    new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
+                    new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure."),
+                    new Field("ProfileGuids", "profileId", FieldKind.AttributeGuid, "Profile attribute for Profile structure.")
+                })
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWindowsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWindowsComponent.cs
@@ -1,19 +1,28 @@
 using System;
+using System.Collections.Generic;
 
 namespace TapirGrasshopperPlugin.Components.ElementsComponents
 {
-    public class ModifyWindowsComponent : JsonItemsExecutorComponent
+    public class ModifyWindowsComponent : ModifyElementsComponentBase
     {
         public override string CommandName => "ModifyWindows";
 
         public ModifyWindowsComponent()
             : base(
                 "ModifyWindows",
-                "Modify Window elements based on the given parameters. Each input item is a JSON object matching the command's documented item schema, e.g. {\"elementId\":{\"guid\":\"...\"},\"position\":1.5}.",
+                "Modify Window elements. Only the connected optional inputs are changed on the elements.",
                 GroupNames.ElementModification,
                 "windowsWithDetails",
-                "ItemsData",
-                "One JSON object per item, matching the command's documented item schema (see component description).")
+                new List<Field>
+                {
+                    new Field("Widths", "width", FieldKind.Number, "Width of the window."),
+                    new Field("Heights", "height", FieldKind.Number, "Height of the window."),
+                    new Field("SillHeights", "sillHeight", FieldKind.Number, "Sill height of the window."),
+                    new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the window center from the beginning point of the owner wall."),
+                    new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the window on its vertical axis."),
+                    new Field("RefSide", "refSide", FieldKind.Boolean, "Place the window on the reference line side of the owner wall."),
+                    new Field("OSide", "oSide", FieldKind.Boolean, "Place the window on the side opposite to the reference line of the owner wall.")
+                })
         {
         }
 

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ModifyElementsComponentBase.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ModifyElementsComponentBase.cs
@@ -1,0 +1,273 @@
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
+using Newtonsoft.Json.Linq;
+using Rhino.Geometry;
+using System;
+using System.Collections.Generic;
+using TapirGrasshopperPlugin.Helps;
+using TapirGrasshopperPlugin.Types.Attributes;
+using TapirGrasshopperPlugin.Types.Element;
+using TapirGrasshopperPlugin.Types.GuidObjects;
+
+namespace TapirGrasshopperPlugin.Components
+{
+    // Shared base for the Modify* element commands. The element ids and the
+    // commonly used detail fields are separate typed inputs; each field input
+    // accepts a single value (applied to every element) or one value per
+    // element. The rarely used or deeply nested fields remain available
+    // through the optional AdditionalSettings JSON input.
+    public abstract class ModifyElementsComponentBase : ArchicadExecutorComponent
+    {
+        protected enum FieldKind
+        {
+            Number,
+            Integer,
+            Boolean,
+            Text,
+            Point2D,
+            Point3D,
+            AttributeGuid
+        }
+
+        protected sealed class Field
+        {
+            public Field(
+                string inputName,
+                string jsonKey,
+                FieldKind kind,
+                string description)
+            {
+                InputName = inputName;
+                JsonKey = jsonKey;
+                Kind = kind;
+                Description = description;
+            }
+
+            public string InputName { get; }
+            public string JsonKey { get; }
+            public FieldKind Kind { get; }
+            public string Description { get; }
+        }
+
+        private readonly string _arrayKey;
+        private readonly string _itemWrapKey;
+        private readonly List<Field> _fields;
+
+        protected ModifyElementsComponentBase(
+            string name,
+            string description,
+            string subCategory,
+            string arrayKey,
+            List<Field> fields,
+            string itemWrapKey = null)
+            : base(
+                name,
+                description,
+                subCategory)
+        {
+            _arrayKey = arrayKey;
+            _itemWrapKey = itemWrapKey;
+            _fields = fields;
+        }
+
+        protected override void AddInputs()
+        {
+            InGenerics(
+                "ElementGuids",
+                "Identifiers of the elements to modify.");
+
+            var index = 1;
+            foreach (var field in _fields)
+            {
+                var description = field.Description +
+                    " Input only 1 to use the same value for all elements. Optional.";
+                switch (field.Kind)
+                {
+                    case FieldKind.Number:
+                        InNumbers(field.InputName, description);
+                        break;
+                    case FieldKind.Integer:
+                        InIntegers(field.InputName, description);
+                        break;
+                    case FieldKind.Boolean:
+                        InBooleans(field.InputName, description);
+                        break;
+                    case FieldKind.Text:
+                        InTexts(field.InputName, description);
+                        break;
+                    case FieldKind.Point2D:
+                    case FieldKind.Point3D:
+                        InPoints(field.InputName, description);
+                        break;
+                    case FieldKind.AttributeGuid:
+                        InGenerics(field.InputName, description);
+                        break;
+                }
+
+                SetOptionality(index);
+                index++;
+            }
+
+            InTexts(
+                "AdditionalSettings",
+                "One JSON object per element with further optional settings matching the " +
+                "command's documented item schema. Input only 1 to use the same settings for all. Optional.");
+            SetOptionality(index);
+        }
+
+        private bool TryApply<T>(
+            IGH_DataAccess da,
+            int inputIndex,
+            string inputName,
+            IReadOnlyList<JObject> targets,
+            Func<T, JToken> convert)
+        {
+            var values = new List<T>();
+            da.GetDataList(inputIndex, values);
+
+            if (values.Count == 0)
+            {
+                return true;
+            }
+
+            if (values.Count != 1 && values.Count != targets.Count)
+            {
+                this.AddError(
+                    $"The size of the input {inputName} must be 0, 1 or equal to the size of the input ElementGuids.");
+                return false;
+            }
+
+            var field = _fields[inputIndex - 1];
+            for (var i = 0; i < targets.Count; i++)
+            {
+                var token = convert(values[values.Count == 1 ? 0 : i]);
+                if (token == null)
+                {
+                    this.AddError(
+                        $"Invalid value in the {inputName} input.");
+                    return false;
+                }
+                targets[i][field.JsonKey] = token;
+            }
+
+            return true;
+        }
+
+        protected override void Solve(
+            IGH_DataAccess da)
+        {
+            if (!da.TryCreateFromList(
+                    0,
+                    out ElementsObject elements))
+            {
+                return;
+            }
+
+            var items = new JArray();
+            var targets = new List<JObject>();
+            foreach (var element in elements.Elements)
+            {
+                var item = JObject.FromObject(element);
+                if (_itemWrapKey != null)
+                {
+                    var wrapped = new JObject();
+                    item[_itemWrapKey] = wrapped;
+                    targets.Add(wrapped);
+                }
+                else
+                {
+                    targets.Add(item);
+                }
+                items.Add(item);
+            }
+
+            for (var fieldIndex = 0; fieldIndex < _fields.Count; fieldIndex++)
+            {
+                var field = _fields[fieldIndex];
+                var inputIndex = fieldIndex + 1;
+                bool ok;
+                switch (field.Kind)
+                {
+                    case FieldKind.Number:
+                        ok = TryApply<double>(da, inputIndex, field.InputName, targets, v => v);
+                        break;
+                    case FieldKind.Integer:
+                        ok = TryApply<int>(da, inputIndex, field.InputName, targets, v => v);
+                        break;
+                    case FieldKind.Boolean:
+                        ok = TryApply<bool>(da, inputIndex, field.InputName, targets, v => v);
+                        break;
+                    case FieldKind.Text:
+                        ok = TryApply<string>(da, inputIndex, field.InputName, targets, v => v);
+                        break;
+                    case FieldKind.Point2D:
+                        ok = TryApply<Point3d>(da, inputIndex, field.InputName, targets, v =>
+                            new JObject { ["x"] = v.X, ["y"] = v.Y });
+                        break;
+                    case FieldKind.Point3D:
+                        ok = TryApply<Point3d>(da, inputIndex, field.InputName, targets, v =>
+                            new JObject { ["x"] = v.X, ["y"] = v.Y, ["z"] = v.Z });
+                        break;
+                    case FieldKind.AttributeGuid:
+                        ok = TryApply<GH_ObjectWrapper>(da, inputIndex, field.InputName, targets, v =>
+                        {
+                            var id = GuidObject<AttributeGuidObject>.CreateFromWrapper(v);
+                            return id == null
+                                ? null
+                                : new JObject { ["guid"] = id.Guid };
+                        });
+                        break;
+                    default:
+                        ok = true;
+                        break;
+                }
+
+                if (!ok)
+                {
+                    return;
+                }
+            }
+
+            var additionalSettings = new List<string>();
+            da.GetDataList(_fields.Count + 1, additionalSettings);
+            if (additionalSettings.Count > 0)
+            {
+                if (additionalSettings.Count != 1 &&
+                    additionalSettings.Count != targets.Count)
+                {
+                    this.AddError(
+                        "The size of the input AdditionalSettings must be 0, 1 or equal to the size of the input ElementGuids.");
+                    return;
+                }
+
+                for (var i = 0; i < targets.Count; i++)
+                {
+                    var json = additionalSettings[additionalSettings.Count == 1 ? 0 : i];
+                    try
+                    {
+                        targets[i].Merge(
+                            JObject.Parse(json),
+                            new JsonMergeSettings
+                            {
+                                MergeArrayHandling = MergeArrayHandling.Replace
+                            });
+                    }
+                    catch (Exception ex)
+                    {
+                        this.AddError(
+                            $"Invalid JSON in the AdditionalSettings input: {ex.Message}");
+                        return;
+                    }
+                }
+            }
+
+            var parameters = new JObject { [_arrayKey] = items };
+
+            TryGetCadResponse(
+                CommandName,
+                parameters,
+                ToAddOn,
+                out _);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #490.

The nine Modify* Grasshopper components (`ModifyWalls`, `ModifyBeams`, `ModifyColumns`, `ModifyDoors`, `ModifyMeshes`, `ModifyWindows`, `ModifyMorphs`, `ModifyRoofs`, `ModifySlabs`) previously exposed a single `ItemsData` JSON text input, which was impossible to use without reading the command schema. They now expose:

- **ElementGuids** - identifiers of the elements to modify (same generic input as the other element components), and
- **separate typed optional inputs** for the commonly used fields of each command (numbers, booleans, integers, texts, points and attribute guids). Each input follows the same 0/1/N rule as the Create components: supply one value to apply it to every element, or one value per element. Only connected inputs are changed on the elements.
- an optional **AdditionalSettings** JSON input (one object per element, or one for all) for the rarely used or deeply nested fields - slab/roof outline polygons and holes, roof `levels`, morph `body`/display/texture settings, mesh `polygonCoordinates`/`sublines` - merged into each item, so the full command schema remains reachable.

Examples of the new typed inputs: ModifyWalls gets BegPoints, EndPoints, ArcAngles, Heights, Thicknesses, BottomOffsets, Offsets, StructureTypes, BuildingMaterialGuids, CompositeGuids, ProfileGuids; ModifyWindows/Doors get Widths, Heights, SillHeights, CenterOffsets, Reflected, RefSide, OSide; ModifyMeshes gets Levels, SkirtTypes, SkirtLevels, Ridges, ShowLines, FloorIndices, ContourPens, LevelPens (written into the command's nested `meshData` object).

## Implementation

- New `Components/ModifyElementsComponentBase.cs`: declarative shared base - subclasses list their fields (input name, JSON key, kind, description); the base creates the inputs, enforces the 0/1/N pairing, builds the per-element JSON items and merges AdditionalSettings. ModifyMeshes uses the base's `itemWrapKey` to target the nested `meshData` object.
- The nine components are now thin field lists. Component GUIDs, names and icons are unchanged. Existing definitions that used the old single-JSON input need rewiring (the input set changed), which is the point of the issue.
- `JsonItemsExecutorComponent` is untouched - other components still use it.

## Test plan

- [x] `dotnet build TapirGrasshopperPlugin.sln` succeeds with 0 warnings/errors
- [ ] In Grasshopper: modify a wall's height/thickness with single and per-element values, check the 0/1/N size validation error, and verify AdditionalSettings still reaches the command (e.g. slab polygonOutline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
