### PR TITLE
Fix duplicated LibPartBasedElementDetails in the GetDetailsOfElements docs

### DIFF
--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -4498,9 +4498,18 @@
         ]
     },
     "ObjectDetails": {
-        "$ref": "#/LibPartBasedElementDetails",
+        "type": "object",
         "description": "Shared shape for Object and Lamp elements (both use the same API_ObjectType struct). lightColor/lightIsOn only apply to Lamps. Per the Archicad SDK's own remarks, per-story visibility (visibility.showRelAbove/showRelBelow) and visibility.linkToSettings.newCreationMode were 'not extended' for Object/Lamp the way they were for other element types - still settable here for schema symmetry, but Archicad may silently ignore them.",
         "properties": {
+            "libPart": {
+                "$ref": "#/LibPartDetails"
+            },
+            "ownerElementId": {
+                "$ref": "#/ElementId"
+            },
+            "ownerElementType": {
+                "$ref": "#/ElementType"
+            },
             "origin": {
                 "$ref": "#/Coordinate3D"
             },
@@ -4617,14 +4626,24 @@
         },
         "additionalProperties": false,
         "required": [
+            "libPart",
             "origin",
             "dimensions",
             "angle"
         ]
     },
     "WindowDoorDetails": {
-        "$ref": "#/LibPartBasedElementDetails",
+        "type": "object",
         "properties": {
+            "libPart": {
+                "$ref": "#/LibPartDetails"
+            },
+            "ownerElementId": {
+                "$ref": "#/ElementId"
+            },
+            "ownerElementType": {
+                "$ref": "#/ElementType"
+            },
             "width": {
                 "type": "number",
                 "description": "Opening width."
@@ -4653,6 +4672,7 @@
         },
         "additionalProperties": false,
         "required": [
+            "libPart",
             "width",
             "height",
             "sillHeight",
@@ -5672,8 +5692,17 @@
         ]
     },
     "LabelDetails": {
-        "$ref": "#/LibPartBasedElementDetails",
+        "type": "object",
         "properties": {
+          "libPart": {
+            "$ref": "#/LibPartDetails"
+          },
+          "ownerElementId": {
+            "$ref": "#/ElementId"
+          },
+          "ownerElementType": {
+            "$ref": "#/ElementType"
+          },
           "begCoordinate": {
             "$ref": "#/Coordinate2D"
           },

--- a/docs/archicad-addon/common_schema_definitions.js
+++ b/docs/archicad-addon/common_schema_definitions.js
@@ -4498,9 +4498,18 @@ var gSchemaDefinitions = {
         ]
     },
     "ObjectDetails": {
-        "$ref": "#/LibPartBasedElementDetails",
+        "type": "object",
         "description": "Shared shape for Object and Lamp elements (both use the same API_ObjectType struct). lightColor/lightIsOn only apply to Lamps. Per the Archicad SDK's own remarks, per-story visibility (visibility.showRelAbove/showRelBelow) and visibility.linkToSettings.newCreationMode were 'not extended' for Object/Lamp the way they were for other element types - still settable here for schema symmetry, but Archicad may silently ignore them.",
         "properties": {
+            "libPart": {
+                "$ref": "#/LibPartDetails"
+            },
+            "ownerElementId": {
+                "$ref": "#/ElementId"
+            },
+            "ownerElementType": {
+                "$ref": "#/ElementType"
+            },
             "origin": {
                 "$ref": "#/Coordinate3D"
             },
@@ -4617,14 +4626,24 @@ var gSchemaDefinitions = {
         },
         "additionalProperties": false,
         "required": [
+            "libPart",
             "origin",
             "dimensions",
             "angle"
         ]
     },
     "WindowDoorDetails": {
-        "$ref": "#/LibPartBasedElementDetails",
+        "type": "object",
         "properties": {
+            "libPart": {
+                "$ref": "#/LibPartDetails"
+            },
+            "ownerElementId": {
+                "$ref": "#/ElementId"
+            },
+            "ownerElementType": {
+                "$ref": "#/ElementType"
+            },
             "width": {
                 "type": "number",
                 "description": "Opening width."
@@ -4653,6 +4672,7 @@ var gSchemaDefinitions = {
         },
         "additionalProperties": false,
         "required": [
+            "libPart",
             "width",
             "height",
             "sillHeight",
@@ -5672,8 +5692,17 @@ var gSchemaDefinitions = {
         ]
     },
     "LabelDetails": {
-        "$ref": "#/LibPartBasedElementDetails",
+        "type": "object",
         "properties": {
+          "libPart": {
+            "$ref": "#/LibPartDetails"
+          },
+          "ownerElementId": {
+            "$ref": "#/ElementId"
+          },
+          "ownerElementType": {
+            "$ref": "#/ElementType"
+          },
           "begCoordinate": {
             "$ref": "#/Coordinate2D"
           },


### PR DESCRIPTION
## Summary

Fixes #426 (GetDetailsOfElements documentation shows `LibPartBasedElementDetails { }` twice).

## Root cause

`ObjectDetails`, `WindowDoorDetails` and `LabelDetails` composed their shared base by putting a top-level `"$ref": "#/LibPartBasedElementDetails"` NEXT TO their own `properties`. Both the documentation renderer (`renderer.js` replaces any node containing `$ref` with the referenced definition, dropping the siblings) and standard JSON Schema ignore siblings of `$ref` - so all three definitions rendered as bare `LibPartBasedElementDetails` entries (the repeats collapse to an empty `{ }`), duplicating the real `LibPartBasedElementDetails` branch of `TypeSpecificDetails`.

## Fix

The three inherited properties (`libPart`, `ownerElementId`, `ownerElementType`) are inlined into each of the three definitions and the top-level `$ref` is removed; `libPart` joins the `required` list of ObjectDetails/WindowDoorDetails (not LabelDetails - text labels have no library part). The generated `docs/archicad-addon/common_schema_definitions.js` is regenerated from the fixed definitions so the live docs are corrected on merge.

This also makes the schemas standard-conforming: under strict JSON Schema semantics the old sibling properties were dead (ignored next to `$ref`), so e.g. `ObjectDetails`' own fields were formally not part of the schema at all.

## Test plan

- [x] Strict duplicate-key JSON validation passes on the schema file
- [ ] Open the docs page, expand GetDetailsOfElements: ObjectDetails / WindowDoorDetails / LabelDetails appear with their full field lists and LibPartBasedElementDetails appears only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)
