### PR TITLE
Fix component base classes configured from constructor parameters

### DIFF
--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ClassificationsComponents/CreateClassificationItemsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ClassificationsComponents/CreateClassificationItemsComponent.cs
@@ -10,15 +10,19 @@ namespace TapirGrasshopperPlugin.Components.ClassificationsComponents
             : base(
                 "CreateClassificationItems",
                 "Create Classification Items in the given Classification Systems based on the given parameters.",
-                GroupNames.Classifications,
-                "newClassificationItems",
-                "NewItems",
-                "One JSON object per classification item, e.g. " +
-                "{\"classificationSystemId\":{\"guid\":\"...\"}," +
-                "\"classificationItemDetails\":{\"id\":\"01\",\"name\":\"...\"}," +
-                "\"parentClassificationItemId\":{\"guid\":\"...\"}}.")
+                GroupNames.Classifications)
         {
         }
+
+        protected override string ArrayKey => "newClassificationItems";
+
+        protected override string InputName => "NewItems";
+
+        protected override string InputDescription =>
+            "One JSON object per classification item, e.g. " +
+            "{\"classificationSystemId\":{\"guid\":\"...\"}," +
+            "\"classificationItemDetails\":{\"id\":\"01\",\"name\":\"...\"}," +
+            "\"parentClassificationItemId\":{\"guid\":\"...\"}}.";
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateClassificationItems;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ClassificationsComponents/CreateClassificationSystemsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ClassificationsComponents/CreateClassificationSystemsComponent.cs
@@ -10,14 +10,18 @@ namespace TapirGrasshopperPlugin.Components.ClassificationsComponents
             : base(
                 "CreateClassificationSystems",
                 "Create Classification Systems including Classification Items based on the given parameters.",
-                GroupNames.Classifications,
-                "classificationSystemsWithItems",
-                "SystemsWithItems",
-                "One JSON object per classification system, e.g. " +
-                "{\"classificationSystem\":{\"name\":\"MySystem\",\"version\":\"1.0\"}," +
-                "\"classificationItems\":[{\"classificationItem\":{\"id\":\"01\",\"name\":\"...\",\"children\":[...]}}]}.")
+                GroupNames.Classifications)
         {
         }
+
+        protected override string ArrayKey => "classificationSystemsWithItems";
+
+        protected override string InputName => "SystemsWithItems";
+
+        protected override string InputDescription =>
+            "One JSON object per classification system, e.g. " +
+            "{\"classificationSystem\":{\"name\":\"MySystem\",\"version\":\"1.0\"}," +
+            "\"classificationItems\":[{\"classificationItem\":{\"id\":\"01\",\"name\":\"...\",\"children\":[...]}}]}.";
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateClassificationSystems;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/CreateElementsComponentBase.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/CreateElementsComponentBase.cs
@@ -19,6 +19,13 @@ namespace TapirGrasshopperPlugin.Components
     // nested fields remain available through the optional AdditionalSettings
     // JSON input. The identifiers of the created elements are returned in the
     // ElementGuids output.
+    //
+    // The configuration is provided through overridable members instead of
+    // constructor parameters on purpose: GH_Component's constructor calls
+    // RegisterInputParams (and thus AddInputs) before the derived
+    // constructor bodies run, so constructor-assigned fields would still be
+    // null at that point. Overrides must not depend on instance state
+    // (return constants or static data).
     public abstract class CreateElementsComponentBase : ArchicadExecutorComponent
     {
         protected enum FieldKind
@@ -64,37 +71,36 @@ namespace TapirGrasshopperPlugin.Components
             public int MinPointsPerBranch { get; }
         }
 
-        private readonly string _arrayKey;
-        private readonly List<Field> _fields;
-        private readonly bool _addAdditionalSettings;
+        // The name of the command's array parameter (e.g. "wallsData").
+        protected abstract string ArrayKey { get; }
 
-        // The first field must be required; it defines the number of created
-        // elements (its list length, or its branch count for tree kinds).
-        // Tree kinds are only supported as the first field. Pass
-        // addAdditionalSettings: false when the typed inputs cover the
-        // command's complete item schema.
+        // The typed fields of the command. The first field must be required;
+        // it defines the number of created elements (its list length, or its
+        // branch count for tree kinds). Tree kinds are only supported as the
+        // first field.
+        protected abstract IReadOnlyList<Field> Fields { get; }
+
+        // Override with false when the typed inputs cover the command's
+        // complete item schema.
+        protected virtual bool HasAdditionalSettingsInput => true;
+
         protected CreateElementsComponentBase(
             string name,
             string description,
-            string subCategory,
-            string arrayKey,
-            List<Field> fields,
-            bool addAdditionalSettings = true)
+            string subCategory)
             : base(
                 name,
                 description,
                 subCategory)
         {
-            _arrayKey = arrayKey;
-            _fields = fields;
-            _addAdditionalSettings = addAdditionalSettings;
         }
 
         protected override void AddInputs()
         {
-            for (var index = 0; index < _fields.Count; index++)
+            var fields = Fields;
+            for (var index = 0; index < fields.Count; index++)
             {
-                var field = _fields[index];
+                var field = fields[index];
                 var description = field.Description;
                 if (index > 0)
                 {
@@ -148,13 +154,13 @@ namespace TapirGrasshopperPlugin.Components
                 }
             }
 
-            if (_addAdditionalSettings)
+            if (HasAdditionalSettingsInput)
             {
                 InTexts(
                     "AdditionalSettings",
                     "One JSON object per element with further optional settings matching the " +
                     "command's documented item schema. Input only 1 to use the same settings for all. Optional.");
-                SetOptionality(_fields.Count);
+                SetOptionality(fields.Count);
             }
         }
 
@@ -372,7 +378,8 @@ namespace TapirGrasshopperPlugin.Components
         protected override void Solve(
             IGH_DataAccess da)
         {
-            var firstField = _fields[0];
+            var fields = Fields;
+            var firstField = fields[0];
             var isTreeFirst = firstField.Kind == FieldKind.PointsTree2D ||
                               firstField.Kind == FieldKind.PointsTree3D;
 
@@ -430,9 +437,9 @@ namespace TapirGrasshopperPlugin.Components
                 }
             }
 
-            for (var fieldIndex = 1; fieldIndex < _fields.Count; fieldIndex++)
+            for (var fieldIndex = 1; fieldIndex < fields.Count; fieldIndex++)
             {
-                var field = _fields[fieldIndex];
+                var field = fields[fieldIndex];
                 if (!TryReadTokens(da, fieldIndex, field, out List<JToken> tokens))
                 {
                     return;
@@ -466,9 +473,9 @@ namespace TapirGrasshopperPlugin.Components
             }
 
             var additionalSettings = new List<string>();
-            if (_addAdditionalSettings)
+            if (HasAdditionalSettingsInput)
             {
-                da.GetDataList(_fields.Count, additionalSettings);
+                da.GetDataList(fields.Count, additionalSettings);
             }
             if (additionalSettings.Count > 0)
             {
@@ -506,7 +513,7 @@ namespace TapirGrasshopperPlugin.Components
             {
                 itemsArray.Add(item);
             }
-            var parameters = new JObject { [_arrayKey] = itemsArray };
+            var parameters = new JObject { [ArrayKey] = itemsArray };
 
             if (!TryGetCadResponse(
                     CommandName,

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateAssociativeDimensionsOnSectionComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateAssociativeDimensionsOnSectionComponent.cs
@@ -13,17 +13,21 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Create associative dimensions on a section database based on a preset. " +
                 "Further options (skinBorderIndices, beginPlane, totalSizePlane, placeOnTop) " +
                 "can be given through the AdditionalSettings input.",
-                GroupNames.ElementCreation,
-                "dimensionsData",
-                new List<Field>
-                {
-                    new Field("SectionElementGuids", "sectionElementId", FieldKind.ElementGuid, "Identifiers of the section elements to dimension on.", required: true),
-                    new Field("ReferencePoints", "referencePoint", FieldKind.Point2D, "Placement point of the dimension line in the section database (only X and Y are used).", required: true),
-                    new Field("Presets", "preset", FieldKind.Text, "Dimensioning preset: WallCompositeFaces, WallSkinBorders, SlabCompositeFaces, SlabSkinBorders, BeamOrColumnRefLineEndPoints, BeamOrColumnBoundingBoxCorners, DoorWindowWallHoleCorners or DoorWindowModelHotspots.", required: true),
-                    new Field("Directions", "direction", FieldKind.Point2D, "Direction of the dimension line (only X and Y are used).")
-                })
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "dimensionsData";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("SectionElementGuids", "sectionElementId", FieldKind.ElementGuid, "Identifiers of the section elements to dimension on.", required: true),
+            new Field("ReferencePoints", "referencePoint", FieldKind.Point2D, "Placement point of the dimension line in the section database (only X and Y are used).", required: true),
+            new Field("Presets", "preset", FieldKind.Text, "Dimensioning preset: WallCompositeFaces, WallSkinBorders, SlabCompositeFaces, SlabSkinBorders, BeamOrColumnRefLineEndPoints, BeamOrColumnBoundingBoxCorners, DoorWindowWallHoleCorners or DoorWindowModelHotspots.", required: true),
+            new Field("Directions", "direction", FieldKind.Point2D, "Direction of the dimension line (only X and Y are used).")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateAssociativeDimensionsOnSection;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateBeamsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateBeamsComponent.cs
@@ -12,23 +12,28 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "CreateBeams",
                 "Create Beam elements based on the given parameters. " +
                 "The Z coordinate of each line's start point is used as the beam's Z coordinate.",
-                GroupNames.ElementCreation,
-                "beamsData",
-                new List<Field>
-                {
-                    new Field("Lines", null, FieldKind.Line, "Reference lines of the beams (start and end point; the start point's Z is used as the beam's Z coordinate).", required: true),
-                    new Field("Widths", "width", FieldKind.Number, "Width of the beam."),
-                    new Field("Heights", "height", FieldKind.Number, "Height of the beam."),
-                    new Field("Offsets", "offset", FieldKind.Number, "Offset of the beam from its reference line."),
-                    new Field("SlantAngles", "slantAngle", FieldKind.Number, "Slant angle of the beam in radians."),
-                    new Field("ArcAngles", "arcAngle", FieldKind.Number, "Arc angle in radians; a non-zero value makes the beam curved."),
-                    new Field("VerticalCurveHeights", "verticalCurveHeight", FieldKind.Number, "Height of the vertical curve of the beam."),
-                    new Field("AnchorPoints", "anchorPoint", FieldKind.Text, "Anchor point: TopLeft, TopCenter, TopRight, MiddleLeft, Center, MiddleRight, BottomLeft, BottomCenter or BottomRight."),
-                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the beam.")
-                },
-                addAdditionalSettings: false)
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "beamsData";
+
+        protected override bool HasAdditionalSettingsInput => false;
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Lines", null, FieldKind.Line, "Reference lines of the beams (start and end point; the start point's Z is used as the beam's Z coordinate).", required: true),
+            new Field("Widths", "width", FieldKind.Number, "Width of the beam."),
+            new Field("Heights", "height", FieldKind.Number, "Height of the beam."),
+            new Field("Offsets", "offset", FieldKind.Number, "Offset of the beam from its reference line."),
+            new Field("SlantAngles", "slantAngle", FieldKind.Number, "Slant angle of the beam in radians."),
+            new Field("ArcAngles", "arcAngle", FieldKind.Number, "Arc angle in radians; a non-zero value makes the beam curved."),
+            new Field("VerticalCurveHeights", "verticalCurveHeight", FieldKind.Number, "Height of the vertical curve of the beam."),
+            new Field("AnchorPoints", "anchorPoint", FieldKind.Text, "Anchor point: TopLeft, TopCenter, TopRight, MiddleLeft, Center, MiddleRight, BottomLeft, BottomCenter or BottomRight."),
+            new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the beam.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateBeams;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateColumnsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateColumnsComponent.cs
@@ -11,21 +11,26 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateColumns",
                 "Create Column elements based on the given parameters.",
-                GroupNames.ElementCreation,
-                "columnsData",
-                new List<Field>
-                {
-                    new Field("Points", "coordinates", FieldKind.Point3D, "Insertion points of the columns.", required: true),
-                    new Field("Heights", "height", FieldKind.Number, "Height of the column."),
-                    new Field("Widths", "width", FieldKind.Number, "Width of the column core."),
-                    new Field("Depths", "depth", FieldKind.Number, "Depth of the column core."),
-                    new Field("AxisRotationAngles", "axisRotationAngle", FieldKind.Number, "Rotation angle of the column axis in radians."),
-                    new Field("CoreAnchors", "coreAnchor", FieldKind.Text, "Core anchor: TopLeft, TopCenter, TopRight, MiddleLeft, Center, MiddleRight, BottomLeft, BottomCenter or BottomRight."),
-                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the column.")
-                },
-                addAdditionalSettings: false)
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "columnsData";
+
+        protected override bool HasAdditionalSettingsInput => false;
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Points", "coordinates", FieldKind.Point3D, "Insertion points of the columns.", required: true),
+            new Field("Heights", "height", FieldKind.Number, "Height of the column."),
+            new Field("Widths", "width", FieldKind.Number, "Width of the column core."),
+            new Field("Depths", "depth", FieldKind.Number, "Depth of the column core."),
+            new Field("AxisRotationAngles", "axisRotationAngle", FieldKind.Number, "Rotation angle of the column axis in radians."),
+            new Field("CoreAnchors", "coreAnchor", FieldKind.Text, "Core anchor: TopLeft, TopCenter, TopRight, MiddleLeft, Center, MiddleRight, BottomLeft, BottomCenter or BottomRight."),
+            new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the column.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateColumns;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateDoorsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateDoorsComponent.cs
@@ -11,23 +11,28 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateDoors",
                 "Create Door elements in the given owner walls.",
-                GroupNames.ElementCreation,
-                "doorsData",
-                new List<Field>
-                {
-                    new Field("OwnerWallGuids", "ownerWallId", FieldKind.ElementGuid, "Identifiers of the walls to place the doors into.", required: true),
-                    new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the door center from the beginning point of the owner wall.", required: true),
-                    new Field("SillHeights", "sillHeight", FieldKind.Number, "Sill height of the door."),
-                    new Field("Widths", "width", FieldKind.Number, "Width of the door."),
-                    new Field("Heights", "height", FieldKind.Number, "Height of the door."),
-                    new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the door on its vertical axis."),
-                    new Field("RefSide", "refSide", FieldKind.Boolean, "Place the door on the reference line side of the owner wall."),
-                    new Field("OSide", "oSide", FieldKind.Boolean, "Place the door on the side opposite to the reference line of the owner wall."),
-                    new Field("FavoriteNames", "favoriteName", FieldKind.Text, "Name of the favorite to use as a base for the door.")
-                },
-                addAdditionalSettings: false)
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "doorsData";
+
+        protected override bool HasAdditionalSettingsInput => false;
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("OwnerWallGuids", "ownerWallId", FieldKind.ElementGuid, "Identifiers of the walls to place the doors into.", required: true),
+            new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the door center from the beginning point of the owner wall.", required: true),
+            new Field("SillHeights", "sillHeight", FieldKind.Number, "Sill height of the door."),
+            new Field("Widths", "width", FieldKind.Number, "Width of the door."),
+            new Field("Heights", "height", FieldKind.Number, "Height of the door."),
+            new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the door on its vertical axis."),
+            new Field("RefSide", "refSide", FieldKind.Boolean, "Place the door on the reference line side of the owner wall."),
+            new Field("OSide", "oSide", FieldKind.Boolean, "Place the door on the side opposite to the reference line of the owner wall."),
+            new Field("FavoriteNames", "favoriteName", FieldKind.Text, "Name of the favorite to use as a base for the door.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateDoors;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateLampsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateLampsComponent.cs
@@ -13,17 +13,21 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Place Lamp elements from the loaded libraries. " +
                 "Dimensions, pens, attributes, visibility and light settings can be given through the " +
                 "AdditionalSettings input (dimensions, pen, surfaceId, visibility, lightIsOn, etc.).",
-                GroupNames.ElementCreation,
-                "lampsData",
-                new List<Field>
-                {
-                    new Field("Points", "coordinates", FieldKind.Point3D, "Insertion points of the lamps.", required: true),
-                    new Field("LibraryPartNames", "libraryPartName", FieldKind.Text, "Name of the library part to place.", required: true),
-                    new Field("Angles", "angle", FieldKind.Number, "Rotation angle in radians."),
-                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the lamp.")
-                })
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "lampsData";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Points", "coordinates", FieldKind.Point3D, "Insertion points of the lamps.", required: true),
+            new Field("LibraryPartNames", "libraryPartName", FieldKind.Text, "Name of the library part to place.", required: true),
+            new Field("Angles", "angle", FieldKind.Number, "Rotation angle in radians."),
+            new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the lamp.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateLamps;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMeshesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMeshesComponent.cs
@@ -13,19 +13,23 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Create Mesh elements based on the given parameters. " +
                 "Holes, arcs and sublines can be given through the AdditionalSettings input " +
                 "(polygonArcs, holes, sublines).",
-                GroupNames.ElementCreation,
-                "meshesData",
-                new List<Field>
-                {
-                    new Field("Polygons", "polygonCoordinates", FieldKind.PointsTree3D, "Boundary points of each mesh (one branch per mesh, at least 3 points).", required: true, minPointsPerBranch: 3),
-                    new Field("Levels", "level", FieldKind.Number, "Z reference level of the mesh coordinates."),
-                    new Field("SkirtTypes", "skirtType", FieldKind.Text, "Skirt type: SurfaceOnlyWithoutSkirt, WithSkirt or SolidBodyWithSkirt."),
-                    new Field("SkirtLevels", "skirtLevel", FieldKind.Number, "Height of the mesh skirt."),
-                    new Field("Ridges", "ridges", FieldKind.Text, "Ridge type: AllSharp, AllSmooth or UserDefined."),
-                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the mesh.")
-                })
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "meshesData";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Polygons", "polygonCoordinates", FieldKind.PointsTree3D, "Boundary points of each mesh (one branch per mesh, at least 3 points).", required: true, minPointsPerBranch: 3),
+            new Field("Levels", "level", FieldKind.Number, "Z reference level of the mesh coordinates."),
+            new Field("SkirtTypes", "skirtType", FieldKind.Text, "Skirt type: SurfaceOnlyWithoutSkirt, WithSkirt or SolidBodyWithSkirt."),
+            new Field("SkirtLevels", "skirtLevel", FieldKind.Number, "Height of the mesh skirt."),
+            new Field("Ridges", "ridges", FieldKind.Text, "Ridge type: AllSharp, AllSmooth or UserDefined."),
+            new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the mesh.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateMeshes;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMorphsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMorphsComponent.cs
@@ -14,21 +14,25 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Either the Sizes input or a body given through the AdditionalSettings input is required. " +
                 "Custom geometry, floor plan display and texture settings can be given through " +
                 "AdditionalSettings (body, displayOption, coverFillType, etc.).",
-                GroupNames.ElementCreation,
-                "morphsData",
-                new List<Field>
-                {
-                    new Field("BasePoints", "basePoint", FieldKind.Point3D, "Base point of each morph.", required: true),
-                    new Field("Sizes", "size", FieldKind.Point3D, "Size of the box shaped morph (X, Y and Z dimensions)."),
-                    new Field("Levels", "level", FieldKind.Number, "Base level of the morph relative to the home story."),
-                    new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute of the morph body."),
-                    new Field("SurfaceGuids", "surfaceId", FieldKind.AttributeGuid, "Surface attribute of the morph body."),
-                    new Field("CastShadows", "castShadow", FieldKind.Boolean, "The morph casts shadow in 3D."),
-                    new Field("ReceiveShadows", "receiveShadow", FieldKind.Boolean, "The morph receives shadow in 3D."),
-                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the morph.")
-                })
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "morphsData";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("BasePoints", "basePoint", FieldKind.Point3D, "Base point of each morph.", required: true),
+            new Field("Sizes", "size", FieldKind.Point3D, "Size of the box shaped morph (X, Y and Z dimensions)."),
+            new Field("Levels", "level", FieldKind.Number, "Base level of the morph relative to the home story."),
+            new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute of the morph body."),
+            new Field("SurfaceGuids", "surfaceId", FieldKind.AttributeGuid, "Surface attribute of the morph body."),
+            new Field("CastShadows", "castShadow", FieldKind.Boolean, "The morph casts shadow in 3D."),
+            new Field("ReceiveShadows", "receiveShadow", FieldKind.Boolean, "The morph receives shadow in 3D."),
+            new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the morph.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateMorphs;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateObjectsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateObjectsComponent.cs
@@ -13,17 +13,21 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Place Object elements from the loaded libraries. " +
                 "Dimensions, pens, attributes and visibility settings can be given through the " +
                 "AdditionalSettings input (dimensions, pen, surfaceId, visibility, etc.).",
-                GroupNames.ElementCreation,
-                "objectsData",
-                new List<Field>
-                {
-                    new Field("Points", "coordinates", FieldKind.Point3D, "Insertion points of the objects.", required: true),
-                    new Field("LibraryPartNames", "libraryPartName", FieldKind.Text, "Name of the library part to place.", required: true),
-                    new Field("Angles", "angle", FieldKind.Number, "Rotation angle in radians."),
-                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the object.")
-                })
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "objectsData";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Points", "coordinates", FieldKind.Point3D, "Insertion points of the objects.", required: true),
+            new Field("LibraryPartNames", "libraryPartName", FieldKind.Text, "Name of the library part to place.", required: true),
+            new Field("Angles", "angle", FieldKind.Number, "Rotation angle in radians."),
+            new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the object.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateObjects;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateOpeningsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateOpeningsComponent.cs
@@ -11,18 +11,23 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateOpenings",
                 "Create Opening elements in the given owner elements (walls, slabs, beams or meshes).",
-                GroupNames.ElementCreation,
-                "openingsData",
-                new List<Field>
-                {
-                    new Field("OwnerElementGuids", "ownerElementId", FieldKind.ElementGuid, "Identifiers of the elements to cut the openings into.", required: true),
-                    new Field("BasePoints", "basePoint", FieldKind.Point3D, "Base point of the opening.", required: true),
-                    new Field("Widths", "width", FieldKind.Number, "Width of the opening."),
-                    new Field("Heights", "height", FieldKind.Number, "Height of the opening.")
-                },
-                addAdditionalSettings: false)
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "openingsData";
+
+        protected override bool HasAdditionalSettingsInput => false;
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("OwnerElementGuids", "ownerElementId", FieldKind.ElementGuid, "Identifiers of the elements to cut the openings into.", required: true),
+            new Field("BasePoints", "basePoint", FieldKind.Point3D, "Base point of the opening.", required: true),
+            new Field("Widths", "width", FieldKind.Number, "Width of the opening."),
+            new Field("Heights", "height", FieldKind.Number, "Height of the opening.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateOpenings;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreatePolylinesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreatePolylinesComponent.cs
@@ -12,18 +12,22 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "CreatePolylines",
                 "Create Polyline elements based on the given parameters. " +
                 "Arcs can be given through the AdditionalSettings input (arcs).",
-                GroupNames.ElementCreation,
-                "polylinesData",
-                new List<Field>
-                {
-                    new Field("Polylines", "coordinates", FieldKind.PointsTree2D, "Points of each polyline (one branch per polyline, at least 2 points; only X and Y are used).", required: true, minPointsPerBranch: 2),
-                    new Field("LayerIndices", "layerIndex", FieldKind.Integer, "Index of the layer of the polyline."),
-                    new Field("LinePenIndices", "linePenIndex", FieldKind.Integer, "Pen index of the polyline."),
-                    new Field("LineTypeIndices", "lineTypeIndex", FieldKind.Integer, "Line type index of the polyline."),
-                    new Field("RoomSeparators", "roomSeparator", FieldKind.Boolean, "The polyline acts as a room separator.")
-                })
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "polylinesData";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Polylines", "coordinates", FieldKind.PointsTree2D, "Points of each polyline (one branch per polyline, at least 2 points; only X and Y are used).", required: true, minPointsPerBranch: 2),
+            new Field("LayerIndices", "layerIndex", FieldKind.Integer, "Index of the layer of the polyline."),
+            new Field("LinePenIndices", "linePenIndex", FieldKind.Integer, "Pen index of the polyline."),
+            new Field("LineTypeIndices", "lineTypeIndex", FieldKind.Integer, "Line type index of the polyline."),
+            new Field("RoomSeparators", "roomSeparator", FieldKind.Boolean, "The polyline acts as a room separator.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreatePolylines;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateRoofsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateRoofsComponent.cs
@@ -13,21 +13,25 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Create multi-plane Roof elements based on the given parameters. " +
                 "Holes, arcs, roof levels and single-plane roofs (pivotLine, angle) can be given " +
                 "through the AdditionalSettings input.",
-                GroupNames.ElementCreation,
-                "roofsData",
-                new List<Field>
-                {
-                    new Field("Polygons", "polygonCoordinates", FieldKind.PointsTree2D, "Outline points of each roof (one branch per roof, at least 3 points; only X and Y are used).", required: true, minPointsPerBranch: 3),
-                    new Field("Levels", "level", FieldKind.Number, "Reference level of the roof.", required: true),
-                    new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the roof."),
-                    new Field("EavesOverhangs", "eavesOverhang", FieldKind.Number, "Eaves overhang of the roof."),
-                    new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic or Composite."),
-                    new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
-                    new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure."),
-                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the roof.")
-                })
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "roofsData";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Polygons", "polygonCoordinates", FieldKind.PointsTree2D, "Outline points of each roof (one branch per roof, at least 3 points; only X and Y are used).", required: true, minPointsPerBranch: 3),
+            new Field("Levels", "level", FieldKind.Number, "Reference level of the roof.", required: true),
+            new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the roof."),
+            new Field("EavesOverhangs", "eavesOverhang", FieldKind.Number, "Eaves overhang of the roof."),
+            new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic or Composite."),
+            new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
+            new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure."),
+            new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the roof.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateRoofs;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateSlabsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateSlabsComponent.cs
@@ -12,18 +12,22 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "CreateSlabs",
                 "Create Slab elements based on the given parameters. " +
                 "Holes and arcs can be given through the AdditionalSettings input (polygonArcs, holes).",
-                GroupNames.ElementCreation,
-                "slabsData",
-                new List<Field>
-                {
-                    new Field("Polygons", "polygonCoordinates", FieldKind.PointsTree2D, "Outline points of each slab (one branch per slab, at least 3 points; only X and Y are used).", required: true, minPointsPerBranch: 3),
-                    new Field("Levels", "level", FieldKind.Number, "The Z coordinate of the reference plane of the slab.", required: true),
-                    new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the slab."),
-                    new Field("ReferencePlaneLocations", "referencePlaneLocation", FieldKind.Text, "Reference plane location: Top, CoreTop, CoreBottom or Bottom."),
-                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the slab.")
-                })
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "slabsData";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Polygons", "polygonCoordinates", FieldKind.PointsTree2D, "Outline points of each slab (one branch per slab, at least 3 points; only X and Y are used).", required: true, minPointsPerBranch: 3),
+            new Field("Levels", "level", FieldKind.Number, "The Z coordinate of the reference plane of the slab.", required: true),
+            new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the slab."),
+            new Field("ReferencePlaneLocations", "referencePlaneLocation", FieldKind.Text, "Reference plane location: Top, CoreTop, CoreBottom or Bottom."),
+            new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the slab.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateSlabs;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateStairsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateStairsComponent.cs
@@ -11,22 +11,27 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateStairs",
                 "Create Stair elements based on the given parameters.",
-                GroupNames.ElementCreation,
-                "stairsData",
-                new List<Field>
-                {
-                    new Field("BaseLines", "baseLinePoints", FieldKind.PointsTree2D, "Base line points of each stair (one branch per stair, at least 2 points; only X and Y are used).", required: true, minPointsPerBranch: 2),
-                    new Field("ZCoordinates", "zCoordinate", FieldKind.Number, "Bottom level of the stair.", required: true),
-                    new Field("TotalHeights", "totalHeight", FieldKind.Number, "Total height of the stair."),
-                    new Field("FlightWidths", "flightWidth", FieldKind.Number, "Width of the stair flight."),
-                    new Field("StepNums", "stepNum", FieldKind.Integer, "Number of steps."),
-                    new Field("RiserHeights", "riserHeight", FieldKind.Number, "Height of the risers."),
-                    new Field("TreadDepths", "treadDepth", FieldKind.Number, "Depth of the treads."),
-                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the stair.")
-                },
-                addAdditionalSettings: false)
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "stairsData";
+
+        protected override bool HasAdditionalSettingsInput => false;
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("BaseLines", "baseLinePoints", FieldKind.PointsTree2D, "Base line points of each stair (one branch per stair, at least 2 points; only X and Y are used).", required: true, minPointsPerBranch: 2),
+            new Field("ZCoordinates", "zCoordinate", FieldKind.Number, "Bottom level of the stair.", required: true),
+            new Field("TotalHeights", "totalHeight", FieldKind.Number, "Total height of the stair."),
+            new Field("FlightWidths", "flightWidth", FieldKind.Number, "Width of the stair flight."),
+            new Field("StepNums", "stepNum", FieldKind.Integer, "Number of steps."),
+            new Field("RiserHeights", "riserHeight", FieldKind.Number, "Height of the risers."),
+            new Field("TreadDepths", "treadDepth", FieldKind.Number, "Depth of the treads."),
+            new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the stair.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateStairs;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateTextsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateTextsComponent.cs
@@ -11,21 +11,26 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateTexts",
                 "Create Text elements based on the given parameters.",
-                GroupNames.ElementCreation,
-                "textsData",
-                new List<Field>
-                {
-                    new Field("Positions", "coordinate", FieldKind.Point3D, "Position of each text element.", required: true),
-                    new Field("Texts", "text", FieldKind.Text, "Content of the text element.", required: true),
-                    new Field("Heights", "height", FieldKind.Number, "Text height in millimeters."),
-                    new Field("Angles", "angle", FieldKind.Number, "Rotation angle in radians."),
-                    new Field("Justifications", "justification", FieldKind.Text, "Justification: Left, Center, Right or Full."),
-                    new Field("Pens", "pen", FieldKind.Integer, "Pen index of the text."),
-                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the text.")
-                },
-                addAdditionalSettings: false)
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "textsData";
+
+        protected override bool HasAdditionalSettingsInput => false;
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Positions", "coordinate", FieldKind.Point3D, "Position of each text element.", required: true),
+            new Field("Texts", "text", FieldKind.Text, "Content of the text element.", required: true),
+            new Field("Heights", "height", FieldKind.Number, "Text height in millimeters."),
+            new Field("Angles", "angle", FieldKind.Number, "Rotation angle in radians."),
+            new Field("Justifications", "justification", FieldKind.Text, "Justification: Left, Center, Right or Full."),
+            new Field("Pens", "pen", FieldKind.Integer, "Pen index of the text."),
+            new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the text.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateTexts;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWallThicknessDimensionsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWallThicknessDimensionsComponent.cs
@@ -11,17 +11,22 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateWallThicknessDimensions",
                 "Create dimensions measuring the thickness of the given walls.",
-                GroupNames.ElementCreation,
-                "dimensionsData",
-                new List<Field>
-                {
-                    new Field("WallGuids", "wallId", FieldKind.ElementGuid, "Identifiers of the walls to dimension.", required: true),
-                    new Field("ReferencePoints", "referencePoint", FieldKind.Point2D, "Point on the wall where the thickness is measured (only X and Y are used).", required: true),
-                    new Field("Directions", "direction", FieldKind.Point2D, "Direction of the dimension line (only X and Y are used).", required: true)
-                },
-                addAdditionalSettings: false)
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "dimensionsData";
+
+        protected override bool HasAdditionalSettingsInput => false;
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("WallGuids", "wallId", FieldKind.ElementGuid, "Identifiers of the walls to dimension.", required: true),
+            new Field("ReferencePoints", "referencePoint", FieldKind.Point2D, "Point on the wall where the thickness is measured (only X and Y are used).", required: true),
+            new Field("Directions", "direction", FieldKind.Point2D, "Direction of the dimension line (only X and Y are used).", required: true)
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateWallThicknessDimensions;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWallsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWallsComponent.cs
@@ -12,25 +12,30 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "CreateWalls",
                 "Create Wall elements based on the given parameters. " +
                 "The Z coordinate of each line's start point is used as the wall's Z coordinate.",
-                GroupNames.ElementCreation,
-                "wallsData",
-                new List<Field>
-                {
-                    new Field("Lines", null, FieldKind.Line, "Reference lines of the walls (start and end point; the start point's Z is used as the wall's Z coordinate).", required: true),
-                    new Field("Heights", "height", FieldKind.Number, "Height of the wall.", required: true),
-                    new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the wall.", required: true),
-                    new Field("Offsets", "offset", FieldKind.Number, "Offset of the wall from its reference line."),
-                    new Field("ArcAngles", "arcAngle", FieldKind.Number, "Arc angle in radians; a non-zero value makes the wall curved."),
-                    new Field("ReferenceLineLocations", "referenceLineLocation", FieldKind.Text, "Reference line location: Outside, Center, Inside, CoreOutside, CoreCenter or CoreInside."),
-                    new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic, Composite or Profile."),
-                    new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
-                    new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure."),
-                    new Field("ProfileGuids", "profileId", FieldKind.AttributeGuid, "Profile attribute for Profile structure."),
-                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the wall.")
-                },
-                addAdditionalSettings: false)
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "wallsData";
+
+        protected override bool HasAdditionalSettingsInput => false;
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Lines", null, FieldKind.Line, "Reference lines of the walls (start and end point; the start point's Z is used as the wall's Z coordinate).", required: true),
+            new Field("Heights", "height", FieldKind.Number, "Height of the wall.", required: true),
+            new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the wall.", required: true),
+            new Field("Offsets", "offset", FieldKind.Number, "Offset of the wall from its reference line."),
+            new Field("ArcAngles", "arcAngle", FieldKind.Number, "Arc angle in radians; a non-zero value makes the wall curved."),
+            new Field("ReferenceLineLocations", "referenceLineLocation", FieldKind.Text, "Reference line location: Outside, Center, Inside, CoreOutside, CoreCenter or CoreInside."),
+            new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic, Composite or Profile."),
+            new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
+            new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure."),
+            new Field("ProfileGuids", "profileId", FieldKind.AttributeGuid, "Profile attribute for Profile structure."),
+            new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the wall.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateWalls;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWindowsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateWindowsComponent.cs
@@ -11,23 +11,28 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateWindows",
                 "Create Window elements in the given owner walls.",
-                GroupNames.ElementCreation,
-                "windowsData",
-                new List<Field>
-                {
-                    new Field("OwnerWallGuids", "ownerWallId", FieldKind.ElementGuid, "Identifiers of the walls to place the windows into.", required: true),
-                    new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the window center from the beginning point of the owner wall.", required: true),
-                    new Field("SillHeights", "sillHeight", FieldKind.Number, "Sill height of the window."),
-                    new Field("Widths", "width", FieldKind.Number, "Width of the window."),
-                    new Field("Heights", "height", FieldKind.Number, "Height of the window."),
-                    new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the window on its vertical axis."),
-                    new Field("RefSide", "refSide", FieldKind.Boolean, "Place the window on the reference line side of the owner wall."),
-                    new Field("OSide", "oSide", FieldKind.Boolean, "Place the window on the side opposite to the reference line of the owner wall."),
-                    new Field("FavoriteNames", "favoriteName", FieldKind.Text, "Name of the favorite to use as a base for the window.")
-                },
-                addAdditionalSettings: false)
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "windowsData";
+
+        protected override bool HasAdditionalSettingsInput => false;
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("OwnerWallGuids", "ownerWallId", FieldKind.ElementGuid, "Identifiers of the walls to place the windows into.", required: true),
+            new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the window center from the beginning point of the owner wall.", required: true),
+            new Field("SillHeights", "sillHeight", FieldKind.Number, "Sill height of the window."),
+            new Field("Widths", "width", FieldKind.Number, "Width of the window."),
+            new Field("Heights", "height", FieldKind.Number, "Height of the window."),
+            new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the window on its vertical axis."),
+            new Field("RefSide", "refSide", FieldKind.Boolean, "Place the window on the reference line side of the owner wall."),
+            new Field("OSide", "oSide", FieldKind.Boolean, "Place the window on the side opposite to the reference line of the owner wall."),
+            new Field("FavoriteNames", "favoriteName", FieldKind.Text, "Name of the favorite to use as a base for the window.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateWindows;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/LabelElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/LabelElementsComponent.cs
@@ -11,20 +11,25 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "LabelElements",
                 "Create Label elements for the given elements.",
-                GroupNames.ElementCreation,
-                "labelsData",
-                new List<Field>
-                {
-                    new Field("ElementGuids", "parentElementId", FieldKind.ElementGuid, "Identifiers of the elements to create labels for.", required: true),
-                    new Field("Texts", "text", FieldKind.Text, "Content of the label (required for text labels)."),
-                    new Field("BegPoints", "begCoordinate", FieldKind.Point2D, "Beginning point of the label pointer line (only X and Y are used)."),
-                    new Field("MidPoints", "midCoordinate", FieldKind.Point2D, "Middle point of the label pointer line (only X and Y are used)."),
-                    new Field("EndPoints", "endCoordinate", FieldKind.Point2D, "End point of the label pointer line (only X and Y are used)."),
-                    new Field("FloorIndices", "floorInd", FieldKind.Number, "Home story index of the label.")
-                },
-                addAdditionalSettings: false)
+                GroupNames.ElementCreation)
         {
         }
+
+        protected override string ArrayKey => "labelsData";
+
+        protected override bool HasAdditionalSettingsInput => false;
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("ElementGuids", "parentElementId", FieldKind.ElementGuid, "Identifiers of the elements to create labels for.", required: true),
+            new Field("Texts", "text", FieldKind.Text, "Content of the label (required for text labels)."),
+            new Field("BegPoints", "begCoordinate", FieldKind.Point2D, "Beginning point of the label pointer line (only X and Y are used)."),
+            new Field("MidPoints", "midCoordinate", FieldKind.Point2D, "Middle point of the label pointer line (only X and Y are used)."),
+            new Field("EndPoints", "endCoordinate", FieldKind.Point2D, "End point of the label pointer line (only X and Y are used)."),
+            new Field("FloorIndices", "floorInd", FieldKind.Number, "Home story index of the label.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.LabelElements;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyBeamsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyBeamsComponent.cs
@@ -11,20 +11,24 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyBeams",
                 "Modify Beam elements. Only the connected optional inputs are changed on the elements.",
-                GroupNames.ElementModification,
-                "beamsWithDetails",
-                new List<Field>
-                {
-                    new Field("BegPoints", "begCoordinate", FieldKind.Point2D, "New beginning point of the beam (only X and Y are used)."),
-                    new Field("EndPoints", "endCoordinate", FieldKind.Point2D, "New end point of the beam (only X and Y are used)."),
-                    new Field("Levels", "level", FieldKind.Number, "Base height of the beam relative to the home story."),
-                    new Field("Offsets", "offset", FieldKind.Number, "Offset of the beam from its reference line."),
-                    new Field("SlantAngles", "slantAngle", FieldKind.Number, "Slant angle of the beam in radians."),
-                    new Field("ArcAngles", "arcAngle", FieldKind.Number, "Arc angle in radians; a non-zero value makes the beam curved."),
-                    new Field("VerticalCurveHeights", "verticalCurveHeight", FieldKind.Number, "Height of the vertical curve of the beam.")
-                })
+                GroupNames.ElementModification)
         {
         }
+
+        protected override string ArrayKey => "beamsWithDetails";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("BegPoints", "begCoordinate", FieldKind.Point2D, "New beginning point of the beam (only X and Y are used)."),
+            new Field("EndPoints", "endCoordinate", FieldKind.Point2D, "New end point of the beam (only X and Y are used)."),
+            new Field("Levels", "level", FieldKind.Number, "Base height of the beam relative to the home story."),
+            new Field("Offsets", "offset", FieldKind.Number, "Offset of the beam from its reference line."),
+            new Field("SlantAngles", "slantAngle", FieldKind.Number, "Slant angle of the beam in radians."),
+            new Field("ArcAngles", "arcAngle", FieldKind.Number, "Arc angle in radians; a non-zero value makes the beam curved."),
+            new Field("VerticalCurveHeights", "verticalCurveHeight", FieldKind.Number, "Height of the vertical curve of the beam.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.ModifyBeams;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyColumnsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyColumnsComponent.cs
@@ -11,18 +11,22 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyColumns",
                 "Modify Column elements. Only the connected optional inputs are changed on the elements.",
-                GroupNames.ElementModification,
-                "columnsWithDetails",
-                new List<Field>
-                {
-                    new Field("Origins", "origin", FieldKind.Point2D, "New origin of the column (only X and Y are used)."),
-                    new Field("ZCoordinates", "zCoordinate", FieldKind.Number, "Bottom level of the column."),
-                    new Field("Heights", "height", FieldKind.Number, "Height of the column."),
-                    new Field("BottomOffsets", "bottomOffset", FieldKind.Number, "Vertical offset of the column bottom from the home story level."),
-                    new Field("AxisRotationAngles", "axisRotationAngle", FieldKind.Number, "Rotation angle of the column axis in radians.")
-                })
+                GroupNames.ElementModification)
         {
         }
+
+        protected override string ArrayKey => "columnsWithDetails";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Origins", "origin", FieldKind.Point2D, "New origin of the column (only X and Y are used)."),
+            new Field("ZCoordinates", "zCoordinate", FieldKind.Number, "Bottom level of the column."),
+            new Field("Heights", "height", FieldKind.Number, "Height of the column."),
+            new Field("BottomOffsets", "bottomOffset", FieldKind.Number, "Vertical offset of the column bottom from the home story level."),
+            new Field("AxisRotationAngles", "axisRotationAngle", FieldKind.Number, "Rotation angle of the column axis in radians.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.ModifyColumns;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyDoorsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyDoorsComponent.cs
@@ -11,20 +11,24 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyDoors",
                 "Modify Door elements. Only the connected optional inputs are changed on the elements.",
-                GroupNames.ElementModification,
-                "doorsWithDetails",
-                new List<Field>
-                {
-                    new Field("Widths", "width", FieldKind.Number, "Width of the door."),
-                    new Field("Heights", "height", FieldKind.Number, "Height of the door."),
-                    new Field("SillHeights", "sillHeight", FieldKind.Number, "Sill height of the door."),
-                    new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the door center from the beginning point of the owner wall."),
-                    new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the door on its vertical axis."),
-                    new Field("RefSide", "refSide", FieldKind.Boolean, "Place the door on the reference line side of the owner wall."),
-                    new Field("OSide", "oSide", FieldKind.Boolean, "Place the door on the side opposite to the reference line of the owner wall.")
-                })
+                GroupNames.ElementModification)
         {
         }
+
+        protected override string ArrayKey => "doorsWithDetails";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Widths", "width", FieldKind.Number, "Width of the door."),
+            new Field("Heights", "height", FieldKind.Number, "Height of the door."),
+            new Field("SillHeights", "sillHeight", FieldKind.Number, "Sill height of the door."),
+            new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the door center from the beginning point of the owner wall."),
+            new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the door on its vertical axis."),
+            new Field("RefSide", "refSide", FieldKind.Boolean, "Place the door on the reference line side of the owner wall."),
+            new Field("OSide", "oSide", FieldKind.Boolean, "Place the door on the side opposite to the reference line of the owner wall.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.ModifyDoors;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMeshesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMeshesComponent.cs
@@ -13,22 +13,27 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Modify Mesh elements. Only the connected optional inputs are changed on the elements. " +
                 "The boundary polygon, holes and sublines can be modified through the AdditionalSettings " +
                 "input (polygonCoordinates, polygonArcs, holes, sublines).",
-                GroupNames.ElementModification,
-                "meshesData",
-                new List<Field>
-                {
-                    new Field("Levels", "level", FieldKind.Number, "Z reference level of the mesh coordinates."),
-                    new Field("SkirtTypes", "skirtType", FieldKind.Text, "Skirt type: SurfaceOnlyWithoutSkirt, WithSkirt or SolidBodyWithSkirt."),
-                    new Field("SkirtLevels", "skirtLevel", FieldKind.Number, "Height of the mesh skirt."),
-                    new Field("Ridges", "ridges", FieldKind.Text, "Ridge type: AllSharp, AllSmooth or UserDefined."),
-                    new Field("ShowLines", "showLines", FieldKind.Boolean, "Show the secondary mesh lines on the floor plan."),
-                    new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the mesh."),
-                    new Field("ContourPens", "contourPen", FieldKind.Integer, "Pen index of the mesh contour."),
-                    new Field("LevelPens", "levelPen", FieldKind.Integer, "Pen index of the mesh level lines.")
-                },
-                itemWrapKey: "meshData")
+                GroupNames.ElementModification)
         {
         }
+
+        protected override string ArrayKey => "meshesData";
+
+        protected override string ItemWrapKey => "meshData";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Levels", "level", FieldKind.Number, "Z reference level of the mesh coordinates."),
+            new Field("SkirtTypes", "skirtType", FieldKind.Text, "Skirt type: SurfaceOnlyWithoutSkirt, WithSkirt or SolidBodyWithSkirt."),
+            new Field("SkirtLevels", "skirtLevel", FieldKind.Number, "Height of the mesh skirt."),
+            new Field("Ridges", "ridges", FieldKind.Text, "Ridge type: AllSharp, AllSmooth or UserDefined."),
+            new Field("ShowLines", "showLines", FieldKind.Boolean, "Show the secondary mesh lines on the floor plan."),
+            new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the mesh."),
+            new Field("ContourPens", "contourPen", FieldKind.Integer, "Pen index of the mesh contour."),
+            new Field("LevelPens", "levelPen", FieldKind.Integer, "Pen index of the mesh level lines.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.ModifyMeshes;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMorphsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyMorphsComponent.cs
@@ -13,20 +13,24 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Modify Morph elements. Only the connected optional inputs are changed on the elements. " +
                 "The body geometry, floor plan display and texture settings can be modified through the " +
                 "AdditionalSettings input (body, showContour, displayOption, coverFillType, etc.).",
-                GroupNames.ElementModification,
-                "morphsWithDetails",
-                new List<Field>
-                {
-                    new Field("Translations", "translation", FieldKind.Point3D, "Translation vector applied to the morph."),
-                    new Field("RotationDegreesZ", "rotationDegreesZ", FieldKind.Number, "Rotation around the vertical axis in degrees."),
-                    new Field("Levels", "level", FieldKind.Number, "Base level of the morph relative to the home story."),
-                    new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute of the morph body."),
-                    new Field("SurfaceGuids", "surfaceId", FieldKind.AttributeGuid, "Surface attribute override of the morph body."),
-                    new Field("CastShadows", "castShadow", FieldKind.Boolean, "The morph casts shadow in 3D."),
-                    new Field("ReceiveShadows", "receiveShadow", FieldKind.Boolean, "The morph receives shadow in 3D.")
-                })
+                GroupNames.ElementModification)
         {
         }
+
+        protected override string ArrayKey => "morphsWithDetails";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Translations", "translation", FieldKind.Point3D, "Translation vector applied to the morph."),
+            new Field("RotationDegreesZ", "rotationDegreesZ", FieldKind.Number, "Rotation around the vertical axis in degrees."),
+            new Field("Levels", "level", FieldKind.Number, "Base level of the morph relative to the home story."),
+            new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute of the morph body."),
+            new Field("SurfaceGuids", "surfaceId", FieldKind.AttributeGuid, "Surface attribute override of the morph body."),
+            new Field("CastShadows", "castShadow", FieldKind.Boolean, "The morph casts shadow in 3D."),
+            new Field("ReceiveShadows", "receiveShadow", FieldKind.Boolean, "The morph receives shadow in 3D.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.ModifyMorphs;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyRoofsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyRoofsComponent.cs
@@ -13,19 +13,23 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Modify multi-plane Roof elements. Only the connected optional inputs are changed on the elements. " +
                 "The roof levels, the outline polygon and holes can be modified through the AdditionalSettings " +
                 "input (levels, polygonOutline, polygonArcs, holes).",
-                GroupNames.ElementModification,
-                "roofsWithDetails",
-                new List<Field>
-                {
-                    new Field("Levels", "level", FieldKind.Number, "Reference level of the roof."),
-                    new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the roof."),
-                    new Field("EavesOverhangs", "eavesOverhang", FieldKind.Number, "Eaves overhang of the roof."),
-                    new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic or Composite."),
-                    new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
-                    new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure.")
-                })
+                GroupNames.ElementModification)
         {
         }
+
+        protected override string ArrayKey => "roofsWithDetails";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Levels", "level", FieldKind.Number, "Reference level of the roof."),
+            new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the roof."),
+            new Field("EavesOverhangs", "eavesOverhang", FieldKind.Number, "Eaves overhang of the roof."),
+            new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic or Composite."),
+            new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
+            new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.ModifyRoofs;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifySlabsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifySlabsComponent.cs
@@ -13,18 +13,22 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Modify Slab elements. Only the connected optional inputs are changed on the elements. " +
                 "The outline polygon and holes can be modified through the AdditionalSettings input " +
                 "(polygonOutline, polygonArcs, holes).",
-                GroupNames.ElementModification,
-                "slabsWithDetails",
-                new List<Field>
-                {
-                    new Field("ZCoordinates", "zCoordinate", FieldKind.Number, "Reference level of the slab."),
-                    new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the slab."),
-                    new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic or Composite."),
-                    new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
-                    new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure.")
-                })
+                GroupNames.ElementModification)
         {
         }
+
+        protected override string ArrayKey => "slabsWithDetails";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("ZCoordinates", "zCoordinate", FieldKind.Number, "Reference level of the slab."),
+            new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the slab."),
+            new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic or Composite."),
+            new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
+            new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.ModifySlabs;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWallsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWallsComponent.cs
@@ -11,24 +11,28 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyWalls",
                 "Modify Wall elements. Only the connected optional inputs are changed on the elements.",
-                GroupNames.ElementModification,
-                "wallsWithDetails",
-                new List<Field>
-                {
-                    new Field("BegPoints", "begCoordinate", FieldKind.Point2D, "New beginning point of the wall (only X and Y are used)."),
-                    new Field("EndPoints", "endCoordinate", FieldKind.Point2D, "New end point of the wall (only X and Y are used)."),
-                    new Field("ArcAngles", "arcAngle", FieldKind.Number, "Arc angle in radians; a non-zero value makes the wall curved."),
-                    new Field("Heights", "height", FieldKind.Number, "Height of the wall."),
-                    new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the wall."),
-                    new Field("BottomOffsets", "bottomOffset", FieldKind.Number, "Vertical offset of the wall bottom from the home story level."),
-                    new Field("Offsets", "offset", FieldKind.Number, "Offset of the wall from its reference line."),
-                    new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic, Composite or Profile."),
-                    new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
-                    new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure."),
-                    new Field("ProfileGuids", "profileId", FieldKind.AttributeGuid, "Profile attribute for Profile structure.")
-                })
+                GroupNames.ElementModification)
         {
         }
+
+        protected override string ArrayKey => "wallsWithDetails";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("BegPoints", "begCoordinate", FieldKind.Point2D, "New beginning point of the wall (only X and Y are used)."),
+            new Field("EndPoints", "endCoordinate", FieldKind.Point2D, "New end point of the wall (only X and Y are used)."),
+            new Field("ArcAngles", "arcAngle", FieldKind.Number, "Arc angle in radians; a non-zero value makes the wall curved."),
+            new Field("Heights", "height", FieldKind.Number, "Height of the wall."),
+            new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the wall."),
+            new Field("BottomOffsets", "bottomOffset", FieldKind.Number, "Vertical offset of the wall bottom from the home story level."),
+            new Field("Offsets", "offset", FieldKind.Number, "Offset of the wall from its reference line."),
+            new Field("StructureTypes", "structureType", FieldKind.Text, "Structure type: Basic, Composite or Profile."),
+            new Field("BuildingMaterialGuids", "buildingMaterialId", FieldKind.AttributeGuid, "Building material attribute for Basic structure."),
+            new Field("CompositeGuids", "compositeId", FieldKind.AttributeGuid, "Composite attribute for Composite structure."),
+            new Field("ProfileGuids", "profileId", FieldKind.AttributeGuid, "Profile attribute for Profile structure.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.ModifyWalls;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWindowsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWindowsComponent.cs
@@ -11,20 +11,24 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "ModifyWindows",
                 "Modify Window elements. Only the connected optional inputs are changed on the elements.",
-                GroupNames.ElementModification,
-                "windowsWithDetails",
-                new List<Field>
-                {
-                    new Field("Widths", "width", FieldKind.Number, "Width of the window."),
-                    new Field("Heights", "height", FieldKind.Number, "Height of the window."),
-                    new Field("SillHeights", "sillHeight", FieldKind.Number, "Sill height of the window."),
-                    new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the window center from the beginning point of the owner wall."),
-                    new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the window on its vertical axis."),
-                    new Field("RefSide", "refSide", FieldKind.Boolean, "Place the window on the reference line side of the owner wall."),
-                    new Field("OSide", "oSide", FieldKind.Boolean, "Place the window on the side opposite to the reference line of the owner wall.")
-                })
+                GroupNames.ElementModification)
         {
         }
+
+        protected override string ArrayKey => "windowsWithDetails";
+
+        private static readonly List<Field> FieldDefinitions = new List<Field>
+        {
+            new Field("Widths", "width", FieldKind.Number, "Width of the window."),
+            new Field("Heights", "height", FieldKind.Number, "Height of the window."),
+            new Field("SillHeights", "sillHeight", FieldKind.Number, "Sill height of the window."),
+            new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the window center from the beginning point of the owner wall."),
+            new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the window on its vertical axis."),
+            new Field("RefSide", "refSide", FieldKind.Boolean, "Place the window on the reference line side of the owner wall."),
+            new Field("OSide", "oSide", FieldKind.Boolean, "Place the window on the side opposite to the reference line of the owner wall.")
+        };
+
+        protected override IReadOnlyList<Field> Fields => FieldDefinitions;
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.ModifyWindows;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/JsonItemsExecutorComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/JsonItemsExecutorComponent.cs
@@ -9,37 +9,40 @@ namespace TapirGrasshopperPlugin.Components
     // Shared base for executor commands whose input is an array of deeply
     // nested objects. Each item is passed as a JSON object matching the
     // command's documented item schema.
+    //
+    // The configuration is provided through overridable members instead of
+    // constructor parameters on purpose: GH_Component's constructor calls
+    // RegisterInputParams (and thus AddInputs) before the derived
+    // constructor bodies run, so constructor-assigned fields would still be
+    // null at that point. Overrides must not depend on instance state.
     public abstract class JsonItemsExecutorComponent : ArchicadExecutorComponent
     {
-        private readonly string _arrayKey;
-        private readonly string _itemWrapKey;
-        private readonly string _inputName;
-        private readonly string _inputDescription;
+        // The name of the command's array parameter (e.g. "subsetsData").
+        protected abstract string ArrayKey { get; }
+
+        // When set, each parsed item is wrapped as { ItemWrapKey: item }.
+        protected virtual string ItemWrapKey => null;
+
+        // Name and description of the JSON text input.
+        protected abstract string InputName { get; }
+        protected abstract string InputDescription { get; }
 
         protected JsonItemsExecutorComponent(
             string name,
             string description,
-            string subCategory,
-            string arrayKey,
-            string inputName,
-            string inputDescription,
-            string itemWrapKey = null)
+            string subCategory)
             : base(
                 name,
                 description,
                 subCategory)
         {
-            _arrayKey = arrayKey;
-            _itemWrapKey = itemWrapKey;
-            _inputName = inputName;
-            _inputDescription = inputDescription;
         }
 
         protected override void AddInputs()
         {
             InTexts(
-                _inputName,
-                _inputDescription);
+                InputName,
+                InputDescription);
         }
 
         protected override void Solve(
@@ -63,13 +66,13 @@ namespace TapirGrasshopperPlugin.Components
                 catch (Exception ex)
                 {
                     this.AddError(
-                        $"Invalid JSON in the {_inputName} input: {ex.Message}");
+                        $"Invalid JSON in the {InputName} input: {ex.Message}");
                     return;
                 }
 
-                if (_itemWrapKey != null)
+                if (ItemWrapKey != null)
                 {
-                    items.Add(new JObject { [_itemWrapKey] = item });
+                    items.Add(new JObject { [ItemWrapKey] = item });
                 }
                 else
                 {
@@ -77,7 +80,7 @@ namespace TapirGrasshopperPlugin.Components
                 }
             }
 
-            var parameters = new JObject { [_arrayKey] = items };
+            var parameters = new JObject { [ArrayKey] = items };
 
             TryGetCadResponse(
                 CommandName,

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ModifyElementsComponentBase.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ModifyElementsComponentBase.cs
@@ -16,6 +16,13 @@ namespace TapirGrasshopperPlugin.Components
     // accepts a single value (applied to every element) or one value per
     // element. The rarely used or deeply nested fields remain available
     // through the optional AdditionalSettings JSON input.
+    //
+    // The configuration is provided through overridable members instead of
+    // constructor parameters on purpose: GH_Component's constructor calls
+    // RegisterInputParams (and thus AddInputs) before the derived
+    // constructor bodies run, so constructor-assigned fields would still be
+    // null at that point. Overrides must not depend on instance state
+    // (return constants or static data).
     public abstract class ModifyElementsComponentBase : ArchicadExecutorComponent
     {
         protected enum FieldKind
@@ -49,25 +56,25 @@ namespace TapirGrasshopperPlugin.Components
             public string Description { get; }
         }
 
-        private readonly string _arrayKey;
-        private readonly string _itemWrapKey;
-        private readonly List<Field> _fields;
+        // The name of the command's array parameter (e.g. "wallsWithDetails").
+        protected abstract string ArrayKey { get; }
+
+        // When set, the field values are written into a nested object with
+        // this key instead of the item itself (e.g. "meshData").
+        protected virtual string ItemWrapKey => null;
+
+        // The typed detail fields of the command.
+        protected abstract IReadOnlyList<Field> Fields { get; }
 
         protected ModifyElementsComponentBase(
             string name,
             string description,
-            string subCategory,
-            string arrayKey,
-            List<Field> fields,
-            string itemWrapKey = null)
+            string subCategory)
             : base(
                 name,
                 description,
                 subCategory)
         {
-            _arrayKey = arrayKey;
-            _itemWrapKey = itemWrapKey;
-            _fields = fields;
         }
 
         protected override void AddInputs()
@@ -77,7 +84,7 @@ namespace TapirGrasshopperPlugin.Components
                 "Identifiers of the elements to modify.");
 
             var index = 1;
-            foreach (var field in _fields)
+            foreach (var field in Fields)
             {
                 var description = field.Description +
                     " Input only 1 to use the same value for all elements. Optional.";
@@ -118,7 +125,7 @@ namespace TapirGrasshopperPlugin.Components
         private bool TryApply<T>(
             IGH_DataAccess da,
             int inputIndex,
-            string inputName,
+            Field field,
             IReadOnlyList<JObject> targets,
             Func<T, JToken> convert)
         {
@@ -133,18 +140,17 @@ namespace TapirGrasshopperPlugin.Components
             if (values.Count != 1 && values.Count != targets.Count)
             {
                 this.AddError(
-                    $"The size of the input {inputName} must be 0, 1 or equal to the size of the input ElementGuids.");
+                    $"The size of the input {field.InputName} must be 0, 1 or equal to the size of the input ElementGuids.");
                 return false;
             }
 
-            var field = _fields[inputIndex - 1];
             for (var i = 0; i < targets.Count; i++)
             {
                 var token = convert(values[values.Count == 1 ? 0 : i]);
                 if (token == null)
                 {
                     this.AddError(
-                        $"Invalid value in the {inputName} input.");
+                        $"Invalid value in the {field.InputName} input.");
                     return false;
                 }
                 targets[i][field.JsonKey] = token;
@@ -163,15 +169,18 @@ namespace TapirGrasshopperPlugin.Components
                 return;
             }
 
+            var fields = Fields;
+            var itemWrapKey = ItemWrapKey;
+
             var items = new JArray();
             var targets = new List<JObject>();
             foreach (var element in elements.Elements)
             {
                 var item = JObject.FromObject(element);
-                if (_itemWrapKey != null)
+                if (itemWrapKey != null)
                 {
                     var wrapped = new JObject();
-                    item[_itemWrapKey] = wrapped;
+                    item[itemWrapKey] = wrapped;
                     targets.Add(wrapped);
                 }
                 else
@@ -181,35 +190,35 @@ namespace TapirGrasshopperPlugin.Components
                 items.Add(item);
             }
 
-            for (var fieldIndex = 0; fieldIndex < _fields.Count; fieldIndex++)
+            for (var fieldIndex = 0; fieldIndex < fields.Count; fieldIndex++)
             {
-                var field = _fields[fieldIndex];
+                var field = fields[fieldIndex];
                 var inputIndex = fieldIndex + 1;
                 bool ok;
                 switch (field.Kind)
                 {
                     case FieldKind.Number:
-                        ok = TryApply<double>(da, inputIndex, field.InputName, targets, v => v);
+                        ok = TryApply<double>(da, inputIndex, field, targets, v => v);
                         break;
                     case FieldKind.Integer:
-                        ok = TryApply<int>(da, inputIndex, field.InputName, targets, v => v);
+                        ok = TryApply<int>(da, inputIndex, field, targets, v => v);
                         break;
                     case FieldKind.Boolean:
-                        ok = TryApply<bool>(da, inputIndex, field.InputName, targets, v => v);
+                        ok = TryApply<bool>(da, inputIndex, field, targets, v => v);
                         break;
                     case FieldKind.Text:
-                        ok = TryApply<string>(da, inputIndex, field.InputName, targets, v => v);
+                        ok = TryApply<string>(da, inputIndex, field, targets, v => v);
                         break;
                     case FieldKind.Point2D:
-                        ok = TryApply<Point3d>(da, inputIndex, field.InputName, targets, v =>
+                        ok = TryApply<Point3d>(da, inputIndex, field, targets, v =>
                             new JObject { ["x"] = v.X, ["y"] = v.Y });
                         break;
                     case FieldKind.Point3D:
-                        ok = TryApply<Point3d>(da, inputIndex, field.InputName, targets, v =>
+                        ok = TryApply<Point3d>(da, inputIndex, field, targets, v =>
                             new JObject { ["x"] = v.X, ["y"] = v.Y, ["z"] = v.Z });
                         break;
                     case FieldKind.AttributeGuid:
-                        ok = TryApply<GH_ObjectWrapper>(da, inputIndex, field.InputName, targets, v =>
+                        ok = TryApply<GH_ObjectWrapper>(da, inputIndex, field, targets, v =>
                         {
                             var id = GuidObject<AttributeGuidObject>.CreateFromWrapper(v);
                             return id == null
@@ -229,7 +238,7 @@ namespace TapirGrasshopperPlugin.Components
             }
 
             var additionalSettings = new List<string>();
-            da.GetDataList(_fields.Count + 1, additionalSettings);
+            da.GetDataList(fields.Count + 1, additionalSettings);
             if (additionalSettings.Count > 0)
             {
                 if (additionalSettings.Count != 1 &&
@@ -261,7 +270,7 @@ namespace TapirGrasshopperPlugin.Components
                 }
             }
 
-            var parameters = new JObject { [_arrayKey] = items };
+            var parameters = new JObject { [ArrayKey] = items };
 
             TryGetCadResponse(
                 CommandName,

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateLayoutSubsetComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateLayoutSubsetComponent.cs
@@ -10,14 +10,18 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
             : base(
                 "CreateLayoutSubset",
                 "Create Layout Book subsets.",
-                GroupNames.Navigator,
-                "subsetsData",
-                "SubsetsData",
-                "One JSON object per subset, e.g. " +
-                "{\"name\":\"My Subset\",\"parentNavigatorItemId\":{\"guid\":\"...\"}," +
-                "\"numberingStyle\":\"1\",\"startAt\":1,\"customNumbering\":false}.")
+                GroupNames.Navigator)
         {
         }
+
+        protected override string ArrayKey => "subsetsData";
+
+        protected override string InputName => "SubsetsData";
+
+        protected override string InputDescription =>
+            "One JSON object per subset, e.g. " +
+            "{\"name\":\"My Subset\",\"parentNavigatorItemId\":{\"guid\":\"...\"}," +
+            "\"numberingStyle\":\"1\",\"startAt\":1,\"customNumbering\":false}.";
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreateLayoutSubset;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/CreatePropertyDefinitionsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/CreatePropertyDefinitionsComponent.cs
@@ -10,15 +10,20 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
             : base(
                 "CreatePropertyDefinitions",
                 "Create Custom Property Definitions based on the given parameters.",
-                GroupNames.Properties,
-                "propertyDefinitions",
-                "PropertyDefinitions",
-                "One JSON object per property definition, e.g. " +
-                "{\"name\":\"MyProperty\",\"description\":\"...\",\"type\":\"string\"," +
-                "\"isEditable\":true,\"defaultValue\":{...},\"availability\":[...],\"group\":{\"name\":\"My Group\"}}.",
-                "propertyDefinition")
+                GroupNames.Properties)
         {
         }
+
+        protected override string ArrayKey => "propertyDefinitions";
+
+        protected override string ItemWrapKey => "propertyDefinition";
+
+        protected override string InputName => "PropertyDefinitions";
+
+        protected override string InputDescription =>
+            "One JSON object per property definition, e.g. " +
+            "{\"name\":\"MyProperty\",\"description\":\"...\",\"type\":\"string\"," +
+            "\"isEditable\":true,\"defaultValue\":{...},\"availability\":[...],\"group\":{\"name\":\"My Group\"}}.";
 
         protected override System.Drawing.Bitmap Icon =>
             Properties.Resources.CreatePropertyDefinitions;


### PR DESCRIPTION
## Summary

Fixes a construction-order bug in the shared Grasshopper component base classes (reported by @tlorantfy): `GH_Component`'s constructor calls `RegisterInputParams` - and through it the `AddInputs()` override - **before** the derived constructor bodies run. The declarative bases (`ModifyElementsComponentBase` from #494, `CreateElementsComponentBase` from #496) and `JsonItemsExecutorComponent` stored their configuration (field lists, array keys, input names) in readonly fields assigned in the constructor body, so `AddInputs` read them while they were still null.

## Fix

The configuration moved from constructor parameters to overridable members, which are safe to call during base construction because the overrides return constants or static data:

- `ModifyElementsComponentBase`: `ArrayKey` (abstract), `ItemWrapKey` (virtual, null), `Fields` (abstract `IReadOnlyList<Field>`).
- `CreateElementsComponentBase`: `ArrayKey`, `Fields`, `HasAdditionalSettingsInput` (virtual, true).
- `JsonItemsExecutorComponent`: `ArrayKey`, `ItemWrapKey`, `InputName`, `InputDescription`.

All 31 derived components now declare their field lists as `private static readonly List<Field> FieldDefinitions` plus property overrides (9 Modify*, 18 creation components, 4 JSON-items components). A comment on each base documents the constructor-order constraint so it is not reintroduced.

No component names, GUIDs, input sets or JSON payloads change - this restores the intended behavior of the previous PRs.

## Test plan

- [x] `dotnet build TapirGrasshopperPlugin.sln` succeeds with 0 warnings/errors
- [ ] In Grasshopper: place a Modify* and a Create* component and verify the inputs appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
