### PR TITLE
Explain what GetConnectedElements actually returns

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -321,7 +321,7 @@ GSErrCode Initialize (void)
         );
         err |= RegisterCommand<GetConnectedElementsCommand> (
             elementCommands, "1.1.4",
-            "Gets connected elements of the given elements."
+            "Gets the elements hosted by (connected to) the given owner elements, filtered to the given element type: for example the Windows or Doors of a Wall, the frames, panels, junctions and accessories of a Curtain Wall, the risers, treads and structures of a Stair, or the posts, rails and panels of a Railing."
         );
         err |= RegisterCommand<GetRelationsOfElementsCommand> (
             elementCommands, "1.5.7",

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -2269,10 +2269,12 @@ GS::Optional<GS::UniString> GetConnectedElementsCommand::GetInputParametersSchem
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/Elements",
+                "description": "The owner (host) elements whose connected elements are collected, e.g. Walls, Curtain Walls, Stairs or Railings."
             },
             "connectedElementType": {
-                "$ref": "#/ElementType"
+                "$ref": "#/ElementType",
+                "description": "The type of the connected elements to collect, e.g. Window or Door for a Wall owner, or a subelement type of a Curtain Wall, Stair or Railing owner."
             }
         },
         "additionalProperties": false,


### PR DESCRIPTION
## Summary

Fixes #277. The `GetConnectedElements` description was circular ("Gets connected elements of the given elements") and the issue reporter had to dig down to the C++ API reference to learn what it does.

The registered command description and the input schema property descriptions now spell out the owner/hosted relationship: the Windows or Doors of a Wall, the frames/panels/junctions/accessories of a Curtain Wall, the risers/treads/structures of a Stair, and the posts/rails/panels of a Railing, filtered by `connectedElementType`. The generated documentation picks these up on the next regeneration.

## Test plan

- [x] AC29 add-on build succeeds
- [ ] Regenerate the docs and check the GetConnectedElements entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
