### PR TITLE
Fix ModifySlabs crashing/failing on any outline or hole change

### DIFF
--- a/archicad-addon/Examples/test_modify_slabs_exhaustive.py
+++ b/archicad-addon/Examples/test_modify_slabs_exhaustive.py
@@ -1,0 +1,140 @@
+"""
+Exhaustive live test for ModifySlabs: outline point count changes (grow and shrink), hole
+add/remove/clear (including the holes-only shorthand that reuses the current outline), arcs on
+both the main outline and individual holes, and combined multi-field modifications in a single
+call. Covers the exact reproduction steps from issue #452 (a fatal crash on a same-size outline
+resend, and holes-only requests being silently ignored).
+"""
+import aclib
+
+def run(cmd, params=None):
+    return aclib.RunTapirCommand(cmd, params or {}, debug=False)
+
+passes = fails = 0
+created_guids = []
+
+def check(label, expected, got):
+    global passes, fails
+    ok = (got == expected)
+    tag = 'PASS' if ok else 'FAIL'
+    if ok:
+        passes += 1
+    else:
+        fails += 1
+    print(f'  [{tag}] {label}  (expected={expected!r}, got={got!r})')
+
+def cleanup():
+    if created_guids:
+        run('DeleteElements', {'elements': [{'elementId': {'guid': g}} for g in created_guids]})
+
+# =============================================================================
+print('TEST -- issue #452 repro: same-outline resend with holes:[] must clear the hole, not crash')
+# =============================================================================
+outline = [{'x': 0, 'y': 0}, {'x': 10, 'y': 0}, {'x': 10, 'y': 10}, {'x': 0, 'y': 10}]
+hole = [{'x': 3, 'y': 3}, {'x': 6, 'y': 3}, {'x': 6, 'y': 6}, {'x': 3, 'y': 6}]
+r = run('CreateSlabs', {'slabsData': [{'level': 0, 'thickness': 0.3, 'polygonCoordinates': outline, 'holes': [{'polygonOutline': hole}]}]})
+guid = r['elements'][0]['elementId']['guid']
+created_guids.append(guid)
+r2 = run('ModifySlabs', {'slabsWithDetails': [{'elementId': {'guid': guid}, 'polygonOutline': outline, 'holes': []}]})
+check('same-outline + holes:[] succeeds (no crash)', True, r2['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid}}]})['detailsOfElements'][0]['details']
+check('hole cleared', [], d.get('holes', []))
+
+print('TEST -- holes-only shorthand (no polygonOutline) adds a hole back, then clears it again')
+r3 = run('ModifySlabs', {'slabsWithDetails': [{'elementId': {'guid': guid}, 'holes': [{'polygonOutline': hole}]}]})
+check('holes-only add succeeds', True, r3['executionResults'][0].get('success'))
+d2 = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid}}]})['detailsOfElements'][0]['details']
+check('hole present, outline untouched', (1, 5), (len(d2.get('holes', [])), len(d2.get('polygonOutline', []))))
+r4 = run('ModifySlabs', {'slabsWithDetails': [{'elementId': {'guid': guid}, 'holes': []}]})
+check('holes-only clear succeeds', True, r4['executionResults'][0].get('success'))
+print()
+
+# =============================================================================
+print('TEST -- outline point count: increase (4->6) and decrease (6->3)')
+# =============================================================================
+outline2 = [{'x': 20, 'y': 0}, {'x': 30, 'y': 0}, {'x': 30, 'y': 10}, {'x': 20, 'y': 10}]
+r5 = run('CreateSlabs', {'slabsData': [{'level': 0, 'thickness': 0.3, 'polygonCoordinates': outline2}]})
+guid2 = r5['elements'][0]['elementId']['guid']
+created_guids.append(guid2)
+grown = [{'x': 20, 'y': 0}, {'x': 25, 'y': 0}, {'x': 30, 'y': 0}, {'x': 30, 'y': 5}, {'x': 30, 'y': 10}, {'x': 20, 'y': 10}]
+r6 = run('ModifySlabs', {'slabsWithDetails': [{'elementId': {'guid': guid2}, 'polygonOutline': grown}]})
+check('point count 4->6 succeeds', True, r6['executionResults'][0].get('success'))
+d3 = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid2}}]})['detailsOfElements'][0]['details']
+check('6 outline points present', 7, len(d3.get('polygonOutline', [])))  # +1 for closing duplicate
+shrunk = [{'x': 20, 'y': 0}, {'x': 30, 'y': 0}, {'x': 25, 'y': 10}]
+r7 = run('ModifySlabs', {'slabsWithDetails': [{'elementId': {'guid': guid2}, 'polygonOutline': shrunk}]})
+check('point count 6->3 succeeds', True, r7['executionResults'][0].get('success'))
+print()
+
+# =============================================================================
+print('TEST -- multiple holes: add 3 different shapes (one with its own arc), then shrink to 2')
+# =============================================================================
+outline3 = [{'x': 40, 'y': 0}, {'x': 80, 'y': 0}, {'x': 80, 'y': 20}, {'x': 40, 'y': 20}]
+h1 = {'polygonOutline': [{'x': 42, 'y': 2}, {'x': 46, 'y': 2}, {'x': 46, 'y': 6}, {'x': 42, 'y': 6}]}
+h2 = {'polygonOutline': [{'x': 50, 'y': 2}, {'x': 54, 'y': 2}, {'x': 52, 'y': 6}],
+      'polygonArcs': [{'begIndex': 0, 'endIndex': 1, 'arcAngle': 0.4}]}
+h3 = {'polygonOutline': [{'x': 58, 'y': 2}, {'x': 62, 'y': 2}, {'x': 64, 'y': 5}, {'x': 62, 'y': 8}, {'x': 58, 'y': 8}]}
+r8 = run('CreateSlabs', {'slabsData': [{'level': 0, 'thickness': 0.3, 'polygonCoordinates': outline3, 'holes': [h1, h2, h3]}]})
+guid3 = r8['elements'][0]['elementId']['guid']
+created_guids.append(guid3)
+d4 = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid3}}]})['detailsOfElements'][0]['details']
+check('3 holes present after create', 3, len(d4.get('holes', [])))
+arced = [h for h in d4.get('holes', []) if h.get('polygonArcs')]
+check('1 hole has an arc', 1, len(arced))
+r9 = run('ModifySlabs', {'slabsWithDetails': [{'elementId': {'guid': guid3}, 'holes': [h2, h3]}]})
+check('shrink 3 holes to 2 succeeds', True, r9['executionResults'][0].get('success'))
+d5 = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid3}}]})['detailsOfElements'][0]['details']
+check('2 holes remain', 2, len(d5.get('holes', [])))
+print()
+
+# =============================================================================
+print('TEST -- arcs: create with 2 outline arcs, replace with 1 different arc, then clear all arcs')
+# =============================================================================
+outline4 = [{'x': 100, 'y': 0}, {'x': 110, 'y': 0}, {'x': 110, 'y': 10}, {'x': 100, 'y': 10}]
+r10 = run('CreateSlabs', {'slabsData': [{'level': 0, 'thickness': 0.3, 'polygonCoordinates': outline4,
+    'polygonArcs': [{'begIndex': 0, 'endIndex': 1, 'arcAngle': 0.8}, {'begIndex': 2, 'endIndex': 3, 'arcAngle': -0.6}]}]})
+guid4 = r10['elements'][0]['elementId']['guid']
+created_guids.append(guid4)
+d6 = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid4}}]})['detailsOfElements'][0]['details']
+check('2 arcs present after create', 2, len(d6.get('polygonArcs', [])))
+r11 = run('ModifySlabs', {'slabsWithDetails': [{'elementId': {'guid': guid4}, 'polygonOutline': outline4,
+    'polygonArcs': [{'begIndex': 1, 'endIndex': 2, 'arcAngle': 0.9}]}]})
+check('replace with 1 arc succeeds', True, r11['executionResults'][0].get('success'))
+d7 = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid4}}]})['detailsOfElements'][0]['details']
+check('exactly 1 arc remains (old ones do not stick around)', 1, len(d7.get('polygonArcs', [])))
+r12 = run('ModifySlabs', {'slabsWithDetails': [{'elementId': {'guid': guid4}, 'polygonOutline': outline4, 'polygonArcs': []}]})
+check('clear all arcs succeeds', True, r12['executionResults'][0].get('success'))
+d8 = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid4}}]})['detailsOfElements'][0]['details']
+check('no arcs remain', [], d8.get('polygonArcs', []))
+print()
+
+# =============================================================================
+print('TEST -- everything at once: grow outline + new arc + replace hole set (different count/style)')
+# =============================================================================
+outline5 = [{'x': 120, 'y': 0}, {'x': 140, 'y': 0}, {'x': 140, 'y': 20}, {'x': 120, 'y': 20}]
+h5a = {'polygonOutline': [{'x': 122, 'y': 2}, {'x': 126, 'y': 2}, {'x': 126, 'y': 6}, {'x': 122, 'y': 6}]}
+r13 = run('CreateSlabs', {'slabsData': [{'level': 0, 'thickness': 0.3, 'polygonCoordinates': outline5, 'holes': [h5a]}]})
+guid5 = r13['elements'][0]['elementId']['guid']
+created_guids.append(guid5)
+new_outline5 = [{'x': 120, 'y': 0}, {'x': 130, 'y': 0}, {'x': 140, 'y': 0}, {'x': 140, 'y': 20}, {'x': 120, 'y': 20}]
+new_arcs5 = [{'begIndex': 3, 'endIndex': 4, 'arcAngle': 1.1}]
+h5b = {'polygonOutline': [{'x': 130, 'y': 14}, {'x': 136, 'y': 14}, {'x': 136, 'y': 18}, {'x': 130, 'y': 18}],
+       'polygonArcs': [{'begIndex': 1, 'endIndex': 2, 'arcAngle': 0.7}]}
+h5c = {'polygonOutline': [{'x': 122, 'y': 2}, {'x': 126, 'y': 2}, {'x': 126, 'y': 6}, {'x': 122, 'y': 6}, {'x': 122, 'y': 4}]}
+r14 = run('ModifySlabs', {'slabsWithDetails': [{'elementId': {'guid': guid5},
+    'polygonOutline': new_outline5, 'polygonArcs': new_arcs5, 'holes': [h5b, h5c]}]})
+check('combined modify succeeds', True, r14['executionResults'][0].get('success'))
+d9 = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid5}}]})['detailsOfElements'][0]['details']
+check('outline grew to 5 points', 6, len(d9.get('polygonOutline', [])))
+check('1 new outline arc', 1, len(d9.get('polygonArcs', [])))
+check('2 holes (different set/style than before)', 2, len(d9.get('holes', [])))
+print()
+
+cleanup()
+
+print('=' * 60)
+print(f'BILAN :  {passes} PASS  |  {fails} FAIL')
+print('=' * 60)
+if fails:
+    import sys
+    sys.exit(1)

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -956,22 +956,62 @@ GS::Optional<GS::UniString> BuildSlabMemoFromGeometry (
     return {};
 }
 
+// The new-style ACAPI_Polygon_InsertPolyNode/DeletePolyNode/InsertSubPoly/DeleteSubPoly functions
+// (declared in ACAPI_Goodies.h) do not exist before Archicad 27 - confirmed via the DevKit headers
+// directly, AC25/26 have no ACAPI_Goodies.h at all. Pre-27, the same operations are reached through
+// the older, untyped ACAPI_Goodies (API_GoodiesID, void*, void*, void*, void*) dispatcher with the
+// APIAny_*PolyNodeID/APIAny_*SubPolyID constants (APIdefs_Goodies.h) - these wrappers keep
+// ApplySlabPolygonChange version-agnostic, mirroring the TAPIR_Browser_* pattern in
+// ScriptUIPalette.cpp for the same AC25/26-vs-27+ split.
+#ifdef ServerMainVers_2700
+static GSErrCode TAPIR_Polygon_InsertPolyNode (API_ElementMemo* memo, Int32* nodeIndex, API_Coord* coord)
+{
+    return ACAPI_Polygon_InsertPolyNode (memo, nodeIndex, coord);
+}
+static GSErrCode TAPIR_Polygon_DeletePolyNode (API_ElementMemo* memo, Int32* nodeIndex)
+{
+    return ACAPI_Polygon_DeletePolyNode (memo, nodeIndex);
+}
+static GSErrCode TAPIR_Polygon_InsertSubPoly (API_ElementMemo* memo, API_ElementMemo* insMemo)
+{
+    return ACAPI_Polygon_InsertSubPoly (memo, insMemo);
+}
+static GSErrCode TAPIR_Polygon_DeleteSubPoly (API_ElementMemo* memo, Int32* subPolyIndex)
+{
+    return ACAPI_Polygon_DeleteSubPoly (memo, subPolyIndex);
+}
+#else
+static GSErrCode TAPIR_Polygon_InsertPolyNode (API_ElementMemo* memo, Int32* nodeIndex, API_Coord* coord)
+{
+    return ACAPI_Goodies (APIAny_InsertPolyNodeID, memo, nodeIndex, coord);
+}
+static GSErrCode TAPIR_Polygon_DeletePolyNode (API_ElementMemo* memo, Int32* nodeIndex)
+{
+    return ACAPI_Goodies (APIAny_DeletePolyNodeID, memo, nodeIndex);
+}
+static GSErrCode TAPIR_Polygon_InsertSubPoly (API_ElementMemo* memo, API_ElementMemo* insMemo)
+{
+    return ACAPI_Goodies (APIAny_InsertSubPolyID, memo, insMemo);
+}
+static GSErrCode TAPIR_Polygon_DeleteSubPoly (API_ElementMemo* memo, Int32* subPolyIndex)
+{
+    return ACAPI_Goodies (APIAny_DeleteSubPolyID, memo, subPolyIndex);
+}
+#endif
+
 // Applies a new outline/arcs/holes shape to an EXISTING slab's memo (already populated via
-// ACAPI_Element_GetMemo), for use with ACAPI_Element_Change. Mirrors BuildMeshPolyMemoFromGeometry
-// further down in this file (used by ModifyMeshes, and proven working live for exactly this
-// "rebuild a memo obtained from GetMemo" scenario): coords/vertexIDs/edgeTrims/pends/parcs are all
-// plain GS Handles (**) and BMReallocHandle on a non-null GetMemo-provided handle works fine for
-// them. sideMaterials is the sole exception - it is a raw Ptr (*, allocated with
-// BMAllocatePtr/BMReallocPtr, not a Handle), and reallocating a GetMemo-provided one with
-// BMReallocPtr reliably corrupted the heap (a real crash report, issue #452: "Fatal memory error
-// in BMReallocPtr... Requested memory size is 48 bytes" / BNValidWritePtr failure) - confirmed by
-// isolating it as the only field Mesh's own polygon memo doesn't have. sideMaterials alone is
-// freed and reallocated fresh instead (BMKillPtr + BMAllocatePtr). An earlier attempt at this
-// function used Graphisoft's ACAPI_Polygon_InsertPolyNode/DeletePolyNode/InsertSubPoly/
-// DeleteSubPoly primitives (matching the DevKit's Element_Test/Element_Modify_Polygon.cpp
-// reference) instead of a from-scratch rebuild, on the mistaken assumption that BMReallocHandle
-// itself (not just BMReallocPtr) was unsafe on a GetMemo handle - Mesh's own working code disproves
-// that.
+// ACAPI_Element_GetMemo), for use with ACAPI_Element_ChangeMemo. Uses Graphisoft's own
+// polygon-editing primitives - TAPIR_Polygon_InsertPolyNode/DeletePolyNode/InsertSubPoly/
+// DeleteSubPoly above, matching the DevKit's own Element_Test/Element_Modify_Polygon.cpp reference
+// example for these exact element types (including API_SlabID) - to keep the coords/pends/parcs/
+// vertexIDs handles obtained from GetMemo internally consistent under a point/hole count change.
+// A from-scratch memo rebuild (the same approach BuildSlabMemoFromGeometry above uses for a fresh
+// Create) reliably failed with APIERR_BADPOLY via ACAPI_Element_Change here whenever the point or
+// subpoly count actually changed - even with every vertexIDs numbering scheme tried (sequential,
+// per-contour, mirrored closing duplicates) - while these primitives, paired with
+// ACAPI_Element_ChangeMemo and vertexIDs left untouched/zero for new vertices (see
+// API_ElementMemo's own documented convention - existing IDs must never be renumbered, new ones
+// get ID 0 for Archicad to assign), work correctly for every case tested (issue #452).
 static GS::Optional<GS::UniString> ApplySlabPolygonChange (
     API_ElementMemo& memo,
     const API_OverriddenAttribute& sideMat,
@@ -1024,7 +1064,7 @@ static GS::Optional<GS::UniString> ApplySlabPolygonChange (
     const Int32 nSubPolys = (Int32) (BMGetHandleSize ((GSHandle) memo.pends) / sizeof (Int32)) - 1;
     for (Int32 subPolyIndex = nSubPolys; subPolyIndex >= 2; --subPolyIndex) {
         Int32 idx = subPolyIndex;
-        GSErrCode err = ACAPI_Polygon_DeleteSubPoly (&memo, &idx);
+        GSErrCode err = TAPIR_Polygon_DeleteSubPoly (&memo, &idx);
         if (err != NoError) {
             return "Failed to remove an existing slab hole.";
         }
@@ -1037,7 +1077,7 @@ static GS::Optional<GS::UniString> ApplySlabPolygonChange (
     const Int32 desiredOutlineCount = (Int32) polygonOutline.GetSize ();
     while (outlineCount > desiredOutlineCount) {
         Int32 idx = 1;
-        GSErrCode err = ACAPI_Polygon_DeletePolyNode (&memo, &idx);
+        GSErrCode err = TAPIR_Polygon_DeletePolyNode (&memo, &idx);
         if (err != NoError) {
             return "Failed to adjust the slab outline's point count.";
         }
@@ -1053,7 +1093,7 @@ static GS::Optional<GS::UniString> ApplySlabPolygonChange (
         const API_Coord& p1 = (*memo.coords)[1];
         const API_Coord& p2 = (*memo.coords)[2];
         API_Coord placeholder = {(p1.x + p2.x) / 2.0, (p1.y + p2.y) / 2.0};
-        GSErrCode err = ACAPI_Polygon_InsertPolyNode (&memo, &idx, &placeholder);
+        GSErrCode err = TAPIR_Polygon_InsertPolyNode (&memo, &idx, &placeholder);
         if (err != NoError) {
             return "Failed to adjust the slab outline's point count.";
         }
@@ -1114,7 +1154,7 @@ static GS::Optional<GS::UniString> ApplySlabPolygonChange (
                 (*insMemo.parcs)[i] = holeArcs[i];
             }
         }
-        GSErrCode err = ACAPI_Polygon_InsertSubPoly (&memo, &insMemo);
+        GSErrCode err = TAPIR_Polygon_InsertSubPoly (&memo, &insMemo);
         if (err != NoError) {
             return "Failed to add a slab hole.";
         }

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -16,6 +16,7 @@
 #include "Polygon2D.hpp"
 #endif
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <map>
@@ -859,41 +860,71 @@ GS::Optional<GS::UniString> BuildSlabMemoFromGeometry (
     // slabs (e.g. the default slab reports nCoords but leaves memo.coords == nullptr).
     // The original size-change-only guards skipped allocation whenever the requested
     // polygon matched the default size, leaving memo.coords null and crashing
-    // AddPolyToMemo with a null dereference. BMReallocHandle does NOT allocate from a
-    // null handle, so a null handle must be created fresh with BMAllocateHandle (as the
-    // mesh/zone commands do); only an existing handle is resized with BMReallocHandle.
+    // AddPolyToMemo with a null dereference.
+    //
+    // Each handle below is checked independently rather than bundled behind a single
+    // coords-based guard: ACAPI_Element_GetMemo can legitimately return edgeTrims/
+    // sideMaterials/vertexIDs as null even when coords itself is populated (e.g. a slab
+    // that has never had a custom edge trim never materializes memo.edgeTrims), and
+    // AddPolyToMemo below unconditionally writes through edgeTrims/sideMaterials whenever
+    // a non-null override pointer is passed in (as it is here).
+    //
+    // On a real size change, existing handles are freed with BMKillHandle/BMKillPtr and
+    // reallocated fresh, not resized in place with BMReallocHandle/BMReallocPtr - confirmed
+    // via a real crash report (issue #452, "Fatal memory error in BMReallocPtr... Requested
+    // memory size is 48 bytes" / BNValidWritePtr failure) that a handle coming back from
+    // ACAPI_Element_GetMemo is not safe to hand to BMRealloc*, even though it reads back
+    // non-null and its contents are valid. This is the same free-then-allocate pattern
+    // already used for the Stair baseline memo rebuild elsewhere in this file.
     const Int32 nCoords    = element.slab.poly.nCoords;
     const Int32 nSubPolys  = element.slab.poly.nSubPolys;
     const Int32 nArcs      = element.slab.poly.nArcs;
-    const bool  coordsWereNull = (memo.coords == nullptr);
+    const bool  sizeChanged = (oldPoly.nCoords != nCoords);
 
-    if (coordsWereNull) {
-        memo.coords        = reinterpret_cast<API_Coord**>             (BMAllocateHandle ((nCoords + 1) * sizeof (API_Coord),               ALLOCATE_CLEAR, 0));
-        memo.vertexIDs     = reinterpret_cast<UInt32**>                (BMAllocateHandle ((nCoords + 1) * sizeof (API_Coord),               ALLOCATE_CLEAR, 0));
-        memo.edgeTrims     = reinterpret_cast<API_EdgeTrim**>          (BMAllocateHandle ((nCoords + 1) * sizeof (API_EdgeTrim),            ALLOCATE_CLEAR, 0));
-        memo.sideMaterials = reinterpret_cast<API_OverriddenAttribute*>(BMAllocatePtr    ((nCoords + 1) * sizeof (API_OverriddenAttribute), ALLOCATE_CLEAR, 0));
-    } else if (oldPoly.nCoords != nCoords) {
-        memo.coords        = reinterpret_cast<API_Coord**>             (BMReallocHandle (reinterpret_cast<GSHandle> (memo.coords),        (nCoords + 1) * sizeof (API_Coord),               REALLOC_CLEAR, 0));
-        memo.vertexIDs     = reinterpret_cast<UInt32**>                (BMReallocHandle (reinterpret_cast<GSHandle> (memo.vertexIDs),     (nCoords + 1) * sizeof (API_Coord),               REALLOC_CLEAR, 0));
-        memo.edgeTrims     = reinterpret_cast<API_EdgeTrim**>          (BMReallocHandle (reinterpret_cast<GSHandle> (memo.edgeTrims),     (nCoords + 1) * sizeof (API_EdgeTrim),            REALLOC_CLEAR, 0));
-        memo.sideMaterials = reinterpret_cast<API_OverriddenAttribute*>(BMReallocPtr    (reinterpret_cast<GSPtr> (memo.sideMaterials), (nCoords + 1) * sizeof (API_OverriddenAttribute), REALLOC_CLEAR, 0));
+    if (memo.coords != nullptr && sizeChanged) {
+        BMKillHandle (reinterpret_cast<GSHandle*> (&memo.coords));
+    }
+    if (memo.coords == nullptr) {
+        memo.coords = reinterpret_cast<API_Coord**> (BMAllocateHandle ((nCoords + 1) * sizeof (API_Coord), ALLOCATE_CLEAR, 0));
+    }
+    if (memo.vertexIDs != nullptr && sizeChanged) {
+        BMKillHandle (reinterpret_cast<GSHandle*> (&memo.vertexIDs));
+    }
+    if (memo.vertexIDs == nullptr) {
+        memo.vertexIDs = reinterpret_cast<UInt32**> (BMAllocateHandle ((nCoords + 1) * sizeof (API_Coord), ALLOCATE_CLEAR, 0));
+    }
+    if (memo.edgeTrims != nullptr && sizeChanged) {
+        BMKillHandle (reinterpret_cast<GSHandle*> (&memo.edgeTrims));
+    }
+    if (memo.edgeTrims == nullptr) {
+        memo.edgeTrims = reinterpret_cast<API_EdgeTrim**> (BMAllocateHandle ((nCoords + 1) * sizeof (API_EdgeTrim), ALLOCATE_CLEAR, 0));
+    }
+    if (memo.sideMaterials != nullptr && sizeChanged) {
+        BMKillPtr (reinterpret_cast<GSPtr*> (&memo.sideMaterials));
+    }
+    if (memo.sideMaterials == nullptr) {
+        memo.sideMaterials = reinterpret_cast<API_OverriddenAttribute*> (BMAllocatePtr ((nCoords + 1) * sizeof (API_OverriddenAttribute), ALLOCATE_CLEAR, 0));
+    }
+    const bool subPolysChanged = (oldPoly.nSubPolys != nSubPolys);
+    if (memo.pends != nullptr && subPolysChanged) {
+        BMKillHandle (reinterpret_cast<GSHandle*> (&memo.pends));
     }
     if (memo.pends == nullptr) {
         memo.pends = reinterpret_cast<Int32**> (BMAllocateHandle ((nSubPolys + 1) * sizeof (Int32), ALLOCATE_CLEAR, 0));
-    } else if (oldPoly.nSubPolys != nSubPolys) {
-        memo.pends = reinterpret_cast<Int32**> (BMReallocHandle (reinterpret_cast<GSHandle> (memo.pends), (nSubPolys + 1) * sizeof (Int32), REALLOC_CLEAR, 0));
     }
     if (nArcs > 0) {
+        const bool arcsChanged = (oldPoly.nArcs != nArcs);
+        if (memo.parcs != nullptr && arcsChanged) {
+            BMKillHandle (reinterpret_cast<GSHandle*> (&memo.parcs));
+        }
         if (memo.parcs == nullptr) {
             memo.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (nArcs * sizeof (API_PolyArc), ALLOCATE_CLEAR, 0));
-        } else if (oldPoly.nArcs != nArcs) {
-            memo.parcs = reinterpret_cast<API_PolyArc**> (BMReallocHandle (reinterpret_cast<GSHandle> (memo.parcs), nArcs * sizeof (API_PolyArc), REALLOC_CLEAR, 0));
         }
     }
-    const bool needToProcessVertexIDs =
-        coordsWereNull ||
-        oldPoly.nCoords != element.slab.poly.nCoords ||
-        oldPoly.nSubPolys != element.slab.poly.nSubPolys;
+    // Always rewrite vertex IDs: with the free-then-allocate pattern above, any size change
+    // yields freshly zeroed (and therefore always-stale) vertex ID slots, and a same-size
+    // in-place reuse still needs correct IDs recomputed for the new geometry.
+    const bool needToProcessVertexIDs = true;
 
     const API_EdgeTrimID edgeTrimSideType = APIEdgeTrim_Vertical;
     Int32 iCoord = 1;
@@ -907,6 +938,210 @@ GS::Optional<GS::UniString> BuildSlabMemoFromGeometry (
         if (GetHoleGeometry (hole, holePolygonOutline, holePolygonArcs)) {
             AddPolyToMemo (holePolygonOutline, holePolygonArcs, iCoord, iArc, iPends, memo, &edgeTrimSideType, &element.slab.sideMat, needToProcessVertexIDs);
         }
+    }
+
+    // vertexIDs[0] must hold the max vertex ID used across the whole shape - an undocumented
+    // ACAPI_Element_Change requirement (confirmed live in this repo's PolyLine/Hatch geometry
+    // SET work) without which ACAPI_Element_Change rejects the polygon with APIERR_BADPOLY.
+    // AddPolyToMemo never writes index 0 itself, so it is filled in here by scanning the IDs
+    // it did write.
+    if (memo.vertexIDs != nullptr) {
+        UInt32 maxVertexID = 0;
+        for (Int32 i = 1; i <= nCoords; ++i) {
+            maxVertexID = std::max (maxVertexID, (*memo.vertexIDs)[i]);
+        }
+        (*memo.vertexIDs)[0] = maxVertexID;
+    }
+
+    return {};
+}
+
+// Applies a new outline/arcs/holes shape to an EXISTING slab's memo (already populated via
+// ACAPI_Element_GetMemo), for use with ACAPI_Element_Change. Mirrors BuildMeshPolyMemoFromGeometry
+// further down in this file (used by ModifyMeshes, and proven working live for exactly this
+// "rebuild a memo obtained from GetMemo" scenario): coords/vertexIDs/edgeTrims/pends/parcs are all
+// plain GS Handles (**) and BMReallocHandle on a non-null GetMemo-provided handle works fine for
+// them. sideMaterials is the sole exception - it is a raw Ptr (*, allocated with
+// BMAllocatePtr/BMReallocPtr, not a Handle), and reallocating a GetMemo-provided one with
+// BMReallocPtr reliably corrupted the heap (a real crash report, issue #452: "Fatal memory error
+// in BMReallocPtr... Requested memory size is 48 bytes" / BNValidWritePtr failure) - confirmed by
+// isolating it as the only field Mesh's own polygon memo doesn't have. sideMaterials alone is
+// freed and reallocated fresh instead (BMKillPtr + BMAllocatePtr). An earlier attempt at this
+// function used Graphisoft's ACAPI_Polygon_InsertPolyNode/DeletePolyNode/InsertSubPoly/
+// DeleteSubPoly primitives (matching the DevKit's Element_Test/Element_Modify_Polygon.cpp
+// reference) instead of a from-scratch rebuild, on the mistaken assumption that BMReallocHandle
+// itself (not just BMReallocPtr) was unsafe on a GetMemo handle - Mesh's own working code disproves
+// that.
+static GS::Optional<GS::UniString> ApplySlabPolygonChange (
+    API_ElementMemo& memo,
+    const API_OverriddenAttribute& sideMat,
+    GS::Array<GS::ObjectState>& polygonOutline,
+    const GS::Array<GS::ObjectState>& polygonArcs,
+    const GS::Array<GS::ObjectState>& holes)
+{
+    if (polygonOutline.GetSize () < 3) {
+        return "'polygonOutline' must contain at least 3 coordinates.";
+    }
+    if (IsSame2DCoordinate (polygonOutline.GetFirst (), polygonOutline.GetLast ())) {
+        polygonOutline.Pop ();
+    }
+    if (memo.coords == nullptr || memo.pends == nullptr) {
+        return "Slab has no polygon data to modify.";
+    }
+
+    // A from-scratch memo rebuild (matching CreateSlabs, and BuildMeshPolyMemoFromGeometry's own
+    // proven-working pattern for ModifyMeshes) plus ACAPI_Element_Change reliably fails with
+    // APIERR_BADPOLY here whenever nCoords changes at all - confirmed live on the plain point-count
+    // case alone (no holes involved), so this is not a vertexIDs-numbering issue as first assumed
+    // (tried: global sequential, global with the closing duplicate mirroring the first point, and
+    // per-contour restart - all three failed identically). Graphisoft's own polygon-editing
+    // primitives - ACAPI_Polygon_InsertPolyNode/DeletePolyNode/InsertSubPoly/DeleteSubPoly, used by
+    // the DevKit's own reference example (Element_Test/Element_Modify_Polygon.cpp, targeting the
+    // same element types including API_SlabID) together with ACAPI_Element_ChangeMemo - keep the
+    // existing GetMemo-provided handles' internal consistency intact across a size change, which a
+    // full replacement apparently cannot always reproduce. They document that memo's coords/pends/
+    // parcs/vertexIDs handles "must be initialized"; ACAPI_Element_GetMemo can legitimately leave
+    // vertexIDs/parcs null (e.g. a slab with no per-edge customization/arcs), so those are seeded
+    // here first.
+    if (memo.vertexIDs == nullptr) {
+        // Per Graphisoft's own API_ElementMemo documentation: "If you retrieve an array of
+        // vertices, edges or contours with ACAPI_Element_GetMemo, do not change the IDs in these
+        // arrays. New vertices, edges and contours should be inserted with ID = 0." "Initialized"
+        // (as InsertPolyNode/DeleteSubPoly/etc. require) means the handle must exist at the right
+        // size, not that it must be pre-filled with a manually invented ID scheme - Archicad
+        // itself assigns real IDs to zero-ID vertices. Earlier attempts at manually numbering this
+        // (global sequential, per-contour restart, with/without mirroring the closing duplicate)
+        // were all guesses at an ID scheme Archicad was never asking for.
+        const Int32 existingNCoords = (Int32) (BMGetHandleSize ((GSHandle) memo.coords) / sizeof (API_Coord)) - 1;
+        memo.vertexIDs = reinterpret_cast<UInt32**> (BMAllocateHandle ((existingNCoords + 1) * sizeof (API_Coord), ALLOCATE_CLEAR, 0));
+    }
+    if (memo.parcs == nullptr) {
+        memo.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (0, ALLOCATE_CLEAR, 0));
+    }
+
+    // Step 1: remove every existing hole (subpoly index >= 2), highest index first so earlier
+    // deletions don't shift the indices of subpolys not yet processed.
+    const Int32 nSubPolys = (Int32) (BMGetHandleSize ((GSHandle) memo.pends) / sizeof (Int32)) - 1;
+    for (Int32 subPolyIndex = nSubPolys; subPolyIndex >= 2; --subPolyIndex) {
+        Int32 idx = subPolyIndex;
+        GSErrCode err = ACAPI_Polygon_DeleteSubPoly (&memo, &idx);
+        if (err != NoError) {
+            return "Failed to remove an existing slab hole.";
+        }
+    }
+
+    // Step 2: resize the main outline (subpoly 1) to the requested point count by repeatedly
+    // inserting/deleting node 1 - the coordinate value used for an inserted placeholder node does
+    // not matter, every point is overwritten with the real final coordinates right after.
+    Int32 outlineCount = (*memo.pends)[1] - 1; // real points, excluding the closing duplicate
+    const Int32 desiredOutlineCount = (Int32) polygonOutline.GetSize ();
+    while (outlineCount > desiredOutlineCount) {
+        Int32 idx = 1;
+        GSErrCode err = ACAPI_Polygon_DeletePolyNode (&memo, &idx);
+        if (err != NoError) {
+            return "Failed to adjust the slab outline's point count.";
+        }
+        --outlineCount;
+    }
+    while (outlineCount < desiredOutlineCount) {
+        // Per Graphisoft's own DevKit reference example (Do_Poly_InsertNode), nodeIndex is set to
+        // the clicked edge's begin-node index + 1 - i.e. the position the NEW node will occupy
+        // (shifting what was there up by one), not "insert after this existing node" as the header
+        // doc's wording alone suggests. To insert between existing nodes 1 and 2, that means
+        // nodeIndex = 2, not 1.
+        Int32 idx = 2;
+        const API_Coord& p1 = (*memo.coords)[1];
+        const API_Coord& p2 = (*memo.coords)[2];
+        API_Coord placeholder = {(p1.x + p2.x) / 2.0, (p1.y + p2.y) / 2.0};
+        GSErrCode err = ACAPI_Polygon_InsertPolyNode (&memo, &idx, &placeholder);
+        if (err != NoError) {
+            return "Failed to adjust the slab outline's point count.";
+        }
+        ++outlineCount;
+    }
+
+    for (Int32 i = 0; i < desiredOutlineCount; ++i) {
+        (*memo.coords)[i + 1] = Get2DCoordinateFromObjectState (polygonOutline[i]);
+    }
+    (*memo.coords)[desiredOutlineCount + 1] = (*memo.coords)[1];
+
+    // Resized to the EXACT new arc count, not just overwritten in place: reusing a stale-sized
+    // handle left old arc entries beyond the new count untouched (e.g. going from 2 arcs to 1, or
+    // to 0, silently kept the old 2nd arc around) - confirmed live, arcs "stuck" across modify
+    // calls that were supposed to remove/replace them.
+    {
+        const GS::Array<API_PolyArc> arcs = GetPolyArcs (polygonArcs, 1);
+        if (memo.parcs != nullptr) {
+            BMKillHandle (reinterpret_cast<GSHandle*> (&memo.parcs));
+        }
+        if (!arcs.IsEmpty ()) {
+            memo.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (arcs.GetSize () * sizeof (API_PolyArc), ALLOCATE_CLEAR, 0));
+            for (UIndex i = 0; i < arcs.GetSize (); ++i) {
+                (*memo.parcs)[i] = arcs[i];
+            }
+        } else {
+            memo.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (0, ALLOCATE_CLEAR, 0));
+        }
+    }
+
+    // Step 3: add the requested holes back, each as a fresh subpoly.
+    for (const GS::ObjectState& hole : holes) {
+        GS::Array<GS::ObjectState> holePolygonOutline;
+        GS::Array<GS::ObjectState> holePolygonArcs;
+        if (!GetHoleGeometry (hole, holePolygonOutline, holePolygonArcs) || holePolygonOutline.GetSize () < 3) {
+            continue;
+        }
+        const Int32 holeNCoords = (Int32) holePolygonOutline.GetSize ();
+        API_ElementMemo insMemo = {};
+        const GS::OnExit insCleanup ([&insMemo] () { ACAPI_DisposeElemMemoHdls (&insMemo); });
+        // +2, not +1: index 0 is the unused dummy slot and index holeNCoords+1 holds the closing
+        // duplicate point written below - allocating only holeNCoords+1 slots left that last write
+        // one element past the end of the handle, corrupting adjacent heap memory (a delayed,
+        // hard-to-diagnose C0000374 crash reported by Archicad much later during an unrelated
+        // commit - confirmed live by reproducing it on a plain hole-add).
+        insMemo.coords = reinterpret_cast<API_Coord**> (BMAllocateHandle ((holeNCoords + 2) * sizeof (API_Coord), ALLOCATE_CLEAR, 0));
+        for (Int32 i = 0; i < holeNCoords; ++i) {
+            (*insMemo.coords)[i + 1] = Get2DCoordinateFromObjectState (holePolygonOutline[i]);
+        }
+        (*insMemo.coords)[holeNCoords + 1] = (*insMemo.coords)[1];
+        insMemo.pends = reinterpret_cast<Int32**> (BMAllocateHandle (2 * sizeof (Int32), ALLOCATE_CLEAR, 0));
+        (*insMemo.pends)[0] = 0;
+        (*insMemo.pends)[1] = holeNCoords + 1;
+        if (!holePolygonArcs.IsEmpty ()) {
+            const GS::Array<API_PolyArc> holeArcs = GetPolyArcs (holePolygonArcs, 1);
+            insMemo.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (holeArcs.GetSize () * sizeof (API_PolyArc), ALLOCATE_CLEAR, 0));
+            for (UIndex i = 0; i < holeArcs.GetSize (); ++i) {
+                (*insMemo.parcs)[i] = holeArcs[i];
+            }
+        }
+        GSErrCode err = ACAPI_Polygon_InsertSubPoly (&memo, &insMemo);
+        if (err != NoError) {
+            return "Failed to add a slab hole.";
+        }
+    }
+
+    // edgeTrims/sideMaterials are not touched by the Insert/Delete primitives above (per their own
+    // documentation - "other memo handles are not touched"), so they are resized fresh to match the
+    // final coordinate count. edgeTrims is a plain Handle (BMKillHandle+BMAllocateHandle is safe);
+    // sideMaterials is a raw Ptr, and BMReallocPtr on a GetMemo-provided one reliably corrupted the
+    // heap (issue #452's original crash report) - so it is freed and reallocated fresh too, never
+    // resized in place. Despite the DevKit's own Do_Poly_InsertNode/DeleteNode reference example
+    // treating this as unnecessary for API_SlabID and using APIMemoMask_Polygon alone for
+    // ACAPI_Element_ChangeMemo, using that narrower mask here reproducibly failed with
+    // APIERR_BADPARS on this exact hole-removal case - live-confirmed; the combined mask plus this
+    // rebuild is what actually works for hole add/remove, multi-hole, and arcs.
+    const Int32 finalNCoords = (Int32) (BMGetHandleSize ((GSHandle) memo.coords) / sizeof (API_Coord)) - 1;
+    if (memo.edgeTrims != nullptr) {
+        BMKillHandle (reinterpret_cast<GSHandle*> (&memo.edgeTrims));
+    }
+    memo.edgeTrims = reinterpret_cast<API_EdgeTrim**> (BMAllocateHandle ((finalNCoords + 1) * sizeof (API_EdgeTrim), ALLOCATE_CLEAR, 0));
+    if (memo.sideMaterials != nullptr) {
+        BMKillPtr (reinterpret_cast<GSPtr*> (&memo.sideMaterials));
+    }
+    memo.sideMaterials = reinterpret_cast<API_OverriddenAttribute*> (BMAllocatePtr ((finalNCoords + 1) * sizeof (API_OverriddenAttribute), ALLOCATE_CLEAR, 0));
+    for (Int32 i = 1; i <= finalNCoords; ++i) {
+        (*memo.edgeTrims)[i].sideType = APIEdgeTrim_Vertical;
+        memo.sideMaterials[i] = sideMat;
     }
 
     return {};
@@ -4270,7 +4505,10 @@ GS::Optional<GS::UniString> ModifySlabsCommand::GetInputParametersSchema () cons
                             "type": "array",
                             "items": { "$ref": "#/PolyArc" }
                         },
-                        "holes": { "$ref": "#/Holes2D" }
+                        "holes": {
+                            "$ref": "#/Holes2D",
+                            "description": "Can be given on its own, without polygonOutline, to add/remove/clear holes in place (an empty array clears all holes) - the slab's current outline is reused unchanged."
+                        }
                     },
                     "additionalProperties": false,
                     "required": ["elementId"]
@@ -4321,10 +4559,27 @@ GS::ObjectState ModifySlabsCommand::Execute (const GS::ObjectState& parameters, 
             }
 
             GS::Array<GS::ObjectState> polygonOutline;
-            if (item.Get ("polygonOutline", polygonOutline)) {
-                if (polygonOutline.GetSize () < 3) {
-                    results.Push (CreateFailedExecutionResult (APIERR_BADPARS, "'polygonOutline' must contain at least 3 coordinates."));
-                    continue;
+            const bool hasNewOutline = item.Get ("polygonOutline", polygonOutline);
+            GS::Array<GS::ObjectState> holes;
+            const bool hasHolesField = item.Get ("holes", holes);
+            if (hasNewOutline || hasHolesField) {
+                // holes can be given on its own (no polygonOutline) to add/remove/clear holes
+                // in place - including an explicit empty array to clear all holes - without
+                // forcing the caller to resend the (possibly large) outline unchanged. Previously
+                // this whole branch was gated on polygonOutline alone, so a holes-only request
+                // fell through to "No slab fields to modify." below (issue #452).
+                GS::Array<GS::ObjectState> polygonArcs;
+                if (hasNewOutline) {
+                    if (polygonOutline.GetSize () < 3) {
+                        results.Push (CreateFailedExecutionResult (APIERR_BADPARS, "'polygonOutline' must contain at least 3 coordinates."));
+                        continue;
+                    }
+                    item.Get ("polygonArcs", polygonArcs);
+                } else {
+                    GS::ObjectState currentGeometry;
+                    AddPolygonWithHolesFromMemoCoords (element.header.guid, currentGeometry, "polygonOutline", "polygonArcs", "holes", "polygonOutline", "polygonArcs");
+                    currentGeometry.Get ("polygonOutline", polygonOutline);
+                    currentGeometry.Get ("polygonArcs", polygonArcs);
                 }
 
                 API_ElementMemo memo = {};
@@ -4333,17 +4588,28 @@ GS::ObjectState ModifySlabsCommand::Execute (const GS::ObjectState& parameters, 
                 });
                 ACAPI_Element_GetMemo (element.header.guid, &memo);
 
-                GS::Array<GS::ObjectState> polygonArcs;
-                GS::Array<GS::ObjectState> holes;
-                item.Get ("polygonArcs", polygonArcs);
-                item.Get ("holes", holes);
-                auto error = BuildSlabMemoFromGeometry (element, memo, polygonOutline, polygonArcs, holes);
+                auto error = ApplySlabPolygonChange (memo, element.slab.sideMat, polygonOutline, polygonArcs, holes);
                 if (error.HasValue ()) {
                     results.Push (CreateFailedExecutionResult (APIERR_BADPARS, error.Get ()));
                     continue;
                 }
 
-                err = ACAPI_Element_Change (&element, &mask, &memo, APIMemoMask_Polygon | APIMemoMask_SideMaterials | APIMemoMask_EdgeTrims, true);
+                // Non-geometry field changes (thickness/level/etc, accumulated into mask above)
+                // are applied first via ACAPI_Element_Change; the polygon itself goes through
+                // ACAPI_Element_ChangeMemo, matching the DevKit's own reference example
+                // (ApplySlabPolygonChange mutates the memo via Graphisoft's polygon-editing
+                // primitives, not a from-scratch replacement, so element.slab.poly's counts are
+                // deliberately not touched here).
+                if (changed) {
+                    err = ACAPI_Element_Change (&element, &mask, nullptr, 0, true);
+                    if (err != NoError) {
+                        results.Push (CreateFailedExecutionResult (err, "Failed to modify slab."));
+                        continue;
+                    }
+                }
+
+                API_Guid slabGuid = element.header.guid;
+                err = ACAPI_Element_ChangeMemo (slabGuid, APIMemoMask_Polygon | APIMemoMask_SideMaterials | APIMemoMask_EdgeTrims, &memo);
                 results.Push (err == NoError ? CreateSuccessfulExecutionResult () : CreateFailedExecutionResult (err, "Failed to modify slab geometry."));
                 continue;
             }


### PR DESCRIPTION
Fixes #452.

`ModifySlabs` could reliably crash Archicad or reject the request with `APIERR_BADPOLY` for anything beyond resending an unchanged outline: adding/removing/clearing holes, growing or shrinking the point count, or changing arcs - covering #452's exact crash (a same-size outline resend with holes cleared) plus every geometry-changing case around it.

## Root causes

Found and fixed one at a time against real live tests, in `ExtendedElementCommands.cpp` (`ApplySlabPolygonChange`):

- **`BMReallocPtr` on `sideMaterials`** (a raw `Ptr`, not a GS `Handle`) corrupted the heap when its size changed - this was the original crash report. Rebuilding the polygon memo now uses Graphisoft's own `ACAPI_Polygon_InsertPolyNode`/`DeletePolyNode`/`InsertSubPoly`/`DeleteSubPoly` primitives (matching the DevKit's own reference example for this exact scenario) instead of a from-scratch handle rebuild.
- **`ACAPI_Polygon_InsertPolyNode`'s `nodeIndex`** needs to be set to the position the new node will occupy (matching the DevKit example's own `neig.inIndex + 1`), not "insert after this index" as the header comment's wording alone suggests - using the wrong index reliably returned `APIERR_BADPARS`.
- **`vertexIDs` must never be manually renumbered.** Per Graphisoft's own `API_ElementMemo` docs, existing IDs must be preserved as-is and new vertices inserted with ID `0`, left for Archicad itself to assign - every earlier attempt at inventing an ID scheme (sequential, global, per-contour) failed in some case.
- **A hole's memo needs +2 (not +1) coordinate slots**: index 0 is the unused dummy slot and the last index holds the closing duplicate - under-allocating by one silently corrupted adjacent heap memory, surfacing as a crash much later on an unrelated commit.
- **`polygonArcs` needs to be resized to the exact new arc count**, not overwritten address-by-address in place - reusing a stale-sized handle left old arc entries stuck around after they should have been replaced or cleared.

## Also

`holes` can now be sent on its own, without `polygonOutline`, to add/remove/clear holes without resending the (possibly large) unchanged outline - previously a holes-only request silently fell through to `"No slab fields to modify."`.

## Test plan

- [x] `archicad-addon/Examples/test_modify_slabs_exhaustive.py` (new, 21 checks): the exact #452 repro, the holes-only shorthand, outline point count growing and shrinking, multi-hole add/shrink with mixed shapes, arc replacement and clearing, and a combined single-call change touching all of the above at once. 21/21 passing live on AC27.
- [x] Verified zero crashes across every geometry-changing scenario tested (previously several of these reliably crashed Archicad or corrupted the heap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
