### PR TITLE
Fix the add-on auto-update on macOS

### DIFF
--- a/archicad-addon/Tools/update_addon_and_restart_archicad.py
+++ b/archicad-addon/Tools/update_addon_and_restart_archicad.py
@@ -25,16 +25,30 @@ def RunTapirCommand (host, port, command):
         }
     }
     request_string = json.dumps (request_data).encode ('utf8')
-    response_data = urllib.request.urlopen (connection_object, request_string)
+    response_data = urllib.request.urlopen (connection_object, request_string, timeout=10)
     response_json = json.loads (response_data.read())
     return response_json['result']['addOnCommandResponse']
 
 def QuitArchicad (host, port):
     archicadLocation = RunTapirCommand (host, port, 'GetArchicadLocation')['archicadLocation']
-    if IsUsingMacOS ():
-        return f"{archicadLocation}/Contents/MacOS/ARCHICAD"
-    RunTapirCommand (host, port, 'QuitArchicad')
+    try:
+        RunTapirCommand (host, port, 'QuitArchicad')
+    except Exception:
+        pass # the connection may drop while Archicad is quitting
     return archicadLocation
+
+def WaitForArchicadToQuit (host, port, maxRetries = 60):
+    # On Windows the file replacement below fails while Archicad still locks
+    # the add-on, so the retry loop is enough to wait. On macOS the files of a
+    # running process can be overwritten, so the shutdown must be awaited
+    # explicitly, otherwise Archicad would be relaunched while the old
+    # instance is still running.
+    for _ in range (maxRetries):
+        try:
+            RunTapirCommand (host, port, 'GetAddOnVersion')
+        except Exception:
+            return
+        time.sleep (1)
 
 def main():
     parser = argparse.ArgumentParser()
@@ -49,13 +63,19 @@ def main():
     downloadedFile, headers = urllib.request.urlretrieve (args.downloadUrl)
 
     archicadLocation = QuitArchicad (host, port)
+    WaitForArchicadToQuit (host, port)
 
     maxRetries = 20
     for attempt in range(maxRetries):
         try:
             if downloadedFile.endswith ('.zip'):
-                with zipfile.ZipFile (downloadedFile, 'r') as zip_ref:
-                    zip_ref.extractall (os.path.dirname (args.addOnLocation))
+                if IsUsingMacOS ():
+                    # ditto keeps the permission bits and symlinks of the
+                    # bundle, which zipfile.extractall would drop.
+                    subprocess.run (['ditto', '-x', '-k', downloadedFile, os.path.dirname (args.addOnLocation)], check=True)
+                else:
+                    with zipfile.ZipFile (downloadedFile, 'r') as zip_ref:
+                        zip_ref.extractall (os.path.dirname (args.addOnLocation))
             else:
                 shutil.copyfile(downloadedFile, args.addOnLocation)
             break
@@ -64,7 +84,13 @@ def main():
                 raise
             time.sleep(1)
 
-    subprocess.Popen ([archicadLocation], shell=True)
+    # A list argument combined with shell=True must be avoided: on POSIX it
+    # runs 'sh -c <first item>', and the Archicad path contains spaces, so the
+    # shell would split it into multiple words.
+    if IsUsingMacOS ():
+        subprocess.Popen (['open', archicadLocation])
+    else:
+        subprocess.Popen ([archicadLocation])
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary

Fixes #489 ("Update and Restart Archicad" does nothing on macOS).

The palette downloads `Tools/update_addon_and_restart_archicad.py` from `main` and runs it detached via `uv`, so failures in the script are invisible to the user. The script had three macOS-specific defects:

1. **Archicad was never quit.** `QuitArchicad ()` returned early in its macOS branch (before sending the `QuitArchicad` command), so nothing visible happened - exactly what the issue reports.
2. **The relaunch could not work.** `subprocess.Popen ([archicadLocation], shell=True)` with a *list* argument on POSIX runs `sh -c "<path>"`, and every real Archicad path contains spaces, so the shell split it apart. The relaunch now uses `open <app bundle>` on macOS (handles spaces and LaunchServices activation) and a plain argument list on Windows.
3. **Nothing waited for Archicad to terminate.** On Windows the file-replacement retry loop waits implicitly because the loaded add-on file is locked; on macOS files of a running process can be overwritten, so the script would have replaced the bundle and "relaunched" while the old instance was still shutting down. A new `WaitForArchicadToQuit` polls the JSON port (with a request timeout) until the connection is refused before proceeding.

Additionally, the bundle is now extracted with `ditto -x -k` on macOS instead of `zipfile.extractall`, which drops Unix permission bits and symlinks.

Because the palette always fetches this script from `main` at update time, merging this PR fixes the update flow for existing installs immediately - no add-on release is required.

## Test plan

- [x] `python -m py_compile` passes
- [ ] On a Mac with an older Tapir version: Tapir menu > Check for updates > Update and Restart Archicad - Archicad quits, the bundle is replaced, Archicad relaunches with the new version
- [ ] On Windows: verify the update flow still works (quit is now awaited via the port poll before the retry loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
