### PR TITLE
Let long command names wrap on the mobile docs page

### DIFF
--- a/docs/archicad-addon/style.css
+++ b/docs/archicad-addon/style.css
@@ -144,6 +144,19 @@ code.language-python.hljs {
         width: auto;
     }
 
+    /* Long command names (e.g. GetSubelementsOfHierarchicalElements) were
+       clipped to invisibility by the nowrap + hidden overflow of the header
+       on narrow screens - let them wrap instead. */
+    summary.command_header {
+        white-space: normal;
+        overflow: visible;
+        text-overflow: clip;
+    }
+
+    span.command_name {
+        word-break: break-word;
+    }
+
 }
 
 .footer {


### PR DESCRIPTION
## Summary

Fixes #336. On mobile widths, `summary.command_header` keeps `white-space: nowrap` with `overflow: hidden`, so long command names such as `GetSubelementsOfHierarchicalElements` were clipped out of view in the command list.

## Fix

Inside the existing `max-width: 1000px` media query the header now wraps (`white-space: normal`, visible overflow) and the command name may break mid-word. Desktop rendering is unchanged.

## Test plan

- [ ] Open the docs page with a narrow viewport (or mobile device) and check that `GetSubelementsOfHierarchicalElements` and other long command names are visible, wrapped onto multiple lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
