### PR TITLE
Wall/Slab/Column/Beam: fill the gaps left by the existing commands

### DIFF
--- a/archicad-addon/Examples/test_wall_slab_column_beam_details.py
+++ b/archicad-addon/Examples/test_wall_slab_column_beam_details.py
@@ -1,0 +1,346 @@
+"""
+Exhaustive live test: Create + GET + SET for the extended Wall/Slab/Column/Beam
+type-specific fields (materials, pens, visibility, cover/floor fill, cross section,
+profile type / slant, polygon geometry with holes and arcs), plus a regression check
+for the ModifySlabs polygon-editing crash (outline/hole changes, point-count growth
+and shrinkage, curved outlines).
+"""
+import sys
+sys.path.insert(0, r'D:\ONEDRIVE\Documents\CODE PLUGINS\tapir-wscb-fix\archicad-addon\Examples')
+import aclib
+
+def run(cmd, params=None):
+    return aclib.RunTapirCommand(cmd, params or {}, debug=False)
+
+passes = fails = 0
+created = []
+
+def check(label, expected, got):
+    global passes, fails
+    ok = (got == expected)
+    tag = 'PASS' if ok else 'FAIL'
+    if ok:
+        passes += 1
+    else:
+        fails += 1
+    print(f'  [{tag}] {label}  (expected={expected!r}, got={got!r})')
+
+surfaces = run('GetAttributesByType', {'attributeType': 'Surface'})['attributes']
+fills = run('GetAttributesByType', {'attributeType': 'Fill'})['attributes']
+profiles = run('GetAttributesByType', {'attributeType': 'Profile'})['attributes']
+materials = run('GetAttributesByType', {'attributeType': 'BuildingMaterial'})['attributes']
+surfaceId = surfaces[0]['attributeId']
+surfaceId2 = surfaces[1]['attributeId'] if len(surfaces) > 1 else surfaceId
+fillId = fills[0]['attributeId']
+profileId = profiles[0]['attributeId']
+materialId = materials[0]['attributeId']
+
+# ======================================================================
+print('SETUP -- Wall, Slab (curved outline), Column, Beam')
+# ======================================================================
+rWall = run('CreateWalls', {'wallsData': [{
+    'begCoordinate': {'x': 4000, 'y': 0}, 'endCoordinate': {'x': 4010, 'y': 0},
+    'height': 3, 'thickness': 0.25, 'arcAngle': 0.6,
+}]})
+wallGuid = rWall['elements'][0]['elementId']['guid']
+created.append(wallGuid)
+
+rSlab = run('CreateSlabs', {'slabsData': [{
+    'level': 0, 'thickness': 0.3,
+    'polygonCoordinates': [{'x': 4020, 'y': 0}, {'x': 4030, 'y': 0}, {'x': 4035, 'y': 5}, {'x': 4030, 'y': 10}, {'x': 4020, 'y': 10}],
+    'polygonArcs': [{'begIndex': 1, 'endIndex': 2, 'arcAngle': 0.5}],
+}]})
+slabGuid = rSlab['elements'][0]['elementId']['guid']
+created.append(slabGuid)
+
+rCol = run('CreateColumns', {'columnsData': [{'coordinates': {'x': 4050, 'y': 0, 'z': 0}, 'height': 3, 'depth': 0.3, 'width': 0.3, 'coreAnchor': 'Center'}]})
+columnGuid = rCol['elements'][0]['elementId']['guid']
+created.append(columnGuid)
+
+rBeam = run('CreateBeams', {'beamsData': [{'begCoordinate': {'x': 4060, 'y': 0}, 'endCoordinate': {'x': 4080, 'y': 0}, 'zCoordinate': 0, 'height': 0.3, 'width': 0.2}]})
+beamGuid = rBeam['elements'][0]['elementId']['guid']
+created.append(beamGuid)
+print()
+
+# ======================================================================
+print('TEST -- Wall: geometry + structure + all extended fields combined in one call')
+# ======================================================================
+# Note: 'height' and 'relativeTopStory' are mutually exclusive (relativeTopStory wins when
+# both are set), and Core* referenceLineLocation values need structureType Composite/Profile
+# - both are exercised separately below, not combined here.
+r = run('ModifyWalls', {'wallsWithDetails': [{
+    'elementId': {'guid': wallGuid},
+    'begCoordinate': {'x': 4000, 'y': 0}, 'endCoordinate': {'x': 4012, 'y': 0}, 'arcAngle': 0.8,
+    'height': 3.2, 'thickness': 0.3, 'offset': 0.05,
+    'structureType': 'Basic',
+    'referenceLineLocation': 'Outside',
+    'zoneRel': 'SubtractFromZone',
+    'visibility': {'showOnHome': True, 'showAllAbove': False, 'showAllBelow': False, 'showRelAbove': 0, 'showRelBelow': 0},
+    'referenceMaterial': {'overridden': True, 'attributeId': surfaceId},
+    'oppositeMaterial': {'overridden': True, 'attributeId': surfaceId2},
+    'sideMaterial': {'overridden': True, 'attributeId': surfaceId},
+    'cutFillPen': {'overridden': True, 'penIndex': 9},
+    'cutFillBackgroundPen': {'overridden': True, 'penIndex': 2},
+}]})
+check('combined ModifyWalls succeeds', True, r['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': wallGuid}}]})['detailsOfElements'][0]['details']
+check('geometryType stays Straight (curved simple wall)', 'Straight', d.get('geometryType'))
+check('arcAngle', 0.8, round(d.get('arcAngle', 0), 6))
+check('height', 3.2, d.get('height'))
+check('thickness (begThickness)', 0.3, d.get('begThickness'))
+check('referenceLineLocation', 'Outside', d.get('referenceLineLocation'))
+check('zoneRel', 'SubtractFromZone', d.get('zoneRel'))
+check('visibility.showOnHome', True, (d.get('visibility') or {}).get('showOnHome'))
+check('isAutoOnStoryVisibility turned off by setting visibility', False, d.get('isAutoOnStoryVisibility'))
+check('referenceMaterial.attributeId', surfaceId, (d.get('referenceMaterial') or {}).get('attributeId'))
+check('oppositeMaterial.attributeId', surfaceId2, (d.get('oppositeMaterial') or {}).get('attributeId'))
+check('cutFillPen.penIndex', 9, (d.get('cutFillPen') or {}).get('penIndex'))
+check('cutFillBackgroundPen.penIndex', 2, (d.get('cutFillBackgroundPen') or {}).get('penIndex'))
+print()
+
+print('TEST -- Wall: relativeTopStory + topOffset (explicit height must not be set in the same call)')
+r = run('ModifyWalls', {'wallsWithDetails': [{'elementId': {'guid': wallGuid}, 'relativeTopStory': 1, 'topOffset': 0.1}]})
+check('relativeTopStory + topOffset succeeds', True, r['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': wallGuid}}]})['detailsOfElements'][0]['details']
+check('relativeTopStory', 1, d.get('relativeTopStory'))
+check('topOffset (only meaningful with relativeTopStory != 0)', 0.1, d.get('topOffset'))
+print()
+
+print('TEST -- Wall: profileType Slanted (single) vs Trapez (double, independent alpha/beta)')
+r = run('ModifyWalls', {'wallsWithDetails': [{'elementId': {'guid': wallGuid}, 'profileType': 'Slanted', 'slantAlpha': 1.3, 'slantBeta': 1.4}]})
+check('profileType Slanted succeeds', True, r['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': wallGuid}}]})['detailsOfElements'][0]['details']
+check('profileType', 'Slanted', d.get('profileType'))
+check('slantAlpha applied', 1.3, d.get('slantAlpha'))
+check('slantBeta forced equal to slantAlpha in Slanted mode', 1.3, d.get('slantBeta'))
+
+r = run('ModifyWalls', {'wallsWithDetails': [{'elementId': {'guid': wallGuid}, 'profileType': 'Trapez', 'slantAlpha': 1.2, 'slantBeta': 1.45}]})
+check('profileType Trapez succeeds', True, r['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': wallGuid}}]})['detailsOfElements'][0]['details']
+check('profileType', 'Trapez', d.get('profileType'))
+check('slantAlpha independent in Trapez mode', 1.2, d.get('slantAlpha'))
+check('slantBeta independent in Trapez mode', 1.45, d.get('slantBeta'))
+
+r = run('ModifyWalls', {'wallsWithDetails': [{'elementId': {'guid': wallGuid}, 'profileType': 'Normal'}]})
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': wallGuid}}]})['detailsOfElements'][0]['details']
+check('profileType back to Normal', 'Normal', d.get('profileType'))
+print()
+
+print('TEST -- Wall: Core reference line location needs Composite structure')
+composites = run('GetAttributesByType', {'attributeType': 'Composite'})['attributes']
+compositeId = composites[0]['attributeId']
+r = run('ModifyWalls', {'wallsWithDetails': [{
+    'elementId': {'guid': wallGuid}, 'structureType': 'Composite', 'compositeId': compositeId, 'referenceLineLocation': 'CoreCenter',
+}]})
+check('structureType+CoreCenter combined succeeds', True, r['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': wallGuid}}]})['detailsOfElements'][0]['details']
+check('structureType is Composite', 'Composite', d.get('structureType'))
+check('CoreCenter now takes effect on a Composite wall', 'CoreCenter', d.get('referenceLineLocation'))
+print()
+
+# ======================================================================
+print('TEST -- Slab: multiple holes (rect + arc) + curved outline growth, combined with materials/fills in one call')
+# ======================================================================
+d0 = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': slabGuid}}]})['detailsOfElements'][0]['details']
+check('initial outline is 5 input points + 1 closing duplicate', 6, len(d0.get('polygonOutline', [])))
+
+r = run('ModifySlabs', {'slabsWithDetails': [{
+    'elementId': {'guid': slabGuid},
+    'polygonOutline': [
+        {'x': 4020, 'y': 0}, {'x': 4032, 'y': 0}, {'x': 4038, 'y': 5}, {'x': 4032, 'y': 10}, {'x': 4020, 'y': 10}, {'x': 4015, 'y': 5},
+    ],
+    'polygonArcs': [{'begIndex': 1, 'endIndex': 2, 'arcAngle': 0.4}, {'begIndex': 4, 'endIndex': 5, 'arcAngle': -0.3}],
+    'holes': [
+        {'polygonOutline': [{'x': 4022, 'y': 2}, {'x': 4024, 'y': 2}, {'x': 4024, 'y': 4}, {'x': 4022, 'y': 4}]},
+        {'polygonOutline': [{'x': 4026, 'y': 6}, {'x': 4028, 'y': 6}, {'x': 4028, 'y': 8}, {'x': 4026, 'y': 8}],
+         'polygonArcs': [{'begIndex': 0, 'endIndex': 1, 'arcAngle': 0.5}]},
+    ],
+    'referencePlaneLocation': 'Top',
+    'topMaterial': {'overridden': True, 'attributeId': surfaceId},
+    'sideMaterial': {'overridden': True, 'attributeId': surfaceId2},
+    'bottomMaterial': {'overridden': True, 'attributeId': surfaceId},
+    'cutFillPen': {'overridden': True, 'penIndex': 8},
+    'cutFillBackgroundPen': {'overridden': True, 'penIndex': 3},
+    'floorFill': {
+        'use': True, 'foregroundPen': 5, 'backgroundPen': 2, 'fillId': fillId, 'use3DHatching': True,
+        'orientation': {'type': 'Global', 'origin': {'x': 0.0, 'y': 0.0}, 'matrix00': 1.0, 'matrix10': 0.0, 'matrix01': 0.0, 'matrix11': 1.0, 'innerRadius': 0.0},
+    },
+}]})
+check('maximal ModifySlabs (6-pt outline, 2 arcs, 2 holes, materials, fill) succeeds', True, r['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': slabGuid}}]})['detailsOfElements'][0]['details']
+check('polygonOutline has 6 input points + 1 closing duplicate', 7, len(d.get('polygonOutline', [])))
+check('polygonArcs has 2 arcs', 2, len(d.get('polygonArcs', [])))
+check('holes has 2 holes', 2, len(d.get('holes', [])))
+check('referencePlaneLocation', 'Top', d.get('referencePlaneLocation'))
+check('topMaterial.attributeId', surfaceId, (d.get('topMaterial') or {}).get('attributeId'))
+check('cutFillPen.penIndex', 8, (d.get('cutFillPen') or {}).get('penIndex'))
+check('floorFill.use3DHatching', True, (d.get('floorFill') or {}).get('use3DHatching'))
+print()
+
+print('TEST -- Slab: shrink outline back down + remove one hole (regression for point-count decrease + hole removal)')
+r = run('ModifySlabs', {'slabsWithDetails': [{
+    'elementId': {'guid': slabGuid},
+    'polygonOutline': [{'x': 4020, 'y': 0}, {'x': 4030, 'y': 0}, {'x': 4030, 'y': 10}, {'x': 4020, 'y': 10}],
+    'holes': [
+        {'polygonOutline': [{'x': 4022, 'y': 2}, {'x': 4024, 'y': 2}, {'x': 4024, 'y': 4}, {'x': 4022, 'y': 4}]},
+    ],
+}]})
+check('shrink outline + drop 1 hole succeeds (no crash)', True, r['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': slabGuid}}]})['detailsOfElements'][0]['details']
+check('polygonOutline back to 4 input points + 1 closing duplicate', 5, len(d.get('polygonOutline', [])))
+check('holes back to 1 hole', 1, len(d.get('holes', [])))
+print()
+
+print('TEST -- Slab: clear all holes with an explicit empty array')
+r = run('ModifySlabs', {'slabsWithDetails': [{'elementId': {'guid': slabGuid}, 'holes': []}]})
+check('clear holes succeeds', True, r['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': slabGuid}}]})['detailsOfElements'][0]['details']
+check('holes now empty', 0, len(d.get('holes', [])))
+print()
+
+# ======================================================================
+print('TEST -- Column: everything combined in one ModifyColumns call')
+# ======================================================================
+# Note: 'height' and 'relativeTopStory' are mutually exclusive, same as Wall - not combined here.
+r = run('ModifyColumns', {'columnsWithDetails': [{
+    'elementId': {'guid': columnGuid},
+    'origin': {'x': 4050, 'y': 1}, 'zCoordinate': 0.2, 'height': 3.5, 'bottomOffset': 0.1,
+    'axisRotationAngle': 0.3, 'coreAnchor': 'TopRight',
+    'isSlanted': True, 'slantAngle': 0.15, 'slantDirectionAngle': 0.7,
+    'wrapping': True,
+    'topOffset': 0.2,
+    'width': 0.5, 'depth': 0.5,
+    'cutFillPen': {'overridden': True, 'penIndex': 6},
+    'cutFillBackgroundPen': {'overridden': True, 'penIndex': 1},
+    'coverFill': {
+        'use': True, 'useFromSurface': False, 'orientationComesFrom3D': True, 'fillId': fillId,
+        'foregroundPen': 4, 'backgroundPen': 2, 'transformationType': 'Global',
+        'transformation': {'origin': {'x': 0.0, 'y': 0.0}, 'xAxis': {'x': 1.0, 'y': 0.0}, 'yAxis': {'x': 0.0, 'y': 1.0}},
+    },
+}]})
+check('maximal ModifyColumns succeeds', True, r['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': columnGuid}}]})['detailsOfElements'][0]['details']
+check('height', 3.5, d.get('height'))
+check('axisRotationAngle', 0.3, d.get('axisRotationAngle'))
+check('coreAnchor', 'TopRight', d.get('coreAnchor'))
+check('isSlanted', True, d.get('isSlanted'))
+check('slantAngle', 0.15, d.get('slantAngle'))
+check('slantDirectionAngle', 0.7, d.get('slantDirectionAngle'))
+check('wrapping', True, d.get('wrapping'))
+check('topOffset', 0.2, d.get('topOffset'))
+check('width', 0.5, d.get('width'))
+check('depth', 0.5, d.get('depth'))
+check('cutFillPen.penIndex', 6, (d.get('cutFillPen') or {}).get('penIndex'))
+check('coverFill.orientationComesFrom3D', True, (d.get('coverFill') or {}).get('orientationComesFrom3D'))
+print()
+
+print('TEST -- Column: relativeTopStory (separate call, explicit height must not be set alongside)')
+r = run('ModifyColumns', {'columnsWithDetails': [{'elementId': {'guid': columnGuid}, 'relativeTopStory': 1}]})
+check('relativeTopStory alone succeeds', True, r['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': columnGuid}}]})['detailsOfElements'][0]['details']
+check('relativeTopStory', 1, d.get('relativeTopStory'))
+print()
+
+# ======================================================================
+print('TEST -- Beam: everything combined in one ModifyBeams call (curved + 2 holes + all fields)')
+# ======================================================================
+r = run('ModifyBeams', {'beamsWithDetails': [{
+    'elementId': {'guid': beamGuid},
+    'begCoordinate': {'x': 4060, 'y': 0}, 'endCoordinate': {'x': 4085, 'y': 0},
+    'level': 0.1, 'offset': 0.02, 'slantAngle': 0.1, 'arcAngle': 0.4, 'verticalCurveHeight': 0.3,
+    'beamShape': 'HorizontallyCurved',
+    'isSlanted': True, 'isFlipped': True, 'profileAngle': 0.2,
+    'anchorPoint': 'TopRight',
+    'width': 0.3, 'height': 0.5,
+    'cutFillPen': {'overridden': True, 'penIndex': 10},
+    'cutFillBackgroundPen': {'overridden': True, 'penIndex': 4},
+    'coverFill': {
+        'use': True, 'useFromSurface': False, 'orientationComesFrom3D': False, 'fillId': fillId,
+        'foregroundPen': 3, 'backgroundPen': 1, 'transformationType': 'Global',
+        'transformation': {'origin': {'x': 0.0, 'y': 0.0}, 'xAxis': {'x': 1.0, 'y': 0.0}, 'yAxis': {'x': 0.0, 'y': 1.0}},
+    },
+}]})
+check('maximal ModifyBeams (no holes) succeeds', True, r['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': beamGuid}}]})['detailsOfElements'][0]['details']
+check('beamShape', 'HorizontallyCurved', d.get('beamShape'))
+check('isFlipped', True, d.get('isFlipped'))
+check('profileAngle', 0.2, d.get('profileAngle'))
+check('anchorPoint', 'TopRight', d.get('anchorPoint'))
+check('width', 0.3, d.get('width'))
+check('height', 0.5, d.get('height'))
+check('cutFillPen.penIndex', 10, (d.get('cutFillPen') or {}).get('penIndex'))
+check('coverFill.foregroundPen', 3, (d.get('coverFill') or {}).get('foregroundPen'))
+print()
+
+print('TEST -- Beam: 2 holes (rect + circular) replace all holes in a separate call')
+r = run('ModifyBeams', {'beamsWithDetails': [{
+    'elementId': {'guid': beamGuid},
+    'holes': [
+        {'type': 'Rectangular', 'showContour': True, 'centerX': 0.3, 'centerZ': 0.1, 'width': 0.1, 'height': 0.08},
+        {'type': 'Circular', 'showContour': False, 'centerX': 0.6, 'centerZ': 0.15, 'width': 0.12},
+    ],
+}]})
+check('2-hole ModifyBeams succeeds', True, r['executionResults'][0].get('success'))
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': beamGuid}}]})['detailsOfElements'][0]['details']
+check('2 holes present', 2, len(d.get('holes', [])))
+check('fields from the previous call are still intact', 'HorizontallyCurved', d.get('beamShape'))
+print()
+
+# ======================================================================
+print('TEST -- Wall: structureType Profile (was previously broken - forced an invalid Poly plan shape)')
+rw2 = run('CreateWalls', {'wallsData': [{'begCoordinate': {'x': 4100, 'y': 0}, 'endCoordinate': {'x': 4110, 'y': 0}, 'height': 3, 'thickness': 0.25, 'structureType': 'Profile', 'profileId': profileId}]})
+check('CreateWalls with structureType Profile succeeds', True, 'elementId' in rw2['elements'][0])
+if 'elementId' in rw2['elements'][0]:
+    w2guid = rw2['elements'][0]['elementId']['guid']
+    created.append(w2guid)
+    dw2 = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': w2guid}}]})['detailsOfElements'][0]['details']
+    check('Wall structureType is Profile', 'Profile', dw2.get('structureType'))
+    check('Wall profileId round-trips', profileId, dw2.get('profileId'))
+    check('Wall geometryType still Straight (not forced to Polygonal)', 'Straight', dw2.get('geometryType'))
+print()
+
+print('TEST -- Column: circleBased, isWidthAndHeightLinked (independent width/depth), buildingMaterialId, profileId')
+rc = run('CreateColumns', {'columnsData': [{
+    'coordinates': {'x': 4120, 'y': 0, 'z': 0}, 'height': 3,
+    'width': 0.3, 'depth': 0.5, 'circleBased': False, 'isWidthAndHeightLinked': False, 'buildingMaterialId': materialId,
+}]})
+c2guid = rc['elements'][0]['elementId']['guid']
+created.append(c2guid)
+dc = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': c2guid}}]})['detailsOfElements'][0]['details']
+check('Column independent width', 0.3, dc.get('width'))
+check('Column independent depth', 0.5, dc.get('depth'))
+check('Column circleBased False', False, dc.get('circleBased'))
+check('Column buildingMaterialId round-trips', materialId, dc.get('buildingMaterialId'))
+
+r = run('ModifyColumns', {'columnsWithDetails': [{'elementId': {'guid': c2guid}, 'profileId': profileId}]})
+check('ModifyColumns to profileId succeeds', True, r['executionResults'][0].get('success'))
+dc2 = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': c2guid}}]})['detailsOfElements'][0]['details']
+check('Column profileId round-trips after Modify', profileId, dc2.get('profileId'))
+print()
+
+print('TEST -- Beam: isWidthAndHeightLinked (independent width/height), buildingMaterialId, profileId')
+rb = run('CreateBeams', {'beamsData': [{
+    'begCoordinate': {'x': 4130, 'y': 0}, 'endCoordinate': {'x': 4150, 'y': 0}, 'zCoordinate': 0,
+    'width': 0.2, 'height': 0.4, 'isWidthAndHeightLinked': False, 'buildingMaterialId': materialId,
+}]})
+b2guid = rb['elements'][0]['elementId']['guid']
+created.append(b2guid)
+db = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': b2guid}}]})['detailsOfElements'][0]['details']
+check('Beam independent width', 0.2, db.get('width'))
+check('Beam independent height', 0.4, db.get('height'))
+check('Beam buildingMaterialId round-trips', materialId, db.get('buildingMaterialId'))
+
+r = run('ModifyBeams', {'beamsWithDetails': [{'elementId': {'guid': b2guid}, 'profileId': profileId}]})
+check('ModifyBeams to profileId succeeds', True, r['executionResults'][0].get('success'))
+db2 = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': b2guid}}]})['detailsOfElements'][0]['details']
+check('Beam profileId round-trips after Modify', profileId, db2.get('profileId'))
+print()
+
+# ======================================================================
+run('DeleteElements', {'elements': [{'elementId': {'guid': g}} for g in created]})
+
+print('=' * 60)
+print(f'BILAN :  {passes} PASS  |  {fails} FAIL')
+print('=' * 60)
+if fails:
+    sys.exit(1)

--- a/archicad-addon/Sources/CommandBase.cpp
+++ b/archicad-addon/Sources/CommandBase.cpp
@@ -188,6 +188,376 @@ std::vector<PolygonData> GetPolygonsFromMemoCoords (const API_Guid& elemGuid, bo
     return polygons;
 }
 
+GS::UniString AnchorIdToString (API_AnchorID anchorId)
+{
+    switch (anchorId) {
+        case APIAnc_LT: return "TopLeft";
+        case APIAnc_MT: return "TopCenter";
+        case APIAnc_RT: return "TopRight";
+        case APIAnc_LM: return "MiddleLeft";
+        case APIAnc_MM: return "Center";
+        case APIAnc_RM: return "MiddleRight";
+        case APIAnc_LB: return "BottomLeft";
+        case APIAnc_MB: return "BottomCenter";
+        case APIAnc_RB: return "BottomRight";
+        default:        return "Center";
+    }
+}
+
+API_AnchorID AnchorIdFromString (const GS::UniString& str, API_AnchorID defaultValue)
+{
+    if (str == "TopLeft")      return APIAnc_LT;
+    if (str == "TopCenter")    return APIAnc_MT;
+    if (str == "TopRight")     return APIAnc_RT;
+    if (str == "MiddleLeft")   return APIAnc_LM;
+    if (str == "Center")       return APIAnc_MM;
+    if (str == "MiddleRight")  return APIAnc_RM;
+    if (str == "BottomLeft")   return APIAnc_LB;
+    if (str == "BottomCenter") return APIAnc_MB;
+    if (str == "BottomRight")  return APIAnc_RB;
+    return defaultValue;
+}
+
+GS::UniString WallReferenceLineLocationToString (API_WallReferenceLineLocationID location)
+{
+    switch (location) {
+        case APIWallRefLine_Outside:     return "Outside";
+        case APIWallRefLine_Center:      return "Center";
+        case APIWallRefLine_Inside:      return "Inside";
+        case APIWallRefLine_CoreOutside: return "CoreOutside";
+        case APIWallRefLine_CoreCenter:  return "CoreCenter";
+        case APIWallRefLine_CoreInside:  return "CoreInside";
+        default:                         return "Outside";
+    }
+}
+
+API_WallReferenceLineLocationID WallReferenceLineLocationFromString (const GS::UniString& str, API_WallReferenceLineLocationID defaultValue)
+{
+    if (str == "Outside")     return APIWallRefLine_Outside;
+    if (str == "Center")      return APIWallRefLine_Center;
+    if (str == "Inside")      return APIWallRefLine_Inside;
+    if (str == "CoreOutside") return APIWallRefLine_CoreOutside;
+    if (str == "CoreCenter")  return APIWallRefLine_CoreCenter;
+    if (str == "CoreInside")  return APIWallRefLine_CoreInside;
+    return defaultValue;
+}
+
+GS::UniString ZoneRelToString (API_ZoneRelID zoneRel)
+{
+    switch (zoneRel) {
+        case APIZRel_Boundary:        return "Boundary";
+        case APIZRel_ReduceArea:      return "ReduceArea";
+        case APIZRel_None:            return "None";
+#ifdef ServerMainVers_2700
+        case APIZRel_SubtractFromZone:return "SubtractFromZone";
+#endif
+        default:                      return "Boundary";
+    }
+}
+
+API_ZoneRelID ZoneRelFromString (const GS::UniString& str, API_ZoneRelID defaultValue)
+{
+    if (str == "Boundary")         return APIZRel_Boundary;
+    if (str == "ReduceArea")       return APIZRel_ReduceArea;
+    if (str == "None")             return APIZRel_None;
+#ifdef ServerMainVers_2700
+    if (str == "SubtractFromZone") return APIZRel_SubtractFromZone;
+#endif
+    return defaultValue;
+}
+
+GS::ObjectState CreateStoryVisibilityObjectState (const API_StoryVisibility& visibility)
+{
+    return GS::ObjectState (
+        "showOnHome", visibility.showOnHome,
+        "showAllAbove", visibility.showAllAbove,
+        "showAllBelow", visibility.showAllBelow,
+        "showRelAbove", visibility.showRelAbove,
+        "showRelBelow", visibility.showRelBelow);
+}
+
+API_StoryVisibility GetStoryVisibilityFromObjectState (const GS::ObjectState& os)
+{
+    API_StoryVisibility visibility = {};
+    os.Get ("showOnHome", visibility.showOnHome);
+    os.Get ("showAllAbove", visibility.showAllAbove);
+    os.Get ("showAllBelow", visibility.showAllBelow);
+    short showRelAbove = 0;
+    if (os.Get ("showRelAbove", showRelAbove)) {
+        visibility.showRelAbove = showRelAbove;
+    }
+    short showRelBelow = 0;
+    if (os.Get ("showRelBelow", showRelBelow)) {
+        visibility.showRelBelow = showRelBelow;
+    }
+    return visibility;
+}
+
+GS::UniString SlabReferencePlaneLocationToString (API_SlabReferencePlaneLocationID location)
+{
+    switch (location) {
+        case APISlabRefPlane_Top:        return "Top";
+        case APISlabRefPlane_CoreTop:    return "CoreTop";
+        case APISlabRefPlane_CoreBottom: return "CoreBottom";
+        case APISlabRefPlane_Bottom:     return "Bottom";
+        default:                         return "Top";
+    }
+}
+
+API_SlabReferencePlaneLocationID SlabReferencePlaneLocationFromString (const GS::UniString& str, API_SlabReferencePlaneLocationID defaultValue)
+{
+    if (str == "Top")        return APISlabRefPlane_Top;
+    if (str == "CoreTop")    return APISlabRefPlane_CoreTop;
+    if (str == "CoreBottom") return APISlabRefPlane_CoreBottom;
+    if (str == "Bottom")     return APISlabRefPlane_Bottom;
+    return defaultValue;
+}
+
+GS::ObjectState CreateOverriddenMaterialObjectState (const API_OverriddenAttribute& attr)
+{
+#ifdef ServerMainVers_2700
+    const bool overridden = attr.hasValue;
+    const API_AttributeIndex index = attr.value;
+#else
+    const bool overridden = attr.overridden;
+    const API_AttributeIndex index = attr.attributeIndex;
+#endif
+    GS::ObjectState os ("overridden", overridden);
+    if (overridden) {
+        os.Add ("attributeId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_MaterialID, index)));
+    }
+    return os;
+}
+
+API_OverriddenAttribute GetOverriddenMaterialFromObjectState (const GS::ObjectState& os)
+{
+    API_OverriddenAttribute attr = {};
+    bool overridden = false;
+    os.Get ("overridden", overridden);
+
+    API_AttributeIndex index = {};
+    GS::ObjectState attributeIdOs;
+    if (overridden && os.Get ("attributeId", attributeIdOs)) {
+        index = GetAttributeIndexFromGuid (API_MaterialID, GetGuidFromObjectState (attributeIdOs));
+    }
+
+#ifdef ServerMainVers_2700
+    attr.hasValue = overridden;
+    attr.value = index;
+#else
+    attr.overridden = overridden;
+    attr.attributeIndex = index;
+#endif
+    return attr;
+}
+
+#ifdef ServerMainVers_2700
+GS::ObjectState CreateOverriddenPenObjectState (const API_OverriddenPen& pen)
+{
+    GS::ObjectState os ("overridden", pen.hasValue);
+    if (pen.hasValue) {
+        os.Add ("penIndex", static_cast<Int32> (pen.value));
+    }
+    return os;
+}
+
+API_OverriddenPen GetOverriddenPenFromObjectState (const GS::ObjectState& os)
+{
+    API_OverriddenPen pen = {};
+    bool overridden = false;
+    os.Get ("overridden", overridden);
+    Int32 penIndex = 0;
+    if (overridden && os.Get ("penIndex", penIndex)) {
+        pen = static_cast<API_PenIndex> (penIndex);
+    } else {
+        pen = APINullValue;
+    }
+    return pen;
+}
+#endif
+
+GS::UniString CoverFillTransformationTypeToString (API_CoverFillTransformationTypeID type)
+{
+    switch (type) {
+        case API_CoverFillTransformationType_Rotated:   return "Rotated";
+        case API_CoverFillTransformationType_Distorted: return "Distorted";
+        case API_CoverFillTransformationType_Global:
+        default:                                        return "Global";
+    }
+}
+
+API_CoverFillTransformationTypeID CoverFillTransformationTypeFromString (const GS::UniString& str, API_CoverFillTransformationTypeID defaultValue)
+{
+    if (str == "Rotated")   return API_CoverFillTransformationType_Rotated;
+    if (str == "Distorted") return API_CoverFillTransformationType_Distorted;
+    if (str == "Global")    return API_CoverFillTransformationType_Global;
+    return defaultValue;
+}
+
+GS::ObjectState CreateCoverFillTransformationObjectState (const API_CoverFillTransformation& transformation)
+{
+    GS::ObjectState os;
+    os.Add ("origin", Create2DCoordinateObjectState (transformation.origo));
+    os.Add ("xAxis", GS::ObjectState ("x", transformation.xAxis.x, "y", transformation.xAxis.y));
+    os.Add ("yAxis", GS::ObjectState ("x", transformation.yAxis.x, "y", transformation.yAxis.y));
+    return os;
+}
+
+API_CoverFillTransformation GetCoverFillTransformationFromObjectState (const GS::ObjectState& os)
+{
+    API_CoverFillTransformation transformation = {};
+    GS::ObjectState originOs;
+    if (os.Get ("origin", originOs)) {
+        transformation.origo = Get2DCoordinateFromObjectState (originOs);
+    }
+    GS::ObjectState xAxisOs;
+    if (os.Get ("xAxis", xAxisOs)) {
+        xAxisOs.Get ("x", transformation.xAxis.x);
+        xAxisOs.Get ("y", transformation.xAxis.y);
+    }
+    GS::ObjectState yAxisOs;
+    if (os.Get ("yAxis", yAxisOs)) {
+        yAxisOs.Get ("x", transformation.yAxis.x);
+        yAxisOs.Get ("y", transformation.yAxis.y);
+    }
+    return transformation;
+}
+
+GS::ObjectState CreateCoverFillObjectState (bool use, bool useFromSurface, bool orientationComesFrom3D, API_AttributeIndex fillIndex, short foregroundPen, short backgroundPen, API_CoverFillTransformationTypeID transformationType, const API_CoverFillTransformation& transformation)
+{
+    GS::ObjectState os;
+    os.Add ("use", use);
+    os.Add ("useFromSurface", useFromSurface);
+    os.Add ("orientationComesFrom3D", orientationComesFrom3D);
+    os.Add ("fillId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_FilltypeID, fillIndex)));
+    os.Add ("foregroundPen", foregroundPen);
+    os.Add ("backgroundPen", backgroundPen);
+    os.Add ("transformationType", CoverFillTransformationTypeToString (transformationType));
+    os.Add ("transformation", CreateCoverFillTransformationObjectState (transformation));
+    return os;
+}
+
+GS::UniString HatchOrientationTypeToString (API_HatchOrientationTypeID type)
+{
+    switch (type) {
+        case API_HatchRotated:   return "Rotated";
+        case API_HatchDistorted: return "Distorted";
+        case API_HatchCentered:  return "Centered";
+        case API_HatchGlobal:
+        default:                 return "Global";
+    }
+}
+
+API_HatchOrientationTypeID HatchOrientationTypeFromString (const GS::UniString& str, API_HatchOrientationTypeID defaultValue)
+{
+    if (str == "Rotated")   return API_HatchRotated;
+    if (str == "Distorted") return API_HatchDistorted;
+    if (str == "Centered")  return API_HatchCentered;
+    if (str == "Global")    return API_HatchGlobal;
+    return defaultValue;
+}
+
+GS::ObjectState CreateHatchOrientationObjectState (const API_HatchOrientation& orientation)
+{
+    GS::ObjectState os;
+    os.Add ("type", HatchOrientationTypeToString (orientation.type));
+    os.Add ("origin", Create2DCoordinateObjectState (orientation.origo));
+    os.Add ("matrix00", orientation.matrix00);
+    os.Add ("matrix10", orientation.matrix10);
+    os.Add ("matrix01", orientation.matrix01);
+    os.Add ("matrix11", orientation.matrix11);
+    os.Add ("innerRadius", orientation.innerRadius);
+    return os;
+}
+
+API_HatchOrientation GetHatchOrientationFromObjectState (const GS::ObjectState& os)
+{
+    API_HatchOrientation orientation = {};
+    GS::UniString typeStr;
+    if (os.Get ("type", typeStr)) {
+        orientation.type = HatchOrientationTypeFromString (typeStr);
+    }
+    GS::ObjectState originOs;
+    if (os.Get ("origin", originOs)) {
+        orientation.origo = Get2DCoordinateFromObjectState (originOs);
+    }
+    os.Get ("matrix00", orientation.matrix00);
+    os.Get ("matrix10", orientation.matrix10);
+    os.Get ("matrix01", orientation.matrix01);
+    os.Get ("matrix11", orientation.matrix11);
+    os.Get ("innerRadius", orientation.innerRadius);
+    return orientation;
+}
+
+void AddBeamHolesFromMemo (const API_Guid& elemGuid, GS::ObjectState& os, const GS::String& holesFieldName)
+{
+    const auto& holes = os.AddList<GS::ObjectState> (holesFieldName);
+
+    API_ElementMemo memo = {};
+    const GS::OnExit guard ([&memo] () { ACAPI_DisposeElemMemoHdls (&memo); });
+    if (ACAPI_Element_GetMemo (elemGuid, &memo, APIMemoMask_BeamHole) != NoError || memo.beamHoles == nullptr) {
+        return;
+    }
+
+    const GSSize nHoles = BMhGetSize (reinterpret_cast<GSHandle> (memo.beamHoles)) / sizeof (API_Beam_Hole);
+    for (GSIndex i = 0; i < nHoles; ++i) {
+        const API_Beam_Hole& hole = (*memo.beamHoles)[i];
+        holes (GS::ObjectState (
+            "holeId", hole.holeID,
+            "type", hole.holeType == APIBHole_Circular ? GS::UniString ("Circular") : GS::UniString ("Rectangular"),
+            "showContour", hole.holeContureOn,
+            "centerX", hole.centerx,
+            "centerZ", hole.centerz,
+            "width", hole.width,
+            "height", hole.height));
+    }
+}
+
+void AddColumnSectionFromMemo (const API_Guid& elemGuid, GS::ObjectState& os)
+{
+    API_ElementMemo memo = {};
+    const GS::OnExit guard ([&memo] () { ACAPI_DisposeElemMemoHdls (&memo); });
+    if (ACAPI_Element_GetMemo (elemGuid, &memo, APIMemoMask_ColumnSegment) != NoError || memo.columnSegments == nullptr) {
+        return;
+    }
+    const GSSize nSegments = BMGetPtrSize (reinterpret_cast<GSPtr> (memo.columnSegments)) / sizeof (API_ColumnSegmentType);
+    if (nSegments == 0) {
+        return;
+    }
+    const API_AssemblySegmentData& segment = memo.columnSegments[0].assemblySegmentData;
+    os.Add ("width", segment.nominalWidth);
+    os.Add ("depth", segment.nominalHeight);
+    os.Add ("isWidthAndHeightLinked", segment.isWidthAndHeightLinked);
+    os.Add ("circleBased", segment.circleBased);
+    if (segment.modelElemStructureType == API_BasicStructure) {
+        os.Add ("buildingMaterialId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_BuildingMaterialID, segment.buildingMaterial)));
+    } else if (segment.modelElemStructureType == API_ProfileStructure) {
+        os.Add ("profileId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_ProfileID, segment.profileAttr)));
+    }
+}
+
+void AddBeamSectionFromMemo (const API_Guid& elemGuid, GS::ObjectState& os)
+{
+    API_ElementMemo memo = {};
+    const GS::OnExit guard ([&memo] () { ACAPI_DisposeElemMemoHdls (&memo); });
+    if (ACAPI_Element_GetMemo (elemGuid, &memo, APIMemoMask_BeamSegment) != NoError || memo.beamSegments == nullptr) {
+        return;
+    }
+    const GSSize nSegments = BMGetPtrSize (reinterpret_cast<GSPtr> (memo.beamSegments)) / sizeof (API_BeamSegmentType);
+    if (nSegments == 0) {
+        return;
+    }
+    const API_AssemblySegmentData& segment = memo.beamSegments[0].assemblySegmentData;
+    os.Add ("width", segment.nominalWidth);
+    os.Add ("height", segment.nominalHeight);
+    os.Add ("isWidthAndHeightLinked", segment.isWidthAndHeightLinked);
+    if (segment.modelElemStructureType == API_BasicStructure) {
+        os.Add ("buildingMaterialId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_BuildingMaterialID, segment.buildingMaterial)));
+    } else if (segment.modelElemStructureType == API_ProfileStructure) {
+        os.Add ("profileId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_ProfileID, segment.profileAttr)));
+    }
+}
+
 void AddPolygonFromMemoCoords (const API_Guid& elemGuid, GS::ObjectState& os, const GS::String& coordsFieldName, const GS::Optional<GS::String>& arcsFieldName)
 {
     const auto& coords = os.AddList<GS::ObjectState> (coordsFieldName);
@@ -538,16 +908,7 @@ API_ElemTypeID GetElementTypeFromNonLocalizedName (const GS::UniString& typeStr)
 
 short ParseAnchorPointString (const GS::UniString& anchorPoint)
 {
-    if (anchorPoint == "TopLeft")      return 0;
-    if (anchorPoint == "TopCenter")    return 1;
-    if (anchorPoint == "TopRight")     return 2;
-    if (anchorPoint == "MiddleLeft")   return 3;
-    if (anchorPoint == "Center")       return 4;
-    if (anchorPoint == "MiddleRight")  return 5;
-    if (anchorPoint == "BottomLeft")   return 6;
-    if (anchorPoint == "BottomCenter") return 7;
-    if (anchorPoint == "BottomRight")  return 8;
-    return 4;
+    return static_cast<short> (AnchorIdFromString (anchorPoint));
 }
 
 API_Guid GetAttributeGuidFromIndex (API_AttrTypeID typeID, API_AttributeIndex index)

--- a/archicad-addon/Sources/CommandBase.hpp
+++ b/archicad-addon/Sources/CommandBase.hpp
@@ -74,6 +74,34 @@ std::vector<PolygonData> GetPolygonsFromMemoCoords (const API_Guid& elemGuid, bo
 void AddPolygonFromMemoCoords (const API_Guid& elemGuid, GS::ObjectState& os, const GS::String& coordsFieldName, const GS::Optional<GS::String>& arcsFieldName = {});
 void AddPolygonWithHolesFromMemoCoords (const API_Guid& elemGuid, GS::ObjectState& os, const GS::String& coordsFieldName, const GS::Optional<GS::String>& arcsFieldName, const GS::String& holesArrayFieldName, const GS::String& holeCoordsFieldName, const GS::Optional<GS::String>& holeArcsFieldName, bool includeZCoords = false);
 bool GetHoleGeometry (const GS::ObjectState& holeOs, GS::Array<GS::ObjectState>& outCoords, GS::Array<GS::ObjectState>& outArcs);
+void AddBeamHolesFromMemo (const API_Guid& elemGuid, GS::ObjectState& os, const GS::String& holesFieldName);
+void AddColumnSectionFromMemo (const API_Guid& elemGuid, GS::ObjectState& os);
+void AddBeamSectionFromMemo (const API_Guid& elemGuid, GS::ObjectState& os);
+GS::UniString AnchorIdToString (API_AnchorID anchorId);
+API_AnchorID AnchorIdFromString (const GS::UniString& str, API_AnchorID defaultValue = APIAnc_MM);
+GS::UniString WallReferenceLineLocationToString (API_WallReferenceLineLocationID location);
+API_WallReferenceLineLocationID WallReferenceLineLocationFromString (const GS::UniString& str, API_WallReferenceLineLocationID defaultValue = APIWallRefLine_Outside);
+GS::UniString ZoneRelToString (API_ZoneRelID zoneRel);
+API_ZoneRelID ZoneRelFromString (const GS::UniString& str, API_ZoneRelID defaultValue = APIZRel_Boundary);
+GS::ObjectState CreateStoryVisibilityObjectState (const API_StoryVisibility& visibility);
+API_StoryVisibility GetStoryVisibilityFromObjectState (const GS::ObjectState& os);
+GS::UniString SlabReferencePlaneLocationToString (API_SlabReferencePlaneLocationID location);
+API_SlabReferencePlaneLocationID SlabReferencePlaneLocationFromString (const GS::UniString& str, API_SlabReferencePlaneLocationID defaultValue = APISlabRefPlane_Top);
+GS::ObjectState CreateOverriddenMaterialObjectState (const API_OverriddenAttribute& attr);
+API_OverriddenAttribute GetOverriddenMaterialFromObjectState (const GS::ObjectState& os);
+#ifdef ServerMainVers_2700
+GS::ObjectState CreateOverriddenPenObjectState (const API_OverriddenPen& pen);
+API_OverriddenPen GetOverriddenPenFromObjectState (const GS::ObjectState& os);
+#endif
+GS::UniString CoverFillTransformationTypeToString (API_CoverFillTransformationTypeID type);
+API_CoverFillTransformationTypeID CoverFillTransformationTypeFromString (const GS::UniString& str, API_CoverFillTransformationTypeID defaultValue = API_CoverFillTransformationType_Global);
+GS::ObjectState CreateCoverFillTransformationObjectState (const API_CoverFillTransformation& transformation);
+API_CoverFillTransformation GetCoverFillTransformationFromObjectState (const GS::ObjectState& os);
+GS::ObjectState CreateCoverFillObjectState (bool use, bool useFromSurface, bool orientationComesFrom3D, API_AttributeIndex fillIndex, short foregroundPen, short backgroundPen, API_CoverFillTransformationTypeID transformationType, const API_CoverFillTransformation& transformation);
+GS::UniString HatchOrientationTypeToString (API_HatchOrientationTypeID type);
+API_HatchOrientationTypeID HatchOrientationTypeFromString (const GS::UniString& str, API_HatchOrientationTypeID defaultValue = API_HatchGlobal);
+GS::ObjectState CreateHatchOrientationObjectState (const API_HatchOrientation& orientation);
+API_HatchOrientation GetHatchOrientationFromObjectState (const GS::ObjectState& os);
 
 // Defined in ExtendedElementCommands.cpp (not ElementCommands.cpp, where it's called from) -
 // reading a Morph's body needs Model3D/MeshBody.hpp, which cannot be included in the same

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -739,10 +739,43 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                 }
                 if (StructureTypeToString (elem.wall.modelElemStructureType) == "Composite") {
                     typeSpecificDetails.Add ("compositeId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_CompWallID, elem.wall.composite)));
+                } else if (StructureTypeToString (elem.wall.modelElemStructureType) == "Basic") {
+                    typeSpecificDetails.Add ("buildingMaterialId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_BuildingMaterialID, elem.wall.buildingMaterial)));
+                } else if (StructureTypeToString (elem.wall.modelElemStructureType) == "Profile") {
+                    typeSpecificDetails.Add ("profileId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_ProfileID, elem.wall.profileAttr)));
                 }
+                typeSpecificDetails.Add ("referenceLineLocation", WallReferenceLineLocationToString (elem.wall.referenceLineLocation));
+                {
+                    const char* profileTypeStr = "Normal";
+                    if (elem.wall.profileType == APISect_Slanted) {
+                        profileTypeStr = "Slanted";
+                    } else if (elem.wall.profileType == APISect_Trapez) {
+                        profileTypeStr = "Trapez";
+                    } else if (elem.wall.profileType == APISect_Poly) {
+                        profileTypeStr = "Poly";
+                    }
+                    typeSpecificDetails.Add ("profileType", profileTypeStr);
+                }
+                typeSpecificDetails.Add ("slantAlpha", elem.wall.slantAlpha);
+                typeSpecificDetails.Add ("slantBeta", elem.wall.slantBeta);
+                typeSpecificDetails.Add ("topOffset", elem.wall.topOffset);
+                typeSpecificDetails.Add ("relativeTopStory", elem.wall.relativeTopStory);
+                typeSpecificDetails.Add ("zoneRel", ZoneRelToString (elem.wall.zoneRel));
+                typeSpecificDetails.Add ("visibility", CreateStoryVisibilityObjectState (elem.wall.visibility));
+                typeSpecificDetails.Add ("isAutoOnStoryVisibility", elem.wall.isAutoOnStoryVisibility);
+                typeSpecificDetails.Add ("referenceMaterial", CreateOverriddenMaterialObjectState (elem.wall.refMat));
+                typeSpecificDetails.Add ("oppositeMaterial", CreateOverriddenMaterialObjectState (elem.wall.oppMat));
+                typeSpecificDetails.Add ("sideMaterial", CreateOverriddenMaterialObjectState (elem.wall.sidMat));
+#ifdef ServerMainVers_2700
+                typeSpecificDetails.Add ("cutFillPen", CreateOverriddenPenObjectState (elem.wall.cutFillPen));
+                typeSpecificDetails.Add ("cutFillBackgroundPen", CreateOverriddenPenObjectState (elem.wall.cutFillBackgroundPen));
+#else
+                typeSpecificDetails.Add ("cutFillPen", GS::ObjectState ("overridden", false));
+                typeSpecificDetails.Add ("cutFillBackgroundPen", GS::ObjectState ("overridden", false));
+#endif
                 break;
 
-            case API_BeamID:
+            case API_BeamID: {
                 typeSpecificDetails.Add ("zCoordinate", GetZPos (elem.header.floorInd, elem.beam.level, stories));
                 typeSpecificDetails.Add ("begCoordinate", Create2DCoordinateObjectState (elem.beam.begC));
                 typeSpecificDetails.Add ("endCoordinate", Create2DCoordinateObjectState (elem.beam.endC));
@@ -751,7 +784,31 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                 typeSpecificDetails.Add ("slantAngle", elem.beam.slantAngle);
                 typeSpecificDetails.Add ("arcAngle", elem.beam.curveAngle);
                 typeSpecificDetails.Add ("verticalCurveHeight", elem.beam.verticalCurveHeight);
-                break;
+                const char* beamShapeStr = "Straight";
+                if (elem.beam.beamShape == API_HorizontallyCurvedBeam) {
+                    beamShapeStr = "HorizontallyCurved";
+                } else if (elem.beam.beamShape == API_VerticallyCurvedBeam) {
+                    beamShapeStr = "VerticallyCurved";
+                }
+                typeSpecificDetails.Add ("beamShape", beamShapeStr);
+                typeSpecificDetails.Add ("isSlanted", elem.beam.isSlanted);
+                typeSpecificDetails.Add ("isFlipped", elem.beam.isFlipped);
+                typeSpecificDetails.Add ("profileAngle", elem.beam.profileAngle);
+                typeSpecificDetails.Add ("anchorPoint", AnchorIdToString (static_cast<API_AnchorID> (elem.beam.anchorPoint)));
+#ifdef ServerMainVers_2700
+                typeSpecificDetails.Add ("cutFillPen", CreateOverriddenPenObjectState (elem.beam.cutFillPen));
+                typeSpecificDetails.Add ("cutFillBackgroundPen", CreateOverriddenPenObjectState (elem.beam.cutFillBackgroundPen));
+#else
+                typeSpecificDetails.Add ("cutFillPen", GS::ObjectState ("overridden", false));
+                typeSpecificDetails.Add ("cutFillBackgroundPen", GS::ObjectState ("overridden", false));
+#endif
+                typeSpecificDetails.Add ("coverFill", CreateCoverFillObjectState (
+                    elem.beam.useCoverFill, elem.beam.useCoverFillFromSurface, elem.beam.coverFillOrientationComesFrom3D,
+                    elem.beam.coverFillType, elem.beam.coverFillForegroundPen, elem.beam.coverFillBackgroundPen,
+                    elem.beam.coverFillTransformationType, elem.beam.coverFillTransformation));
+                AddBeamHolesFromMemo (elem.header.guid, typeSpecificDetails, "holes");
+                AddBeamSectionFromMemo (elem.header.guid, typeSpecificDetails);
+            } break;
 
             case API_SlabID:
                 typeSpecificDetails.Add ("structureType", StructureTypeToString (elem.slab.modelElemStructureType));
@@ -759,6 +816,32 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                 typeSpecificDetails.Add ("level", elem.slab.level);
                 typeSpecificDetails.Add ("offsetFromTop", elem.slab.offsetFromTop);
                 typeSpecificDetails.Add ("zCoordinate", GetZPos (elem.header.floorInd, elem.slab.level, stories));
+                typeSpecificDetails.Add ("referencePlaneLocation", SlabReferencePlaneLocationToString (elem.slab.referencePlaneLocation));
+                if (StructureTypeToString (elem.slab.modelElemStructureType) == "Composite") {
+                    typeSpecificDetails.Add ("compositeId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_CompWallID, elem.slab.composite)));
+                } else {
+                    typeSpecificDetails.Add ("buildingMaterialId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_BuildingMaterialID, elem.slab.buildingMaterial)));
+                }
+                typeSpecificDetails.Add ("topMaterial", CreateOverriddenMaterialObjectState (elem.slab.topMat));
+                typeSpecificDetails.Add ("sideMaterial", CreateOverriddenMaterialObjectState (elem.slab.sideMat));
+                typeSpecificDetails.Add ("bottomMaterial", CreateOverriddenMaterialObjectState (elem.slab.botMat));
+#ifdef ServerMainVers_2700
+                typeSpecificDetails.Add ("cutFillPen", CreateOverriddenPenObjectState (elem.slab.cutFillPen));
+                typeSpecificDetails.Add ("cutFillBackgroundPen", CreateOverriddenPenObjectState (elem.slab.cutFillBackgroundPen));
+#else
+                typeSpecificDetails.Add ("cutFillPen", GS::ObjectState ("overridden", false));
+                typeSpecificDetails.Add ("cutFillBackgroundPen", GS::ObjectState ("overridden", false));
+#endif
+                {
+                    GS::ObjectState floorFillOs;
+                    floorFillOs.Add ("use", elem.slab.useFloorFill);
+                    floorFillOs.Add ("foregroundPen", elem.slab.floorFillPen);
+                    floorFillOs.Add ("backgroundPen", elem.slab.floorFillBGPen);
+                    floorFillOs.Add ("fillId", CreateGuidObjectState (GetAttributeGuidFromIndex (API_FilltypeID, elem.slab.floorFillInd)));
+                    floorFillOs.Add ("use3DHatching", elem.slab.use3DHatching);
+                    floorFillOs.Add ("orientation", CreateHatchOrientationObjectState (elem.slab.hatchOrientation));
+                    typeSpecificDetails.Add ("floorFill", floorFillOs);
+                }
                 AddPolygonWithHolesFromMemoCoords (elem.header.guid, typeSpecificDetails, "polygonOutline", "polygonArcs", "holes", "polygonOutline", "polygonArcs");
                 break;
 
@@ -776,9 +859,30 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
 
             case API_ColumnID:
                 typeSpecificDetails.Add ("origin", Create2DCoordinateObjectState (elem.column.origoPos));
+                typeSpecificDetails.Add ("coreAnchor", AnchorIdToString (static_cast<API_AnchorID> (elem.column.coreAnchor)));
                 typeSpecificDetails.Add ("zCoordinate", GetZPos (elem.header.floorInd, elem.column.bottomOffset, stories));
                 typeSpecificDetails.Add ("height", elem.column.height);
                 typeSpecificDetails.Add ("bottomOffset", elem.column.bottomOffset);
+                typeSpecificDetails.Add ("axisRotationAngle", elem.column.axisRotationAngle);
+                typeSpecificDetails.Add ("isSlanted", elem.column.isSlanted);
+                typeSpecificDetails.Add ("slantAngle", elem.column.slantAngle);
+                typeSpecificDetails.Add ("slantDirectionAngle", elem.column.slantDirectionAngle);
+                typeSpecificDetails.Add ("isFlipped", elem.column.isFlipped);
+                typeSpecificDetails.Add ("wrapping", elem.column.wrapping);
+                typeSpecificDetails.Add ("topOffset", elem.column.topOffset);
+                typeSpecificDetails.Add ("relativeTopStory", elem.column.relativeTopStory);
+#ifdef ServerMainVers_2700
+                typeSpecificDetails.Add ("cutFillPen", CreateOverriddenPenObjectState (elem.column.cutFillPen));
+                typeSpecificDetails.Add ("cutFillBackgroundPen", CreateOverriddenPenObjectState (elem.column.cutFillBackgroundPen));
+#else
+                typeSpecificDetails.Add ("cutFillPen", GS::ObjectState ("overridden", false));
+                typeSpecificDetails.Add ("cutFillBackgroundPen", GS::ObjectState ("overridden", false));
+#endif
+                typeSpecificDetails.Add ("coverFill", CreateCoverFillObjectState (
+                    elem.column.useCoverFill, elem.column.useCoverFillFromSurface, elem.column.coverFillOrientationComesFrom3D,
+                    elem.column.coverFillType, elem.column.coverFillForegroundPen, elem.column.coverFillBackgroundPen,
+                    elem.column.coverFillTransformationType, elem.column.coverFillTransformation));
+                AddColumnSectionFromMemo (elem.header.guid, typeSpecificDetails);
                 break;
 
             case API_DoorID:

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -163,6 +163,22 @@ GS::Optional<GS::UniString> CreateColumnsCommand::GetInputParametersSchema () co
                             "description": "Optional anchor point of the column core on a 3x3 grid.",
                             "enum": ["TopLeft", "TopCenter", "TopRight", "MiddleLeft", "Center", "MiddleRight", "BottomLeft", "BottomCenter", "BottomRight"]
                         },
+                        "circleBased": {
+                            "type": "boolean",
+                            "description": "True for a round column cross section, false for rectangular. Ignored if profileId is also given. Applied to all segments."
+                        },
+                        "isWidthAndHeightLinked": {
+                            "type": "boolean",
+                            "description": "When true (the default), Archicad keeps width and depth equal and setting one changes the other - set to false to give width/depth independent values. Applied to all segments."
+                        },
+                        "buildingMaterialId": {
+                            "$ref": "#/AttributeId",
+                            "description": "Cross section building material (round or rectangular, per circleBased). Applied to all segments."
+                        },
+                        "profileId": {
+                            "$ref": "#/AttributeId",
+                            "description": "Switches the cross section to this custom extruded profile (circleBased becomes false). Applied to all segments."
+                        },
                         "floorIndex": {
                             "type": "integer",
                             "description": "Optional floor index. If omitted, derived from the coordinate's z value."
@@ -208,14 +224,36 @@ GS::Optional<GS::ObjectState> CreateColumnsCommand::SetTypeSpecificParameters (A
     bool hasWidth = parameters.Get ("width", width);
     bool hasDepth = parameters.Get ("depth", depth);
 
-    if ((hasWidth || hasDepth) && memo.columnSegments != nullptr) {
+    bool circleBased = false;
+    const bool hasCircleBased = parameters.Get ("circleBased", circleBased);
+    bool isWidthAndHeightLinked = false;
+    const bool hasIsWidthAndHeightLinked = parameters.Get ("isWidthAndHeightLinked", isWidthAndHeightLinked);
+    const GS::ObjectState* buildingMaterialIdOs = parameters.Get ("buildingMaterialId");
+    const GS::ObjectState* profileIdOs = parameters.Get ("profileId");
+
+    if ((hasWidth || hasDepth || hasCircleBased || hasIsWidthAndHeightLinked || buildingMaterialIdOs != nullptr || profileIdOs != nullptr) && memo.columnSegments != nullptr) {
         GSSize nSegments = BMGetPtrSize (reinterpret_cast<GSPtr>(memo.columnSegments)) / sizeof (API_ColumnSegmentType);
         for (GSSize i = 0; i < nSegments; ++i) {
+            API_AssemblySegmentData& segment = memo.columnSegments[i].assemblySegmentData;
+            if (hasIsWidthAndHeightLinked) {
+                segment.isWidthAndHeightLinked = isWidthAndHeightLinked;
+            }
             if (hasWidth) {
-                memo.columnSegments[i].assemblySegmentData.nominalWidth = width;
+                segment.nominalWidth = width;
             }
             if (hasDepth) {
-                memo.columnSegments[i].assemblySegmentData.nominalHeight = depth;
+                segment.nominalHeight = depth;
+            }
+            if (hasCircleBased) {
+                segment.circleBased = circleBased;
+            }
+            if (profileIdOs != nullptr) {
+                segment.modelElemStructureType = API_ProfileStructure;
+                segment.profileAttr = GetAttributeIndexFromGuid (API_ProfileID, GetGuidFromObjectState (*profileIdOs));
+                segment.circleBased = false;
+            } else if (buildingMaterialIdOs != nullptr) {
+                segment.modelElemStructureType = API_BasicStructure;
+                segment.buildingMaterial = GetAttributeIndexFromGuid (API_BuildingMaterialID, GetGuidFromObjectState (*buildingMaterialIdOs));
             }
         }
     }

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -16,6 +16,7 @@
 #include "Polygon2D.hpp"
 #endif
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <map>
@@ -859,41 +860,71 @@ GS::Optional<GS::UniString> BuildSlabMemoFromGeometry (
     // slabs (e.g. the default slab reports nCoords but leaves memo.coords == nullptr).
     // The original size-change-only guards skipped allocation whenever the requested
     // polygon matched the default size, leaving memo.coords null and crashing
-    // AddPolyToMemo with a null dereference. BMReallocHandle does NOT allocate from a
-    // null handle, so a null handle must be created fresh with BMAllocateHandle (as the
-    // mesh/zone commands do); only an existing handle is resized with BMReallocHandle.
+    // AddPolyToMemo with a null dereference.
+    //
+    // Each handle below is checked independently rather than bundled behind a single
+    // coords-based guard: ACAPI_Element_GetMemo can legitimately return edgeTrims/
+    // sideMaterials/vertexIDs as null even when coords itself is populated (e.g. a slab
+    // that has never had a custom edge trim never materializes memo.edgeTrims), and
+    // AddPolyToMemo below unconditionally writes through edgeTrims/sideMaterials whenever
+    // a non-null override pointer is passed in (as it is here).
+    //
+    // On a real size change, existing handles are freed with BMKillHandle/BMKillPtr and
+    // reallocated fresh, not resized in place with BMReallocHandle/BMReallocPtr - confirmed
+    // via a real crash report (issue #452, "Fatal memory error in BMReallocPtr... Requested
+    // memory size is 48 bytes" / BNValidWritePtr failure) that a handle coming back from
+    // ACAPI_Element_GetMemo is not safe to hand to BMRealloc*, even though it reads back
+    // non-null and its contents are valid. This is the same free-then-allocate pattern
+    // already used for the Stair baseline memo rebuild elsewhere in this file.
     const Int32 nCoords    = element.slab.poly.nCoords;
     const Int32 nSubPolys  = element.slab.poly.nSubPolys;
     const Int32 nArcs      = element.slab.poly.nArcs;
-    const bool  coordsWereNull = (memo.coords == nullptr);
+    const bool  sizeChanged = (oldPoly.nCoords != nCoords);
 
-    if (coordsWereNull) {
-        memo.coords        = reinterpret_cast<API_Coord**>             (BMAllocateHandle ((nCoords + 1) * sizeof (API_Coord),               ALLOCATE_CLEAR, 0));
-        memo.vertexIDs     = reinterpret_cast<UInt32**>                (BMAllocateHandle ((nCoords + 1) * sizeof (API_Coord),               ALLOCATE_CLEAR, 0));
-        memo.edgeTrims     = reinterpret_cast<API_EdgeTrim**>          (BMAllocateHandle ((nCoords + 1) * sizeof (API_EdgeTrim),            ALLOCATE_CLEAR, 0));
-        memo.sideMaterials = reinterpret_cast<API_OverriddenAttribute*>(BMAllocatePtr    ((nCoords + 1) * sizeof (API_OverriddenAttribute), ALLOCATE_CLEAR, 0));
-    } else if (oldPoly.nCoords != nCoords) {
-        memo.coords        = reinterpret_cast<API_Coord**>             (BMReallocHandle (reinterpret_cast<GSHandle> (memo.coords),        (nCoords + 1) * sizeof (API_Coord),               REALLOC_CLEAR, 0));
-        memo.vertexIDs     = reinterpret_cast<UInt32**>                (BMReallocHandle (reinterpret_cast<GSHandle> (memo.vertexIDs),     (nCoords + 1) * sizeof (API_Coord),               REALLOC_CLEAR, 0));
-        memo.edgeTrims     = reinterpret_cast<API_EdgeTrim**>          (BMReallocHandle (reinterpret_cast<GSHandle> (memo.edgeTrims),     (nCoords + 1) * sizeof (API_EdgeTrim),            REALLOC_CLEAR, 0));
-        memo.sideMaterials = reinterpret_cast<API_OverriddenAttribute*>(BMReallocPtr    (reinterpret_cast<GSPtr> (memo.sideMaterials), (nCoords + 1) * sizeof (API_OverriddenAttribute), REALLOC_CLEAR, 0));
+    if (memo.coords != nullptr && sizeChanged) {
+        BMKillHandle (reinterpret_cast<GSHandle*> (&memo.coords));
+    }
+    if (memo.coords == nullptr) {
+        memo.coords = reinterpret_cast<API_Coord**> (BMAllocateHandle ((nCoords + 1) * sizeof (API_Coord), ALLOCATE_CLEAR, 0));
+    }
+    if (memo.vertexIDs != nullptr && sizeChanged) {
+        BMKillHandle (reinterpret_cast<GSHandle*> (&memo.vertexIDs));
+    }
+    if (memo.vertexIDs == nullptr) {
+        memo.vertexIDs = reinterpret_cast<UInt32**> (BMAllocateHandle ((nCoords + 1) * sizeof (API_Coord), ALLOCATE_CLEAR, 0));
+    }
+    if (memo.edgeTrims != nullptr && sizeChanged) {
+        BMKillHandle (reinterpret_cast<GSHandle*> (&memo.edgeTrims));
+    }
+    if (memo.edgeTrims == nullptr) {
+        memo.edgeTrims = reinterpret_cast<API_EdgeTrim**> (BMAllocateHandle ((nCoords + 1) * sizeof (API_EdgeTrim), ALLOCATE_CLEAR, 0));
+    }
+    if (memo.sideMaterials != nullptr && sizeChanged) {
+        BMKillPtr (reinterpret_cast<GSPtr*> (&memo.sideMaterials));
+    }
+    if (memo.sideMaterials == nullptr) {
+        memo.sideMaterials = reinterpret_cast<API_OverriddenAttribute*> (BMAllocatePtr ((nCoords + 1) * sizeof (API_OverriddenAttribute), ALLOCATE_CLEAR, 0));
+    }
+    const bool subPolysChanged = (oldPoly.nSubPolys != nSubPolys);
+    if (memo.pends != nullptr && subPolysChanged) {
+        BMKillHandle (reinterpret_cast<GSHandle*> (&memo.pends));
     }
     if (memo.pends == nullptr) {
         memo.pends = reinterpret_cast<Int32**> (BMAllocateHandle ((nSubPolys + 1) * sizeof (Int32), ALLOCATE_CLEAR, 0));
-    } else if (oldPoly.nSubPolys != nSubPolys) {
-        memo.pends = reinterpret_cast<Int32**> (BMReallocHandle (reinterpret_cast<GSHandle> (memo.pends), (nSubPolys + 1) * sizeof (Int32), REALLOC_CLEAR, 0));
     }
     if (nArcs > 0) {
+        const bool arcsChanged = (oldPoly.nArcs != nArcs);
+        if (memo.parcs != nullptr && arcsChanged) {
+            BMKillHandle (reinterpret_cast<GSHandle*> (&memo.parcs));
+        }
         if (memo.parcs == nullptr) {
             memo.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (nArcs * sizeof (API_PolyArc), ALLOCATE_CLEAR, 0));
-        } else if (oldPoly.nArcs != nArcs) {
-            memo.parcs = reinterpret_cast<API_PolyArc**> (BMReallocHandle (reinterpret_cast<GSHandle> (memo.parcs), nArcs * sizeof (API_PolyArc), REALLOC_CLEAR, 0));
         }
     }
-    const bool needToProcessVertexIDs =
-        coordsWereNull ||
-        oldPoly.nCoords != element.slab.poly.nCoords ||
-        oldPoly.nSubPolys != element.slab.poly.nSubPolys;
+    // Always rewrite vertex IDs: with the free-then-allocate pattern above, any size change
+    // yields freshly zeroed (and therefore always-stale) vertex ID slots, and a same-size
+    // in-place reuse still needs correct IDs recomputed for the new geometry.
+    const bool needToProcessVertexIDs = true;
 
     const API_EdgeTrimID edgeTrimSideType = APIEdgeTrim_Vertical;
     Int32 iCoord = 1;
@@ -907,6 +938,250 @@ GS::Optional<GS::UniString> BuildSlabMemoFromGeometry (
         if (GetHoleGeometry (hole, holePolygonOutline, holePolygonArcs)) {
             AddPolyToMemo (holePolygonOutline, holePolygonArcs, iCoord, iArc, iPends, memo, &edgeTrimSideType, &element.slab.sideMat, needToProcessVertexIDs);
         }
+    }
+
+    // vertexIDs[0] must hold the max vertex ID used across the whole shape - an undocumented
+    // ACAPI_Element_Change requirement (confirmed live in this repo's PolyLine/Hatch geometry
+    // SET work) without which ACAPI_Element_Change rejects the polygon with APIERR_BADPOLY.
+    // AddPolyToMemo never writes index 0 itself, so it is filled in here by scanning the IDs
+    // it did write.
+    if (memo.vertexIDs != nullptr) {
+        UInt32 maxVertexID = 0;
+        for (Int32 i = 1; i <= nCoords; ++i) {
+            maxVertexID = std::max (maxVertexID, (*memo.vertexIDs)[i]);
+        }
+        (*memo.vertexIDs)[0] = maxVertexID;
+    }
+
+    return {};
+}
+
+// The new-style ACAPI_Polygon_InsertPolyNode/DeletePolyNode/InsertSubPoly/DeleteSubPoly functions
+// (declared in ACAPI_Goodies.h) do not exist before Archicad 27 - confirmed via the DevKit headers
+// directly, AC25/26 have no ACAPI_Goodies.h at all. Pre-27, the same operations are reached through
+// the older, untyped ACAPI_Goodies (API_GoodiesID, void*, void*, void*, void*) dispatcher with the
+// APIAny_*PolyNodeID/APIAny_*SubPolyID constants (APIdefs_Goodies.h) - these wrappers keep
+// ApplySlabPolygonChange version-agnostic, mirroring the TAPIR_Browser_* pattern in
+// ScriptUIPalette.cpp for the same AC25/26-vs-27+ split.
+#ifdef ServerMainVers_2700
+static GSErrCode TAPIR_Polygon_InsertPolyNode (API_ElementMemo* memo, Int32* nodeIndex, API_Coord* coord)
+{
+    return ACAPI_Polygon_InsertPolyNode (memo, nodeIndex, coord);
+}
+static GSErrCode TAPIR_Polygon_DeletePolyNode (API_ElementMemo* memo, Int32* nodeIndex)
+{
+    return ACAPI_Polygon_DeletePolyNode (memo, nodeIndex);
+}
+static GSErrCode TAPIR_Polygon_InsertSubPoly (API_ElementMemo* memo, API_ElementMemo* insMemo)
+{
+    return ACAPI_Polygon_InsertSubPoly (memo, insMemo);
+}
+static GSErrCode TAPIR_Polygon_DeleteSubPoly (API_ElementMemo* memo, Int32* subPolyIndex)
+{
+    return ACAPI_Polygon_DeleteSubPoly (memo, subPolyIndex);
+}
+#else
+static GSErrCode TAPIR_Polygon_InsertPolyNode (API_ElementMemo* memo, Int32* nodeIndex, API_Coord* coord)
+{
+    return ACAPI_Goodies (APIAny_InsertPolyNodeID, memo, nodeIndex, coord);
+}
+static GSErrCode TAPIR_Polygon_DeletePolyNode (API_ElementMemo* memo, Int32* nodeIndex)
+{
+    return ACAPI_Goodies (APIAny_DeletePolyNodeID, memo, nodeIndex);
+}
+static GSErrCode TAPIR_Polygon_InsertSubPoly (API_ElementMemo* memo, API_ElementMemo* insMemo)
+{
+    return ACAPI_Goodies (APIAny_InsertSubPolyID, memo, insMemo);
+}
+static GSErrCode TAPIR_Polygon_DeleteSubPoly (API_ElementMemo* memo, Int32* subPolyIndex)
+{
+    return ACAPI_Goodies (APIAny_DeleteSubPolyID, memo, subPolyIndex);
+}
+#endif
+
+// Applies a new outline/arcs/holes shape to an EXISTING slab's memo (already populated via
+// ACAPI_Element_GetMemo), for use with ACAPI_Element_ChangeMemo. Uses Graphisoft's own
+// polygon-editing primitives - TAPIR_Polygon_InsertPolyNode/DeletePolyNode/InsertSubPoly/
+// DeleteSubPoly above, matching the DevKit's own Element_Test/Element_Modify_Polygon.cpp reference
+// example for these exact element types (including API_SlabID) - to keep the coords/pends/parcs/
+// vertexIDs handles obtained from GetMemo internally consistent under a point/hole count change.
+// A from-scratch memo rebuild (the same approach BuildSlabMemoFromGeometry above uses for a fresh
+// Create) reliably failed with APIERR_BADPOLY via ACAPI_Element_Change here whenever the point or
+// subpoly count actually changed - even with every vertexIDs numbering scheme tried (sequential,
+// per-contour, mirrored closing duplicates) - while these primitives, paired with
+// ACAPI_Element_ChangeMemo and vertexIDs left untouched/zero for new vertices (see
+// API_ElementMemo's own documented convention - existing IDs must never be renumbered, new ones
+// get ID 0 for Archicad to assign), work correctly for every case tested (issue #452).
+static GS::Optional<GS::UniString> ApplySlabPolygonChange (
+    API_ElementMemo& memo,
+    const API_OverriddenAttribute& sideMat,
+    GS::Array<GS::ObjectState>& polygonOutline,
+    const GS::Array<GS::ObjectState>& polygonArcs,
+    const GS::Array<GS::ObjectState>& holes)
+{
+    if (polygonOutline.GetSize () < 3) {
+        return "'polygonOutline' must contain at least 3 coordinates.";
+    }
+    if (IsSame2DCoordinate (polygonOutline.GetFirst (), polygonOutline.GetLast ())) {
+        polygonOutline.Pop ();
+    }
+    if (memo.coords == nullptr || memo.pends == nullptr) {
+        return "Slab has no polygon data to modify.";
+    }
+
+    // A from-scratch memo rebuild (matching CreateSlabs, and BuildMeshPolyMemoFromGeometry's own
+    // proven-working pattern for ModifyMeshes) plus ACAPI_Element_Change reliably fails with
+    // APIERR_BADPOLY here whenever nCoords changes at all - confirmed live on the plain point-count
+    // case alone (no holes involved), so this is not a vertexIDs-numbering issue as first assumed
+    // (tried: global sequential, global with the closing duplicate mirroring the first point, and
+    // per-contour restart - all three failed identically). Graphisoft's own polygon-editing
+    // primitives - ACAPI_Polygon_InsertPolyNode/DeletePolyNode/InsertSubPoly/DeleteSubPoly, used by
+    // the DevKit's own reference example (Element_Test/Element_Modify_Polygon.cpp, targeting the
+    // same element types including API_SlabID) together with ACAPI_Element_ChangeMemo - keep the
+    // existing GetMemo-provided handles' internal consistency intact across a size change, which a
+    // full replacement apparently cannot always reproduce. They document that memo's coords/pends/
+    // parcs/vertexIDs handles "must be initialized"; ACAPI_Element_GetMemo can legitimately leave
+    // vertexIDs/parcs null (e.g. a slab with no per-edge customization/arcs), so those are seeded
+    // here first.
+    if (memo.vertexIDs == nullptr) {
+        // Per Graphisoft's own API_ElementMemo documentation: "If you retrieve an array of
+        // vertices, edges or contours with ACAPI_Element_GetMemo, do not change the IDs in these
+        // arrays. New vertices, edges and contours should be inserted with ID = 0." "Initialized"
+        // (as InsertPolyNode/DeleteSubPoly/etc. require) means the handle must exist at the right
+        // size, not that it must be pre-filled with a manually invented ID scheme - Archicad
+        // itself assigns real IDs to zero-ID vertices. Earlier attempts at manually numbering this
+        // (global sequential, per-contour restart, with/without mirroring the closing duplicate)
+        // were all guesses at an ID scheme Archicad was never asking for.
+        const Int32 existingNCoords = (Int32) (BMGetHandleSize ((GSHandle) memo.coords) / sizeof (API_Coord)) - 1;
+        memo.vertexIDs = reinterpret_cast<UInt32**> (BMAllocateHandle ((existingNCoords + 1) * sizeof (API_Coord), ALLOCATE_CLEAR, 0));
+    }
+    if (memo.parcs == nullptr) {
+        memo.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (0, ALLOCATE_CLEAR, 0));
+    }
+
+    // Step 1: remove every existing hole (subpoly index >= 2), highest index first so earlier
+    // deletions don't shift the indices of subpolys not yet processed.
+    const Int32 nSubPolys = (Int32) (BMGetHandleSize ((GSHandle) memo.pends) / sizeof (Int32)) - 1;
+    for (Int32 subPolyIndex = nSubPolys; subPolyIndex >= 2; --subPolyIndex) {
+        Int32 idx = subPolyIndex;
+        GSErrCode err = TAPIR_Polygon_DeleteSubPoly (&memo, &idx);
+        if (err != NoError) {
+            return "Failed to remove an existing slab hole.";
+        }
+    }
+
+    // Step 2: resize the main outline (subpoly 1) to the requested point count by repeatedly
+    // inserting/deleting node 1 - the coordinate value used for an inserted placeholder node does
+    // not matter, every point is overwritten with the real final coordinates right after.
+    Int32 outlineCount = (*memo.pends)[1] - 1; // real points, excluding the closing duplicate
+    const Int32 desiredOutlineCount = (Int32) polygonOutline.GetSize ();
+    while (outlineCount > desiredOutlineCount) {
+        Int32 idx = 1;
+        GSErrCode err = TAPIR_Polygon_DeletePolyNode (&memo, &idx);
+        if (err != NoError) {
+            return "Failed to adjust the slab outline's point count.";
+        }
+        --outlineCount;
+    }
+    while (outlineCount < desiredOutlineCount) {
+        // Per Graphisoft's own DevKit reference example (Do_Poly_InsertNode), nodeIndex is set to
+        // the clicked edge's begin-node index + 1 - i.e. the position the NEW node will occupy
+        // (shifting what was there up by one), not "insert after this existing node" as the header
+        // doc's wording alone suggests. To insert between existing nodes 1 and 2, that means
+        // nodeIndex = 2, not 1.
+        Int32 idx = 2;
+        const API_Coord& p1 = (*memo.coords)[1];
+        const API_Coord& p2 = (*memo.coords)[2];
+        API_Coord placeholder = {(p1.x + p2.x) / 2.0, (p1.y + p2.y) / 2.0};
+        GSErrCode err = TAPIR_Polygon_InsertPolyNode (&memo, &idx, &placeholder);
+        if (err != NoError) {
+            return "Failed to adjust the slab outline's point count.";
+        }
+        ++outlineCount;
+    }
+
+    for (Int32 i = 0; i < desiredOutlineCount; ++i) {
+        (*memo.coords)[i + 1] = Get2DCoordinateFromObjectState (polygonOutline[i]);
+    }
+    (*memo.coords)[desiredOutlineCount + 1] = (*memo.coords)[1];
+
+    // Resized to the EXACT new arc count, not just overwritten in place: reusing a stale-sized
+    // handle left old arc entries beyond the new count untouched (e.g. going from 2 arcs to 1, or
+    // to 0, silently kept the old 2nd arc around) - confirmed live, arcs "stuck" across modify
+    // calls that were supposed to remove/replace them.
+    {
+        const GS::Array<API_PolyArc> arcs = GetPolyArcs (polygonArcs, 1);
+        if (memo.parcs != nullptr) {
+            BMKillHandle (reinterpret_cast<GSHandle*> (&memo.parcs));
+        }
+        if (!arcs.IsEmpty ()) {
+            memo.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (arcs.GetSize () * sizeof (API_PolyArc), ALLOCATE_CLEAR, 0));
+            for (UIndex i = 0; i < arcs.GetSize (); ++i) {
+                (*memo.parcs)[i] = arcs[i];
+            }
+        } else {
+            memo.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (0, ALLOCATE_CLEAR, 0));
+        }
+    }
+
+    // Step 3: add the requested holes back, each as a fresh subpoly.
+    for (const GS::ObjectState& hole : holes) {
+        GS::Array<GS::ObjectState> holePolygonOutline;
+        GS::Array<GS::ObjectState> holePolygonArcs;
+        if (!GetHoleGeometry (hole, holePolygonOutline, holePolygonArcs) || holePolygonOutline.GetSize () < 3) {
+            continue;
+        }
+        const Int32 holeNCoords = (Int32) holePolygonOutline.GetSize ();
+        API_ElementMemo insMemo = {};
+        const GS::OnExit insCleanup ([&insMemo] () { ACAPI_DisposeElemMemoHdls (&insMemo); });
+        // +2, not +1: index 0 is the unused dummy slot and index holeNCoords+1 holds the closing
+        // duplicate point written below - allocating only holeNCoords+1 slots left that last write
+        // one element past the end of the handle, corrupting adjacent heap memory (a delayed,
+        // hard-to-diagnose C0000374 crash reported by Archicad much later during an unrelated
+        // commit - confirmed live by reproducing it on a plain hole-add).
+        insMemo.coords = reinterpret_cast<API_Coord**> (BMAllocateHandle ((holeNCoords + 2) * sizeof (API_Coord), ALLOCATE_CLEAR, 0));
+        for (Int32 i = 0; i < holeNCoords; ++i) {
+            (*insMemo.coords)[i + 1] = Get2DCoordinateFromObjectState (holePolygonOutline[i]);
+        }
+        (*insMemo.coords)[holeNCoords + 1] = (*insMemo.coords)[1];
+        insMemo.pends = reinterpret_cast<Int32**> (BMAllocateHandle (2 * sizeof (Int32), ALLOCATE_CLEAR, 0));
+        (*insMemo.pends)[0] = 0;
+        (*insMemo.pends)[1] = holeNCoords + 1;
+        if (!holePolygonArcs.IsEmpty ()) {
+            const GS::Array<API_PolyArc> holeArcs = GetPolyArcs (holePolygonArcs, 1);
+            insMemo.parcs = reinterpret_cast<API_PolyArc**> (BMAllocateHandle (holeArcs.GetSize () * sizeof (API_PolyArc), ALLOCATE_CLEAR, 0));
+            for (UIndex i = 0; i < holeArcs.GetSize (); ++i) {
+                (*insMemo.parcs)[i] = holeArcs[i];
+            }
+        }
+        GSErrCode err = TAPIR_Polygon_InsertSubPoly (&memo, &insMemo);
+        if (err != NoError) {
+            return "Failed to add a slab hole.";
+        }
+    }
+
+    // edgeTrims/sideMaterials are not touched by the Insert/Delete primitives above (per their own
+    // documentation - "other memo handles are not touched"), so they are resized fresh to match the
+    // final coordinate count. edgeTrims is a plain Handle (BMKillHandle+BMAllocateHandle is safe);
+    // sideMaterials is a raw Ptr, and BMReallocPtr on a GetMemo-provided one reliably corrupted the
+    // heap (issue #452's original crash report) - so it is freed and reallocated fresh too, never
+    // resized in place. Despite the DevKit's own Do_Poly_InsertNode/DeleteNode reference example
+    // treating this as unnecessary for API_SlabID and using APIMemoMask_Polygon alone for
+    // ACAPI_Element_ChangeMemo, using that narrower mask here reproducibly failed with
+    // APIERR_BADPARS on this exact hole-removal case - live-confirmed; the combined mask plus this
+    // rebuild is what actually works for hole add/remove, multi-hole, and arcs.
+    const Int32 finalNCoords = (Int32) (BMGetHandleSize ((GSHandle) memo.coords) / sizeof (API_Coord)) - 1;
+    if (memo.edgeTrims != nullptr) {
+        BMKillHandle (reinterpret_cast<GSHandle*> (&memo.edgeTrims));
+    }
+    memo.edgeTrims = reinterpret_cast<API_EdgeTrim**> (BMAllocateHandle ((finalNCoords + 1) * sizeof (API_EdgeTrim), ALLOCATE_CLEAR, 0));
+    if (memo.sideMaterials != nullptr) {
+        BMKillPtr (reinterpret_cast<GSPtr*> (&memo.sideMaterials));
+    }
+    memo.sideMaterials = reinterpret_cast<API_OverriddenAttribute*> (BMAllocatePtr ((finalNCoords + 1) * sizeof (API_OverriddenAttribute), ALLOCATE_CLEAR, 0));
+    for (Int32 i = 1; i <= finalNCoords; ++i) {
+        (*memo.edgeTrims)[i].sideType = APIEdgeTrim_Vertical;
+        memo.sideMaterials[i] = sideMat;
     }
 
     return {};
@@ -1116,7 +1391,12 @@ GS::Optional<GS::UniString> ApplyWallStructure (
             if (selection.profile != APIInvalidAttributeIndex) {
                 element.wall.profileAttr = selection.profile;
             }
-            element.wall.type = APIWtyp_Poly;
+            // Note: unlike Basic/Composite above, wall.type (the plan outline shape) is left
+            // untouched here - it is orthogonal to modelElemStructureType (the cross section),
+            // same relationship as profileType/slantAlpha for a Slanted/Trapez wall. Forcing
+            // APIWtyp_Poly here previously made ACAPI_Element_Create/_Change fail outright,
+            // since a Poly wall needs an actual polygon memo that neither CreateWalls nor
+            // ModifyWalls builds.
             break;
         case StructureSelectionKind::Unspecified:
             break;
@@ -1224,6 +1504,22 @@ GS::Optional<GS::UniString> ApplySlabStructure (
 bool ApplyWallDetails (API_Element& element, API_Element& mask, const GS::ObjectState& details)
 {
     bool changed = false;
+    GS::UniString geometryType;
+    if (details.Get ("geometryType", geometryType)) {
+        // Only Straight/Trapezoid are settable here: Polygonal would need a full outline/arc
+        // memo (like ModifySlabs' polygonOutline), which the wall's Modify command does not
+        // take as input at all yet. This is the plan outline shape (wall.type), unrelated to
+        // profileType/slantAlpha/slantBeta below (the cross section shape).
+        if (geometryType == "Trapezoid") {
+            element.wall.type = APIWtyp_Trapez;
+            ACAPI_ELEMENT_MASK_SET (mask, API_WallType, type);
+            changed = true;
+        } else if (geometryType == "Straight") {
+            element.wall.type = APIWtyp_Normal;
+            ACAPI_ELEMENT_MASK_SET (mask, API_WallType, type);
+            changed = true;
+        }
+    }
     auto begCoordinate = GetOptionalCoordinate2D (details, "begCoordinate");
     if (begCoordinate.HasValue ()) {
         element.wall.begC = begCoordinate.Get ();
@@ -1268,6 +1564,114 @@ bool ApplyWallDetails (API_Element& element, API_Element& mask, const GS::Object
         ACAPI_ELEMENT_MASK_SET (mask, API_WallType, bottomOffset);
         changed = true;
     }
+    GS::UniString referenceLineLocationStr;
+    if (details.Get ("referenceLineLocation", referenceLineLocationStr)) {
+        element.wall.referenceLineLocation = WallReferenceLineLocationFromString (referenceLineLocationStr);
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, referenceLineLocation);
+        changed = true;
+    }
+    GS::UniString profileTypeStr;
+    if (details.Get ("profileType", profileTypeStr)) {
+        // Distinct from geometryType/wall.type above: this is the cross section shape
+        // (APISect_*), not the plan outline. slantAlpha/slantBeta only have an effect once
+        // this is set to Slanted (Poly is not settable here - it needs a profile attribute
+        // wired through a separate mechanism, out of scope).
+        if (profileTypeStr == "Slanted") {
+            element.wall.profileType = APISect_Slanted;
+            ACAPI_ELEMENT_MASK_SET (mask, API_WallType, profileType);
+            changed = true;
+        } else if (profileTypeStr == "Trapez") {
+            element.wall.profileType = APISect_Trapez;
+            ACAPI_ELEMENT_MASK_SET (mask, API_WallType, profileType);
+            changed = true;
+        } else if (profileTypeStr == "Normal") {
+            element.wall.profileType = APISect_Normal;
+            ACAPI_ELEMENT_MASK_SET (mask, API_WallType, profileType);
+            changed = true;
+        }
+    }
+    auto slantAlpha = GetOptionalDouble (details, "slantAlpha");
+    if (slantAlpha.HasValue ()) {
+        element.wall.slantAlpha = slantAlpha.Get ();
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, slantAlpha);
+        changed = true;
+    }
+    auto slantBeta = GetOptionalDouble (details, "slantBeta");
+    if (slantBeta.HasValue ()) {
+        element.wall.slantBeta = slantBeta.Get ();
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, slantBeta);
+        changed = true;
+    }
+    auto topOffset = GetOptionalDouble (details, "topOffset");
+    if (topOffset.HasValue ()) {
+        element.wall.topOffset = topOffset.Get ();
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, topOffset);
+        changed = true;
+    }
+    auto relativeTopStory = GetOptionalDouble (details, "relativeTopStory");
+    if (relativeTopStory.HasValue ()) {
+        element.wall.relativeTopStory = static_cast<short> (relativeTopStory.Get ());
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, relativeTopStory);
+        changed = true;
+    }
+    GS::UniString zoneRelStr;
+    if (details.Get ("zoneRel", zoneRelStr)) {
+        element.wall.zoneRel = ZoneRelFromString (zoneRelStr);
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, zoneRel);
+        changed = true;
+    }
+    GS::ObjectState visibilityOs;
+    if (details.Get ("visibility", visibilityOs)) {
+        element.wall.visibility = GetStoryVisibilityFromObjectState (visibilityOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, visibility);
+        changed = true;
+        if (!details.Contains ("isAutoOnStoryVisibility")) {
+            // isAutoOnStoryVisibility defaults to true on a wall, in which case Archicad
+            // recomputes 'visibility' from the wall's vertical extent and silently discards
+            // whatever was just requested above - explicitly setting 'visibility' only makes
+            // sense once auto mode is off, so turn it off unless the caller says otherwise.
+            element.wall.isAutoOnStoryVisibility = false;
+            ACAPI_ELEMENT_MASK_SET (mask, API_WallType, isAutoOnStoryVisibility);
+        }
+    }
+    bool isAutoOnStoryVisibility = false;
+    if (details.Get ("isAutoOnStoryVisibility", isAutoOnStoryVisibility)) {
+        element.wall.isAutoOnStoryVisibility = isAutoOnStoryVisibility;
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, isAutoOnStoryVisibility);
+        changed = true;
+    }
+    GS::ObjectState referenceMaterialOs;
+    if (details.Get ("referenceMaterial", referenceMaterialOs)) {
+        element.wall.refMat = GetOverriddenMaterialFromObjectState (referenceMaterialOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, refMat);
+        changed = true;
+    }
+    GS::ObjectState oppositeMaterialOs;
+    if (details.Get ("oppositeMaterial", oppositeMaterialOs)) {
+        element.wall.oppMat = GetOverriddenMaterialFromObjectState (oppositeMaterialOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, oppMat);
+        changed = true;
+    }
+    GS::ObjectState sideMaterialOs;
+    if (details.Get ("sideMaterial", sideMaterialOs)) {
+        element.wall.sidMat = GetOverriddenMaterialFromObjectState (sideMaterialOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, sidMat);
+        changed = true;
+    }
+#ifdef ServerMainVers_2700
+    GS::ObjectState cutFillPenOs;
+    if (details.Get ("cutFillPen", cutFillPenOs)) {
+        element.wall.cutFillPen = GetOverriddenPenFromObjectState (cutFillPenOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, cutFillPen);
+        changed = true;
+    }
+    GS::ObjectState cutFillBackgroundPenOs;
+    if (details.Get ("cutFillBackgroundPen", cutFillBackgroundPenOs)) {
+        element.wall.cutFillBackgroundPen = GetOverriddenPenFromObjectState (cutFillBackgroundPenOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_WallType, cutFillBackgroundPen);
+        changed = true;
+    }
+#endif
     return changed;
 }
 
@@ -1328,6 +1732,75 @@ bool ApplySlabDetails (API_Element& element, API_Element& mask, const GS::Object
         element.slab.level = floorIndexAndOffset.second;
         ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, floorInd);
         ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, level);
+        changed = true;
+    }
+
+    GS::UniString referencePlaneLocationStr;
+    if (details.Get ("referencePlaneLocation", referencePlaneLocationStr)) {
+        element.slab.referencePlaneLocation = SlabReferencePlaneLocationFromString (referencePlaneLocationStr);
+        ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, referencePlaneLocation);
+        changed = true;
+    }
+
+    GS::ObjectState topMaterialOs;
+    if (details.Get ("topMaterial", topMaterialOs)) {
+        element.slab.topMat = GetOverriddenMaterialFromObjectState (topMaterialOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, topMat);
+        changed = true;
+    }
+    GS::ObjectState sideMaterialOs;
+    if (details.Get ("sideMaterial", sideMaterialOs)) {
+        element.slab.sideMat = GetOverriddenMaterialFromObjectState (sideMaterialOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, sideMat);
+        changed = true;
+    }
+    GS::ObjectState bottomMaterialOs;
+    if (details.Get ("bottomMaterial", bottomMaterialOs)) {
+        element.slab.botMat = GetOverriddenMaterialFromObjectState (bottomMaterialOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, botMat);
+        changed = true;
+    }
+#ifdef ServerMainVers_2700
+    GS::ObjectState cutFillPenOs;
+    if (details.Get ("cutFillPen", cutFillPenOs)) {
+        element.slab.cutFillPen = GetOverriddenPenFromObjectState (cutFillPenOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, cutFillPen);
+        changed = true;
+    }
+    GS::ObjectState cutFillBackgroundPenOs;
+    if (details.Get ("cutFillBackgroundPen", cutFillBackgroundPenOs)) {
+        element.slab.cutFillBackgroundPen = GetOverriddenPenFromObjectState (cutFillBackgroundPenOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, cutFillBackgroundPen);
+        changed = true;
+    }
+#endif
+
+    GS::ObjectState floorFillOs;
+    if (details.Get ("floorFill", floorFillOs)) {
+        floorFillOs.Get ("use", element.slab.useFloorFill);
+        Int32 foregroundPen = 0;
+        if (floorFillOs.Get ("foregroundPen", foregroundPen)) {
+            element.slab.floorFillPen = static_cast<short> (foregroundPen);
+        }
+        Int32 backgroundPen = 0;
+        if (floorFillOs.Get ("backgroundPen", backgroundPen)) {
+            element.slab.floorFillBGPen = static_cast<short> (backgroundPen);
+        }
+        GS::ObjectState fillIdOs;
+        if (floorFillOs.Get ("fillId", fillIdOs)) {
+            element.slab.floorFillInd = GetAttributeIndexFromGuid (API_FilltypeID, GetGuidFromObjectState (fillIdOs));
+        }
+        floorFillOs.Get ("use3DHatching", element.slab.use3DHatching);
+        GS::ObjectState orientationOs;
+        if (floorFillOs.Get ("orientation", orientationOs)) {
+            element.slab.hatchOrientation = GetHatchOrientationFromObjectState (orientationOs);
+        }
+        ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, useFloorFill);
+        ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, floorFillPen);
+        ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, floorFillBGPen);
+        ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, floorFillInd);
+        ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, use3DHatching);
+        ACAPI_ELEMENT_MASK_SET (mask, API_SlabType, hatchOrientation);
         changed = true;
     }
 
@@ -1416,6 +1889,103 @@ bool ApplyColumnDetails (API_Element& element, API_Element& mask, const GS::Obje
         ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, axisRotationAngle);
         changed = true;
     }
+    GS::UniString coreAnchor;
+    if (details.Get ("coreAnchor", coreAnchor)) {
+        element.column.coreAnchor = static_cast<short> (AnchorIdFromString (coreAnchor));
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, coreAnchor);
+        changed = true;
+    }
+    bool isSlanted = false;
+    if (details.Get ("isSlanted", isSlanted)) {
+        element.column.isSlanted = isSlanted;
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, isSlanted);
+        changed = true;
+    }
+    auto slantAngle = GetOptionalDouble (details, "slantAngle");
+    if (slantAngle.HasValue ()) {
+        element.column.slantAngle = slantAngle.Get ();
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, slantAngle);
+        changed = true;
+    }
+    auto slantDirectionAngle = GetOptionalDouble (details, "slantDirectionAngle");
+    if (slantDirectionAngle.HasValue ()) {
+        element.column.slantDirectionAngle = slantDirectionAngle.Get ();
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, slantDirectionAngle);
+        changed = true;
+    }
+    bool isFlipped = false;
+    if (details.Get ("isFlipped", isFlipped)) {
+        element.column.isFlipped = isFlipped;
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, isFlipped);
+        changed = true;
+    }
+    bool wrapping = false;
+    if (details.Get ("wrapping", wrapping)) {
+        element.column.wrapping = wrapping;
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, wrapping);
+        changed = true;
+    }
+    auto topOffset = GetOptionalDouble (details, "topOffset");
+    if (topOffset.HasValue ()) {
+        element.column.topOffset = topOffset.Get ();
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, topOffset);
+        changed = true;
+    }
+    auto relativeTopStory = GetOptionalDouble (details, "relativeTopStory");
+    if (relativeTopStory.HasValue ()) {
+        element.column.relativeTopStory = static_cast<short> (relativeTopStory.Get ());
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, relativeTopStory);
+        changed = true;
+    }
+#ifdef ServerMainVers_2700
+    GS::ObjectState cutFillPenOs;
+    if (details.Get ("cutFillPen", cutFillPenOs)) {
+        element.column.cutFillPen = GetOverriddenPenFromObjectState (cutFillPenOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, cutFillPen);
+        changed = true;
+    }
+    GS::ObjectState cutFillBackgroundPenOs;
+    if (details.Get ("cutFillBackgroundPen", cutFillBackgroundPenOs)) {
+        element.column.cutFillBackgroundPen = GetOverriddenPenFromObjectState (cutFillBackgroundPenOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, cutFillBackgroundPen);
+        changed = true;
+    }
+#endif
+    GS::ObjectState coverFillOs;
+    if (details.Get ("coverFill", coverFillOs)) {
+        coverFillOs.Get ("use", element.column.useCoverFill);
+        coverFillOs.Get ("useFromSurface", element.column.useCoverFillFromSurface);
+        coverFillOs.Get ("orientationComesFrom3D", element.column.coverFillOrientationComesFrom3D);
+        GS::ObjectState fillIdOs;
+        if (coverFillOs.Get ("fillId", fillIdOs)) {
+            element.column.coverFillType = GetAttributeIndexFromGuid (API_FilltypeID, GetGuidFromObjectState (fillIdOs));
+        }
+        Int32 foregroundPen = 0;
+        if (coverFillOs.Get ("foregroundPen", foregroundPen)) {
+            element.column.coverFillForegroundPen = static_cast<short> (foregroundPen);
+        }
+        Int32 backgroundPen = 0;
+        if (coverFillOs.Get ("backgroundPen", backgroundPen)) {
+            element.column.coverFillBackgroundPen = static_cast<short> (backgroundPen);
+        }
+        GS::UniString transformationTypeStr;
+        if (coverFillOs.Get ("transformationType", transformationTypeStr)) {
+            element.column.coverFillTransformationType = CoverFillTransformationTypeFromString (transformationTypeStr);
+        }
+        GS::ObjectState transformationOs;
+        if (coverFillOs.Get ("transformation", transformationOs)) {
+            element.column.coverFillTransformation = GetCoverFillTransformationFromObjectState (transformationOs);
+        }
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, useCoverFill);
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, useCoverFillFromSurface);
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, coverFillOrientationComesFrom3D);
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, coverFillType);
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, coverFillForegroundPen);
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, coverFillBackgroundPen);
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, coverFillTransformationType);
+        ACAPI_ELEMENT_MASK_SET (mask, API_ColumnType, coverFillTransformation);
+        changed = true;
+    }
     return changed;
 }
 
@@ -1464,7 +2034,182 @@ bool ApplyBeamDetails (API_Element& element, API_Element& mask, const GS::Object
         ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, verticalCurveHeight);
         changed = true;
     }
+    GS::UniString beamShapeStr;
+    if (details.Get ("beamShape", beamShapeStr)) {
+        if (beamShapeStr == "HorizontallyCurved") {
+            element.beam.beamShape = API_HorizontallyCurvedBeam;
+        } else if (beamShapeStr == "VerticallyCurved") {
+            element.beam.beamShape = API_VerticallyCurvedBeam;
+        } else {
+            element.beam.beamShape = API_StraightBeam;
+        }
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, beamShape);
+        changed = true;
+    }
+    bool isSlanted = false;
+    if (details.Get ("isSlanted", isSlanted)) {
+        element.beam.isSlanted = isSlanted;
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, isSlanted);
+        changed = true;
+    }
+    bool isFlipped = false;
+    if (details.Get ("isFlipped", isFlipped)) {
+        element.beam.isFlipped = isFlipped;
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, isFlipped);
+        changed = true;
+    }
+    auto profileAngle = GetOptionalDouble (details, "profileAngle");
+    if (profileAngle.HasValue ()) {
+        element.beam.profileAngle = profileAngle.Get ();
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, profileAngle);
+        changed = true;
+    }
+    GS::UniString anchorPointStr;
+    if (details.Get ("anchorPoint", anchorPointStr)) {
+        element.beam.anchorPoint = static_cast<short> (AnchorIdFromString (anchorPointStr));
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, anchorPoint);
+        changed = true;
+    }
+#ifdef ServerMainVers_2700
+    GS::ObjectState cutFillPenOs;
+    if (details.Get ("cutFillPen", cutFillPenOs)) {
+        element.beam.cutFillPen = GetOverriddenPenFromObjectState (cutFillPenOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, cutFillPen);
+        changed = true;
+    }
+    GS::ObjectState cutFillBackgroundPenOs;
+    if (details.Get ("cutFillBackgroundPen", cutFillBackgroundPenOs)) {
+        element.beam.cutFillBackgroundPen = GetOverriddenPenFromObjectState (cutFillBackgroundPenOs);
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, cutFillBackgroundPen);
+        changed = true;
+    }
+#endif
+    GS::ObjectState coverFillOs;
+    if (details.Get ("coverFill", coverFillOs)) {
+        coverFillOs.Get ("use", element.beam.useCoverFill);
+        coverFillOs.Get ("useFromSurface", element.beam.useCoverFillFromSurface);
+        coverFillOs.Get ("orientationComesFrom3D", element.beam.coverFillOrientationComesFrom3D);
+        GS::ObjectState fillIdOs;
+        if (coverFillOs.Get ("fillId", fillIdOs)) {
+            element.beam.coverFillType = GetAttributeIndexFromGuid (API_FilltypeID, GetGuidFromObjectState (fillIdOs));
+        }
+        Int32 foregroundPen = 0;
+        if (coverFillOs.Get ("foregroundPen", foregroundPen)) {
+            element.beam.coverFillForegroundPen = static_cast<short> (foregroundPen);
+        }
+        Int32 backgroundPen = 0;
+        if (coverFillOs.Get ("backgroundPen", backgroundPen)) {
+            element.beam.coverFillBackgroundPen = static_cast<short> (backgroundPen);
+        }
+        GS::UniString transformationTypeStr;
+        if (coverFillOs.Get ("transformationType", transformationTypeStr)) {
+            element.beam.coverFillTransformationType = CoverFillTransformationTypeFromString (transformationTypeStr);
+        }
+        GS::ObjectState transformationOs;
+        if (coverFillOs.Get ("transformation", transformationOs)) {
+            element.beam.coverFillTransformation = GetCoverFillTransformationFromObjectState (transformationOs);
+        }
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, useCoverFill);
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, useCoverFillFromSurface);
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, coverFillOrientationComesFrom3D);
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, coverFillType);
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, coverFillForegroundPen);
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, coverFillBackgroundPen);
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, coverFillTransformationType);
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, coverFillTransformation);
+        changed = true;
+    }
     return changed;
+}
+
+static bool ApplyColumnSectionToMemo (API_Guid elemGuid, const GS::ObjectState& details)
+{
+    auto width = GetOptionalDouble (details, "width");
+    auto depth = GetOptionalDouble (details, "depth");
+    bool circleBased = false;
+    const bool hasCircleBased = details.Get ("circleBased", circleBased);
+    bool isWidthAndHeightLinked = false;
+    const bool hasIsWidthAndHeightLinked = details.Get ("isWidthAndHeightLinked", isWidthAndHeightLinked);
+    const GS::ObjectState* buildingMaterialIdOs = details.Get ("buildingMaterialId");
+    const GS::ObjectState* profileIdOs = details.Get ("profileId");
+    if (!width.HasValue () && !depth.HasValue () && !hasCircleBased && !hasIsWidthAndHeightLinked && buildingMaterialIdOs == nullptr && profileIdOs == nullptr) {
+        return true;
+    }
+
+    API_ElementMemo memo = {};
+    const GS::OnExit guard ([&memo] () { ACAPI_DisposeElemMemoHdls (&memo); });
+    if (ACAPI_Element_GetMemo (elemGuid, &memo, APIMemoMask_ColumnSegment) != NoError || memo.columnSegments == nullptr) {
+        return false;
+    }
+
+    const GSSize nSegments = BMGetPtrSize (reinterpret_cast<GSPtr> (memo.columnSegments)) / sizeof (API_ColumnSegmentType);
+    for (GSSize i = 0; i < nSegments; ++i) {
+        API_AssemblySegmentData& segment = memo.columnSegments[i].assemblySegmentData;
+        if (hasIsWidthAndHeightLinked) {
+            segment.isWidthAndHeightLinked = isWidthAndHeightLinked;
+        }
+        if (width.HasValue ()) {
+            segment.nominalWidth = width.Get ();
+        }
+        if (depth.HasValue ()) {
+            segment.nominalHeight = depth.Get ();
+        }
+        if (hasCircleBased) {
+            segment.circleBased = circleBased;
+        }
+        if (profileIdOs != nullptr) {
+            segment.modelElemStructureType = API_ProfileStructure;
+            segment.profileAttr = GetAttributeIndexFromGuid (API_ProfileID, GetGuidFromObjectState (*profileIdOs));
+            segment.circleBased = false;
+        } else if (buildingMaterialIdOs != nullptr) {
+            segment.modelElemStructureType = API_BasicStructure;
+            segment.buildingMaterial = GetAttributeIndexFromGuid (API_BuildingMaterialID, GetGuidFromObjectState (*buildingMaterialIdOs));
+        }
+    }
+
+    return ACAPI_Element_ChangeMemo (elemGuid, APIMemoMask_ColumnSegment, &memo) == NoError;
+}
+
+static bool ApplyBeamSectionToMemo (API_Guid elemGuid, const GS::ObjectState& details)
+{
+    auto width = GetOptionalDouble (details, "width");
+    auto height = GetOptionalDouble (details, "height");
+    bool isWidthAndHeightLinked = false;
+    const bool hasIsWidthAndHeightLinked = details.Get ("isWidthAndHeightLinked", isWidthAndHeightLinked);
+    const GS::ObjectState* buildingMaterialIdOs = details.Get ("buildingMaterialId");
+    const GS::ObjectState* profileIdOs = details.Get ("profileId");
+    if (!width.HasValue () && !height.HasValue () && !hasIsWidthAndHeightLinked && buildingMaterialIdOs == nullptr && profileIdOs == nullptr) {
+        return true;
+    }
+
+    API_ElementMemo memo = {};
+    const GS::OnExit guard ([&memo] () { ACAPI_DisposeElemMemoHdls (&memo); });
+    if (ACAPI_Element_GetMemo (elemGuid, &memo, APIMemoMask_BeamSegment) != NoError || memo.beamSegments == nullptr) {
+        return false;
+    }
+
+    const GSSize nSegments = BMGetPtrSize (reinterpret_cast<GSPtr> (memo.beamSegments)) / sizeof (API_BeamSegmentType);
+    for (GSSize i = 0; i < nSegments; ++i) {
+        API_AssemblySegmentData& segment = memo.beamSegments[i].assemblySegmentData;
+        if (hasIsWidthAndHeightLinked) {
+            segment.isWidthAndHeightLinked = isWidthAndHeightLinked;
+        }
+        if (width.HasValue ()) {
+            segment.nominalWidth = width.Get ();
+        }
+        if (height.HasValue ()) {
+            segment.nominalHeight = height.Get ();
+        }
+        if (profileIdOs != nullptr) {
+            segment.modelElemStructureType = API_ProfileStructure;
+            segment.profileAttr = GetAttributeIndexFromGuid (API_ProfileID, GetGuidFromObjectState (*profileIdOs));
+        } else if (buildingMaterialIdOs != nullptr) {
+            segment.modelElemStructureType = API_BasicStructure;
+            segment.buildingMaterial = GetAttributeIndexFromGuid (API_BuildingMaterialID, GetGuidFromObjectState (*buildingMaterialIdOs));
+        }
+    }
+
+    return ACAPI_Element_ChangeMemo (elemGuid, APIMemoMask_BeamSegment, &memo) == NoError;
 }
 
 bool BuildCuboidMorphMemo (double sizeX, double sizeY, double sizeZ, API_AttributeIndex buildingMaterial, API_ElementMemo& memo)
@@ -1613,7 +2358,11 @@ static bool TextureProjectionTypeFromString (const GS::UniString& s, API_Texture
     return false;
 }
 
-static GS::UniString HatchOrientationTypeToString (API_HatchOrientationTypeID orientationType)
+// Named distinctly from CommandBase.hpp's HatchOrientationTypeToString/FromString (added
+// alongside the Slab cover-fill work): that pair has a different signature (returns the value
+// directly, with a fallback default) and cannot report an invalid string, whereas Morph's own
+// coverFillOrientation handling below specifically needs to reject an invalid type string outright.
+static GS::UniString MorphHatchOrientationTypeToString (API_HatchOrientationTypeID orientationType)
 {
     switch (orientationType) {
         case API_HatchRotated:   return "Rotated";
@@ -1624,7 +2373,7 @@ static GS::UniString HatchOrientationTypeToString (API_HatchOrientationTypeID or
     }
 }
 
-static bool HatchOrientationTypeFromString (const GS::UniString& s, API_HatchOrientationTypeID& out)
+static bool MorphHatchOrientationTypeFromString (const GS::UniString& s, API_HatchOrientationTypeID& out)
 {
     if (s == "Global")     { out = API_HatchGlobal; return true; }
     if (s == "Rotated")    { out = API_HatchRotated; return true; }
@@ -2039,7 +2788,7 @@ bool ApplyMorphCosmeticDetails (const GS::ObjectState& details, API_Element& ele
             GS::UniString typeStr;
             if (orientOS->Get ("type", typeStr)) {
                 API_HatchOrientationTypeID t;
-                if (!HatchOrientationTypeFromString (typeStr, t)) {
+                if (!MorphHatchOrientationTypeFromString (typeStr, t)) {
                     errorOut = "Invalid 'coverFillOrientation.type'.";
                     return false;
                 }
@@ -2269,7 +3018,7 @@ void AddMorphBodyFromMemo (const API_Element& elem, GS::ObjectState& typeSpecifi
 
     {
         GS::ObjectState orientOS;
-        orientOS.Add ("type", HatchOrientationTypeToString (elem.morph.coverFillOrientation.type));
+        orientOS.Add ("type", MorphHatchOrientationTypeToString (elem.morph.coverFillOrientation.type));
         orientOS.Add ("origo", Create2DCoordinateObjectState (elem.morph.coverFillOrientation.origo));
         orientOS.Add ("matrix00", elem.morph.coverFillOrientation.matrix00);
         orientOS.Add ("matrix10", elem.morph.coverFillOrientation.matrix10);
@@ -2559,6 +3308,18 @@ GS::Optional<GS::UniString> CreateBeamsCommand::GetInputParametersSchema () cons
                             "type": "string",
                             "description": "Optional anchor point of the beam cross section on a 3x3 grid.",
                             "enum": ["TopLeft", "TopCenter", "TopRight", "MiddleLeft", "Center", "MiddleRight", "BottomLeft", "BottomCenter", "BottomRight"]
+                        },
+                        "isWidthAndHeightLinked": {
+                            "type": "boolean",
+                            "description": "When true (the default), Archicad keeps width and height equal and setting one changes the other - set to false to give width/height independent values. Applied to all segments."
+                        },
+                        "buildingMaterialId": {
+                            "$ref": "#/AttributeId",
+                            "description": "Cross section building material. Applied to all segments."
+                        },
+                        "profileId": {
+                            "$ref": "#/AttributeId",
+                            "description": "Switches the cross section to this custom extruded profile. Applied to all segments."
                         }
                     },
                     "additionalProperties": false,
@@ -2613,15 +3374,30 @@ GS::Optional<GS::ObjectState> CreateBeamsCommand::SetTypeSpecificParameters (API
 
     auto width = GetOptionalDouble (parameters, "width");
     auto height = GetOptionalDouble (parameters, "height");
+    bool isWidthAndHeightLinked = false;
+    const bool hasIsWidthAndHeightLinked = parameters.Get ("isWidthAndHeightLinked", isWidthAndHeightLinked);
+    const GS::ObjectState* buildingMaterialIdOs = parameters.Get ("buildingMaterialId");
+    const GS::ObjectState* profileIdOs = parameters.Get ("profileId");
 
-    if ((width.HasValue () || height.HasValue ()) && memo.beamSegments != nullptr) {
+    if ((width.HasValue () || height.HasValue () || hasIsWidthAndHeightLinked || buildingMaterialIdOs != nullptr || profileIdOs != nullptr) && memo.beamSegments != nullptr) {
         GSSize nSegments = BMGetPtrSize (reinterpret_cast<GSPtr>(memo.beamSegments)) / sizeof (API_BeamSegmentType);
         for (GSSize i = 0; i < nSegments; ++i) {
+            API_AssemblySegmentData& segment = memo.beamSegments[i].assemblySegmentData;
+            if (hasIsWidthAndHeightLinked) {
+                segment.isWidthAndHeightLinked = isWidthAndHeightLinked;
+            }
             if (width.HasValue ()) {
-                memo.beamSegments[i].assemblySegmentData.nominalWidth = width.Get ();
+                segment.nominalWidth = width.Get ();
             }
             if (height.HasValue ()) {
-                memo.beamSegments[i].assemblySegmentData.nominalHeight = height.Get ();
+                segment.nominalHeight = height.Get ();
+            }
+            if (profileIdOs != nullptr) {
+                segment.modelElemStructureType = API_ProfileStructure;
+                segment.profileAttr = GetAttributeIndexFromGuid (API_ProfileID, GetGuidFromObjectState (*profileIdOs));
+            } else if (buildingMaterialIdOs != nullptr) {
+                segment.modelElemStructureType = API_BasicStructure;
+                segment.buildingMaterial = GetAttributeIndexFromGuid (API_BuildingMaterialID, GetGuidFromObjectState (*buildingMaterialIdOs));
             }
         }
     }
@@ -4081,10 +4857,11 @@ GS::Optional<GS::UniString> ModifyWallsCommand::GetInputParametersSchema () cons
                     "type": "object",
                     "properties": {
                         "elementId": { "$ref": "#/ElementId" },
+                        "geometryType": { "type": "string", "enum": ["Straight", "Trapezoid"], "description": "The wall's plan outline shape (Polygonal is not settable here, read-only via GetDetailsOfElements). This is unrelated to slantAlpha/slantBeta - see profileType for the cross section shape those depend on." },
                         "begCoordinate": { "$ref": "#/Coordinate2D" },
                         "endCoordinate": { "$ref": "#/Coordinate2D" },
                         "arcAngle": { "type": "number", "description": "Arc angle in radians; non-zero makes the wall curved (begCoordinate/endCoordinate are the chord endpoints)." },
-                        "height": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "height": { "type": "number", "exclusiveMinimum": 0.0, "description": "Sets relativeTopStory to 0 (explicit height). Do not combine with relativeTopStory in the same call - whichever is applied last wins, and Archicad recomputes the actual height from the story elevations once relativeTopStory is non-zero." },
                         "thickness": { "type": "number", "exclusiveMinimum": 0.0 },
                         "bottomOffset": { "type": "number" },
                         "offset": { "type": "number" },
@@ -4094,7 +4871,28 @@ GS::Optional<GS::UniString> ModifyWallsCommand::GetInputParametersSchema () cons
                         },
                         "buildingMaterialId": { "$ref": "#/AttributeId" },
                         "compositeId": { "$ref": "#/AttributeId" },
-                        "profileId": { "$ref": "#/AttributeId" }
+                        "profileId": { "$ref": "#/AttributeId" },
+                        "referenceLineLocation": {
+                            "type": "string",
+                            "enum": ["Outside", "Center", "Inside", "CoreOutside", "CoreCenter", "CoreInside"],
+                            "description": "The Core* values only have an effect on a Composite or Profile wall (structureType) - a Basic wall has no core skin."
+                        },
+                        "profileType": { "type": "string", "enum": ["Normal", "Slanted", "Trapez"], "description": "Cross section shape of the wall, distinct from geometryType (which is the plan outline). slantAlpha/slantBeta only have an effect once this is set to Slanted." },
+                        "slantAlpha": { "type": "number", "description": "Only has an effect once profileType is set to Slanted or Trapez." },
+                        "slantBeta": { "type": "number", "description": "Only has an effect once profileType is set to Slanted or Trapez." },
+                        "topOffset": { "type": "number", "description": "Only has an effect when relativeTopStory is non-zero." },
+                        "relativeTopStory": { "type": "number", "description": "Non-zero links the wall's top to another story instead of an explicit height - do not set together with 'height' in the same call, see the note on 'height' above." },
+                        "zoneRel": {
+                            "type": "string",
+                            "enum": ["Boundary", "ReduceArea", "None", "SubtractFromZone"]
+                        },
+                        "visibility": { "$ref": "#/StoryVisibility" },
+                        "isAutoOnStoryVisibility": { "type": "boolean", "description": "When true (the default on a new wall), Archicad recomputes 'visibility' automatically from the wall's vertical extent and ignores any value set for it. Setting 'visibility' without also setting this field turns it off automatically." },
+                        "referenceMaterial": { "$ref": "#/OverriddenMaterial" },
+                        "oppositeMaterial": { "$ref": "#/OverriddenMaterial" },
+                        "sideMaterial": { "$ref": "#/OverriddenMaterial" },
+                        "cutFillPen": { "$ref": "#/OverriddenPen" },
+                        "cutFillBackgroundPen": { "$ref": "#/OverriddenPen" }
                     },
                     "additionalProperties": false,
                     "required": ["elementId"]
@@ -4179,7 +4977,37 @@ GS::Optional<GS::UniString> ModifyBeamsCommand::GetInputParametersSchema () cons
                         "offset": { "type": "number" },
                         "slantAngle": { "type": "number" },
                         "arcAngle": { "type": "number" },
-                        "verticalCurveHeight": { "type": "number" }
+                        "verticalCurveHeight": { "type": "number" },
+                        "beamShape": { "type": "string", "enum": ["Straight", "HorizontallyCurved", "VerticallyCurved"] },
+                        "isSlanted": { "type": "boolean" },
+                        "isFlipped": { "type": "boolean" },
+                        "profileAngle": { "type": "number" },
+                        "anchorPoint": { "type": "string", "enum": ["TopLeft", "TopCenter", "TopRight", "MiddleLeft", "Center", "MiddleRight", "BottomLeft", "BottomCenter", "BottomRight"] },
+                        "width": { "type": "number", "exclusiveMinimum": 0.0, "description": "Cross section width of the beam. Applied to all segments." },
+                        "height": { "type": "number", "exclusiveMinimum": 0.0, "description": "Cross section height of the beam. Applied to all segments." },
+                        "isWidthAndHeightLinked": { "type": "boolean", "description": "When true, Archicad keeps width and height equal and setting one changes the other - set to false first to give width/height independent values. Applied to all segments." },
+                        "buildingMaterialId": { "$ref": "#/AttributeId", "description": "Cross section building material. Applied to all segments." },
+                        "profileId": { "$ref": "#/AttributeId", "description": "Switches the cross section to this custom extruded profile. Applied to all segments." },
+                        "holes": {
+                            "type": "array",
+                            "description": "Replaces all holes currently placed on the beam.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "type": { "type": "string", "enum": ["Rectangular", "Circular"] },
+                                    "showContour": { "type": "boolean" },
+                                    "centerX": { "type": "number" },
+                                    "centerZ": { "type": "number" },
+                                    "width": { "type": "number", "exclusiveMinimum": 0.0 },
+                                    "height": { "type": "number", "exclusiveMinimum": 0.0, "description": "Only used for the Rectangular type." }
+                                },
+                                "additionalProperties": false,
+                                "required": ["type", "centerX", "centerZ", "width"]
+                            }
+                        },
+                        "cutFillPen": { "$ref": "#/OverriddenPen" },
+                        "cutFillBackgroundPen": { "$ref": "#/OverriddenPen" },
+                        "coverFill": { "$ref": "#/CoverFill" }
                     },
                     "additionalProperties": false,
                     "required": ["elementId"]
@@ -4220,14 +5048,68 @@ GS::ObjectState ModifyBeamsCommand::Execute (const GS::ObjectState& parameters, 
 
             API_Element mask = {};
             ACAPI_ELEMENT_MASK_CLEAR (mask);
-            const bool changed = ApplyBeamDetails (element, mask, item);
-            if (!changed) {
+            bool changed = ApplyBeamDetails (element, mask, item);
+            const bool hasSectionFields = item.Contains ("width") || item.Contains ("height") || item.Contains ("isWidthAndHeightLinked") || item.Contains ("buildingMaterialId") || item.Contains ("profileId");
+
+            GS::Array<GS::ObjectState> holes;
+            if (item.Get ("holes", holes)) {
+                API_ElementMemo memo = {};
+                const GS::OnExit cleanup ([&]() { ACAPI_DisposeElemMemoHdls (&memo); });
+                const GSSize nHoles = holes.GetSize ();
+                memo.beamHoles = reinterpret_cast<API_Beam_Hole**> (BMAllocateHandle (GS::Max<GSSize> (nHoles, 1) * sizeof (API_Beam_Hole), ALLOCATE_CLEAR, 0));
+                if (memo.beamHoles == nullptr) {
+                    results.Push (CreateFailedExecutionResult (APIERR_MEMFULL, "Failed to allocate memory for beam holes."));
+                    continue;
+                }
+                for (GSIndex i = 0; i < nHoles; ++i) {
+                    const GS::ObjectState& holeOs = holes[i];
+                    API_Beam_Hole& hole = (*memo.beamHoles)[i];
+                    hole = {};
+                    hole.holeID = static_cast<Int32> (i + 1);
+                    GS::UniString typeStr;
+                    holeOs.Get ("type", typeStr);
+                    hole.holeType = (typeStr == "Circular") ? APIBHole_Circular : APIBHole_Rectangular;
+                    holeOs.Get ("showContour", hole.holeContureOn);
+                    holeOs.Get ("centerX", hole.centerx);
+                    holeOs.Get ("centerZ", hole.centerz);
+                    holeOs.Get ("width", hole.width);
+                    holeOs.Get ("height", hole.height);
+                }
+
+                err = ACAPI_Element_Change (&element, &mask, &memo, APIMemoMask_BeamHole, true);
+                if (err != NoError) {
+                    results.Push (CreateFailedExecutionResult (err, "Failed to modify beam holes."));
+                    continue;
+                }
+                if (hasSectionFields) {
+                    bool sectionOk = ApplyBeamSectionToMemo (element.header.guid, item);
+                    results.Push (sectionOk ? CreateSuccessfulExecutionResult () : CreateFailedExecutionResult (APIERR_GENERAL, "Failed to modify beam cross section."));
+                    continue;
+                }
+                results.Push (CreateSuccessfulExecutionResult ());
+                continue;
+            }
+
+            if (!changed && !hasSectionFields) {
                 results.Push (CreateFailedExecutionResult (APIERR_BADPARS, "No beam fields to modify."));
                 continue;
             }
 
-            err = ACAPI_Element_Change (&element, &mask, nullptr, 0, true);
-            results.Push (err == NoError ? CreateSuccessfulExecutionResult () : CreateFailedExecutionResult (err, "Failed to modify beam."));
+            if (changed) {
+                err = ACAPI_Element_Change (&element, &mask, nullptr, 0, true);
+                if (err != NoError) {
+                    results.Push (CreateFailedExecutionResult (err, "Failed to modify beam."));
+                    continue;
+                }
+            }
+
+            if (hasSectionFields) {
+                bool sectionOk = ApplyBeamSectionToMemo (element.header.guid, item);
+                results.Push (sectionOk ? CreateSuccessfulExecutionResult () : CreateFailedExecutionResult (APIERR_GENERAL, "Failed to modify beam cross section."));
+                continue;
+            }
+
+            results.Push (CreateSuccessfulExecutionResult ());
         }
     });
 }
@@ -4261,6 +5143,10 @@ GS::Optional<GS::UniString> ModifySlabsCommand::GetInputParametersSchema () cons
                         },
                         "buildingMaterialId": { "$ref": "#/AttributeId" },
                         "compositeId": { "$ref": "#/AttributeId" },
+                        "referencePlaneLocation": {
+                            "type": "string",
+                            "enum": ["Top", "CoreTop", "CoreBottom", "Bottom"]
+                        },
                         "polygonOutline": {
                             "type": "array",
                             "items": { "$ref": "#/Coordinate2D" },
@@ -4270,7 +5156,16 @@ GS::Optional<GS::UniString> ModifySlabsCommand::GetInputParametersSchema () cons
                             "type": "array",
                             "items": { "$ref": "#/PolyArc" }
                         },
-                        "holes": { "$ref": "#/Holes2D" }
+                        "holes": {
+                            "$ref": "#/Holes2D",
+                            "description": "Can be given on its own, without polygonOutline, to add/remove/clear holes in place (an empty array clears all holes) - the slab's current outline is reused unchanged."
+                        },
+                        "topMaterial": { "$ref": "#/OverriddenMaterial" },
+                        "sideMaterial": { "$ref": "#/OverriddenMaterial" },
+                        "bottomMaterial": { "$ref": "#/OverriddenMaterial" },
+                        "cutFillPen": { "$ref": "#/OverriddenPen" },
+                        "cutFillBackgroundPen": { "$ref": "#/OverriddenPen" },
+                        "floorFill": { "$ref": "#/FloorFill" }
                     },
                     "additionalProperties": false,
                     "required": ["elementId"]
@@ -4321,10 +5216,27 @@ GS::ObjectState ModifySlabsCommand::Execute (const GS::ObjectState& parameters, 
             }
 
             GS::Array<GS::ObjectState> polygonOutline;
-            if (item.Get ("polygonOutline", polygonOutline)) {
-                if (polygonOutline.GetSize () < 3) {
-                    results.Push (CreateFailedExecutionResult (APIERR_BADPARS, "'polygonOutline' must contain at least 3 coordinates."));
-                    continue;
+            const bool hasNewOutline = item.Get ("polygonOutline", polygonOutline);
+            GS::Array<GS::ObjectState> holes;
+            const bool hasHolesField = item.Get ("holes", holes);
+            if (hasNewOutline || hasHolesField) {
+                // holes can be given on its own (no polygonOutline) to add/remove/clear holes
+                // in place - including an explicit empty array to clear all holes - without
+                // forcing the caller to resend the (possibly large) outline unchanged. Previously
+                // this whole branch was gated on polygonOutline alone, so a holes-only request
+                // fell through to "No slab fields to modify." below (issue #452).
+                GS::Array<GS::ObjectState> polygonArcs;
+                if (hasNewOutline) {
+                    if (polygonOutline.GetSize () < 3) {
+                        results.Push (CreateFailedExecutionResult (APIERR_BADPARS, "'polygonOutline' must contain at least 3 coordinates."));
+                        continue;
+                    }
+                    item.Get ("polygonArcs", polygonArcs);
+                } else {
+                    GS::ObjectState currentGeometry;
+                    AddPolygonWithHolesFromMemoCoords (element.header.guid, currentGeometry, "polygonOutline", "polygonArcs", "holes", "polygonOutline", "polygonArcs");
+                    currentGeometry.Get ("polygonOutline", polygonOutline);
+                    currentGeometry.Get ("polygonArcs", polygonArcs);
                 }
 
                 API_ElementMemo memo = {};
@@ -4333,17 +5245,28 @@ GS::ObjectState ModifySlabsCommand::Execute (const GS::ObjectState& parameters, 
                 });
                 ACAPI_Element_GetMemo (element.header.guid, &memo);
 
-                GS::Array<GS::ObjectState> polygonArcs;
-                GS::Array<GS::ObjectState> holes;
-                item.Get ("polygonArcs", polygonArcs);
-                item.Get ("holes", holes);
-                auto error = BuildSlabMemoFromGeometry (element, memo, polygonOutline, polygonArcs, holes);
+                auto error = ApplySlabPolygonChange (memo, element.slab.sideMat, polygonOutline, polygonArcs, holes);
                 if (error.HasValue ()) {
                     results.Push (CreateFailedExecutionResult (APIERR_BADPARS, error.Get ()));
                     continue;
                 }
 
-                err = ACAPI_Element_Change (&element, &mask, &memo, APIMemoMask_Polygon | APIMemoMask_SideMaterials | APIMemoMask_EdgeTrims, true);
+                // Non-geometry field changes (thickness/level/etc, accumulated into mask above)
+                // are applied first via ACAPI_Element_Change; the polygon itself goes through
+                // ACAPI_Element_ChangeMemo, matching the DevKit's own reference example
+                // (ApplySlabPolygonChange mutates the memo via Graphisoft's polygon-editing
+                // primitives, not a from-scratch replacement, so element.slab.poly's counts are
+                // deliberately not touched here).
+                if (changed) {
+                    err = ACAPI_Element_Change (&element, &mask, nullptr, 0, true);
+                    if (err != NoError) {
+                        results.Push (CreateFailedExecutionResult (err, "Failed to modify slab."));
+                        continue;
+                    }
+                }
+
+                API_Guid slabGuid = element.header.guid;
+                err = ACAPI_Element_ChangeMemo (slabGuid, APIMemoMask_Polygon | APIMemoMask_SideMaterials | APIMemoMask_EdgeTrims, &memo);
                 results.Push (err == NoError ? CreateSuccessfulExecutionResult () : CreateFailedExecutionResult (err, "Failed to modify slab geometry."));
                 continue;
             }
@@ -4672,9 +5595,26 @@ GS::Optional<GS::UniString> ModifyColumnsCommand::GetInputParametersSchema () co
                         "elementId": { "$ref": "#/ElementId" },
                         "origin": { "$ref": "#/Coordinate2D" },
                         "zCoordinate": { "type": "number" },
-                        "height": { "type": "number", "exclusiveMinimum": 0.0 },
+                        "height": { "type": "number", "exclusiveMinimum": 0.0, "description": "Sets relativeTopStory to 0 (explicit height). Do not combine with relativeTopStory in the same call - see the note on relativeTopStory below." },
                         "bottomOffset": { "type": "number" },
-                        "axisRotationAngle": { "type": "number" }
+                        "axisRotationAngle": { "type": "number" },
+                        "coreAnchor": { "type": "string", "enum": ["TopLeft", "TopCenter", "TopRight", "MiddleLeft", "Center", "MiddleRight", "BottomLeft", "BottomCenter", "BottomRight"] },
+                        "isSlanted": { "type": "boolean" },
+                        "slantAngle": { "type": "number" },
+                        "slantDirectionAngle": { "type": "number" },
+                        "isFlipped": { "type": "boolean", "description": "Has no visible effect on a circular column (circleBased cross section) - Archicad ignores it there." },
+                        "wrapping": { "type": "boolean" },
+                        "topOffset": { "type": "number" },
+                        "relativeTopStory": { "type": "number", "description": "Non-zero links the column's top to another story instead of an explicit height - do not set together with 'height' in the same call, see the note on 'height' above." },
+                        "width": { "type": "number", "exclusiveMinimum": 0.0, "description": "Cross section width of the column. Applied to all segments." },
+                        "depth": { "type": "number", "exclusiveMinimum": 0.0, "description": "Cross section depth (height) of the column. Applied to all segments." },
+                        "isWidthAndHeightLinked": { "type": "boolean", "description": "When true, Archicad keeps width and depth equal and setting one changes the other - set to false first to give width/depth independent values. Applied to all segments." },
+                        "circleBased": { "type": "boolean", "description": "True for a round column cross section, false for rectangular. Ignored once profileId switches the column to a custom profile shape. Applied to all segments." },
+                        "buildingMaterialId": { "$ref": "#/AttributeId", "description": "Cross section building material (round or rectangular, per circleBased). Applied to all segments." },
+                        "profileId": { "$ref": "#/AttributeId", "description": "Switches the cross section to this custom extruded profile (circleBased becomes false). Applied to all segments." },
+                        "cutFillPen": { "$ref": "#/OverriddenPen" },
+                        "cutFillBackgroundPen": { "$ref": "#/OverriddenPen" },
+                        "coverFill": { "$ref": "#/CoverFill" }
                     },
                     "additionalProperties": false,
                     "required": ["elementId"]
@@ -4718,13 +5658,27 @@ GS::ObjectState ModifyColumnsCommand::Execute (const GS::ObjectState& parameters
             API_Element mask = {};
             ACAPI_ELEMENT_MASK_CLEAR (mask);
             const bool changed = ApplyColumnDetails (element, mask, item, stories);
-            if (!changed) {
+            const bool hasSectionFields = item.Contains ("width") || item.Contains ("depth") || item.Contains ("isWidthAndHeightLinked") || item.Contains ("circleBased") || item.Contains ("buildingMaterialId") || item.Contains ("profileId");
+            if (!changed && !hasSectionFields) {
                 results.Push (CreateFailedExecutionResult (APIERR_BADPARS, "No column fields to modify."));
                 continue;
             }
 
-            err = ACAPI_Element_Change (&element, &mask, nullptr, 0, true);
-            results.Push (err == NoError ? CreateSuccessfulExecutionResult () : CreateFailedExecutionResult (err, "Failed to modify column."));
+            if (changed) {
+                err = ACAPI_Element_Change (&element, &mask, nullptr, 0, true);
+                if (err != NoError) {
+                    results.Push (CreateFailedExecutionResult (err, "Failed to modify column."));
+                    continue;
+                }
+            }
+
+            if (hasSectionFields) {
+                bool sectionOk = ApplyColumnSectionToMemo (element.header.guid, item);
+                results.Push (sectionOk ? CreateSuccessfulExecutionResult () : CreateFailedExecutionResult (APIERR_GENERAL, "Failed to modify column cross section."));
+                continue;
+            }
+
+            results.Push (CreateSuccessfulExecutionResult ());
         }
     });
 }

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -4264,6 +4264,75 @@
             },
             "profileId": {
                 "$ref": "#/AttributeId"
+            },
+            "referenceLineLocation": {
+                "type": "string",
+                "enum": [
+                    "Outside",
+                    "Center",
+                    "Inside",
+                    "CoreOutside",
+                    "CoreCenter",
+                    "CoreInside"
+                ],
+                "description": "The Core* values only have an effect on a Composite or Profile wall (structureType) - a Basic wall has no core skin, and Archicad falls back to the nearest non-core equivalent (e.g. CoreCenter becomes Center)."
+            },
+            "profileType": {
+                "type": "string",
+                "enum": [
+                    "Normal",
+                    "Slanted",
+                    "Trapez",
+                    "Poly"
+                ],
+                "description": "Cross section shape of the wall, distinct from geometryType (which is the plan outline). Only Normal/Slanted/Trapez are settable via ModifyWalls - Poly needs a profile attribute wired through a separate mechanism. slantAlpha/slantBeta only have an effect once this is Slanted or Trapez."
+            },
+            "slantAlpha": {
+                "type": "number",
+                "description": "Only has an effect once profileType is set to Slanted or Trapez."
+            },
+            "slantBeta": {
+                "type": "number",
+                "description": "Only has an effect once profileType is set to Slanted or Trapez."
+            },
+            "topOffset": {
+                "type": "number",
+                "description": "Only has an effect when relativeTopStory is non-zero."
+            },
+            "relativeTopStory": {
+                "type": "number",
+                "description": "Non-zero links the wall's top to another story instead of an explicit height - do not set together with 'height' via ModifyWalls in the same call."
+            },
+            "zoneRel": {
+                "type": "string",
+                "enum": [
+                    "Boundary",
+                    "ReduceArea",
+                    "None",
+                    "SubtractFromZone"
+                ]
+            },
+            "visibility": {
+                "$ref": "#/StoryVisibility"
+            },
+            "isAutoOnStoryVisibility": {
+                "type": "boolean",
+                "description": "When true (the default on a new wall), Archicad recomputes 'visibility' automatically from the wall's vertical extent and ignores any value set for it."
+            },
+            "referenceMaterial": {
+                "$ref": "#/OverriddenMaterial"
+            },
+            "oppositeMaterial": {
+                "$ref": "#/OverriddenMaterial"
+            },
+            "sideMaterial": {
+                "$ref": "#/OverriddenMaterial"
+            },
+            "cutFillPen": {
+                "$ref": "#/OverriddenPen"
+            },
+            "cutFillBackgroundPen": {
+                "$ref": "#/OverriddenPen"
             }
         },
         "additionalProperties": false,
@@ -4308,6 +4377,107 @@
             "verticalCurveHeight": {
                 "type": "number",
                 "description": "The height of the vertical curve of the beam."
+            },
+            "beamShape": {
+                "type": "string",
+                "enum": [
+                    "Straight",
+                    "HorizontallyCurved",
+                    "VerticallyCurved"
+                ]
+            },
+            "isSlanted": {
+                "type": "boolean"
+            },
+            "isFlipped": {
+                "type": "boolean"
+            },
+            "profileAngle": {
+                "type": "number"
+            },
+            "anchorPoint": {
+                "type": "string",
+                "enum": [
+                    "TopLeft",
+                    "TopCenter",
+                    "TopRight",
+                    "MiddleLeft",
+                    "Center",
+                    "MiddleRight",
+                    "BottomLeft",
+                    "BottomCenter",
+                    "BottomRight"
+                ]
+            },
+            "cutFillPen": {
+                "$ref": "#/OverriddenPen"
+            },
+            "cutFillBackgroundPen": {
+                "$ref": "#/OverriddenPen"
+            },
+            "coverFill": {
+                "$ref": "#/CoverFill"
+            },
+            "holes": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "holeId": {
+                            "type": "number"
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "Rectangular",
+                                "Circular"
+                            ]
+                        },
+                        "showContour": {
+                            "type": "boolean"
+                        },
+                        "centerX": {
+                            "type": "number"
+                        },
+                        "centerZ": {
+                            "type": "number"
+                        },
+                        "width": {
+                            "type": "number"
+                        },
+                        "height": {
+                            "type": "number"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "holeId",
+                        "type",
+                        "centerX",
+                        "centerZ",
+                        "width"
+                    ]
+                }
+            },
+            "width": {
+                "type": "number",
+                "description": "Cross section width of the beam (all segments)."
+            },
+            "height": {
+                "type": "number",
+                "description": "Cross section height of the beam (all segments)."
+            },
+            "isWidthAndHeightLinked": {
+                "type": "boolean",
+                "description": "When true, Archicad keeps width and height equal - set to false via ModifyBeams/CreateBeams to give them independent values."
+            },
+            "buildingMaterialId": {
+                "$ref": "#/AttributeId",
+                "description": "Present when the cross section uses a building material rather than a custom profile."
+            },
+            "profileId": {
+                "$ref": "#/AttributeId",
+                "description": "Present when the cross section uses a custom extruded profile rather than a building material."
             }
         },
         "additionalProperties": false,
@@ -4369,6 +4539,33 @@
             },
             "compositeId": {
                 "$ref": "#/AttributeId"
+            },
+            "referencePlaneLocation": {
+                "type": "string",
+                "enum": [
+                    "Top",
+                    "CoreTop",
+                    "CoreBottom",
+                    "Bottom"
+                ]
+            },
+            "topMaterial": {
+                "$ref": "#/OverriddenMaterial"
+            },
+            "sideMaterial": {
+                "$ref": "#/OverriddenMaterial"
+            },
+            "bottomMaterial": {
+                "$ref": "#/OverriddenMaterial"
+            },
+            "cutFillPen": {
+                "$ref": "#/OverriddenPen"
+            },
+            "cutFillBackgroundPen": {
+                "$ref": "#/OverriddenPen"
+            },
+            "floorFill": {
+                "$ref": "#/FloorFill"
             }
         },
         "additionalProperties": false,
@@ -4397,6 +4594,79 @@
             "bottomOffset": {
                 "type": "number",
                 "description": "base level of the column relative to the floor level"
+            },
+            "axisRotationAngle": {
+                "type": "number"
+            },
+            "coreAnchor": {
+                "type": "string",
+                "enum": [
+                    "TopLeft",
+                    "TopCenter",
+                    "TopRight",
+                    "MiddleLeft",
+                    "Center",
+                    "MiddleRight",
+                    "BottomLeft",
+                    "BottomCenter",
+                    "BottomRight"
+                ]
+            },
+            "isSlanted": {
+                "type": "boolean"
+            },
+            "slantAngle": {
+                "type": "number"
+            },
+            "slantDirectionAngle": {
+                "type": "number"
+            },
+            "isFlipped": {
+                "type": "boolean",
+                "description": "Has no visible effect on a circular column (circleBased cross section) - Archicad ignores it there."
+            },
+            "wrapping": {
+                "type": "boolean"
+            },
+            "topOffset": {
+                "type": "number"
+            },
+            "relativeTopStory": {
+                "type": "number",
+                "description": "Non-zero links the column's top to another story instead of an explicit height - do not set together with 'height' via ModifyColumns in the same call."
+            },
+            "cutFillPen": {
+                "$ref": "#/OverriddenPen"
+            },
+            "cutFillBackgroundPen": {
+                "$ref": "#/OverriddenPen"
+            },
+            "coverFill": {
+                "$ref": "#/CoverFill"
+            },
+            "width": {
+                "type": "number",
+                "description": "Cross section width of the column (all segments)."
+            },
+            "depth": {
+                "type": "number",
+                "description": "Cross section depth (height) of the column (all segments)."
+            },
+            "circleBased": {
+                "type": "boolean",
+                "description": "True for a round column cross section, false for rectangular."
+            },
+            "isWidthAndHeightLinked": {
+                "type": "boolean",
+                "description": "When true, Archicad keeps width and depth equal - set to false via ModifyColumns/CreateColumns to give them independent values."
+            },
+            "buildingMaterialId": {
+                "$ref": "#/AttributeId",
+                "description": "Present when the cross section uses a building material rather than a custom profile."
+            },
+            "profileId": {
+                "$ref": "#/AttributeId",
+                "description": "Present when the cross section uses a custom extruded profile rather than a building material."
             }
         },
         "additionalProperties": false,
@@ -7529,6 +7799,197 @@
             {
                 "$ref": "#/ErrorItem"
             }
+        ]
+    },
+    "CoverFill": {
+        "type": "object",
+        "description": "Floor plan cover fill settings of a Column or Beam.",
+        "properties": {
+            "use": {
+                "type": "boolean",
+                "description": "Whether the cover fill is shown on the floor plan."
+            },
+            "useFromSurface": {
+                "type": "boolean",
+                "description": "Whether the fill is taken from the top surface material of the element."
+            },
+            "orientationComesFrom3D": {
+                "type": "boolean",
+                "description": "Whether the cover fill orientation comes from the 3D view of the element."
+            },
+            "fillId": {
+                "$ref": "#/AttributeId"
+            },
+            "foregroundPen": {
+                "type": "integer"
+            },
+            "backgroundPen": {
+                "type": "integer"
+            },
+            "transformationType": {
+                "type": "string",
+                "enum": [
+                    "Global",
+                    "Rotated",
+                    "Distorted"
+                ]
+            },
+            "transformation": {
+                "$ref": "#/CoverFillTransformation"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "use",
+            "useFromSurface",
+            "orientationComesFrom3D",
+            "fillId",
+            "foregroundPen",
+            "backgroundPen",
+            "transformationType",
+            "transformation"
+        ]
+    },
+    "CoverFillTransformation": {
+        "type": "object",
+        "description": "Orientation and distortion parameters of a cover fill.",
+        "properties": {
+            "origin": {
+                "$ref": "#/Coordinate2D",
+                "description": "The origin of the fill relative to the center of the element."
+            },
+            "xAxis": {
+                "$ref": "#/Coordinate2D",
+                "description": "Primary distortion (direction) vector."
+            },
+            "yAxis": {
+                "$ref": "#/Coordinate2D",
+                "description": "Secondary distortion (direction) vector."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "origin",
+            "xAxis",
+            "yAxis"
+        ]
+    },
+    "FloorFill": {
+        "type": "object",
+        "description": "Floor plan cover fill settings of a Slab.",
+        "properties": {
+            "use": {
+                "type": "boolean",
+                "description": "Whether the cover fill is shown on the floor plan."
+            },
+            "foregroundPen": {
+                "type": "integer"
+            },
+            "backgroundPen": {
+                "type": "integer"
+            },
+            "fillId": {
+                "$ref": "#/AttributeId"
+            },
+            "use3DHatching": {
+                "type": "boolean",
+                "description": "Use Vectorial 3D Hatch patterns in Floor Plan view, taken from the top side material."
+            },
+            "orientation": {
+                "$ref": "#/HatchOrientation"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "use",
+            "foregroundPen",
+            "backgroundPen",
+            "fillId",
+            "use3DHatching",
+            "orientation"
+        ]
+    },
+    "HatchOrientation": {
+        "type": "object",
+        "description": "Orientation and distortion parameters of a fill.",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [
+                    "Global",
+                    "Rotated",
+                    "Distorted",
+                    "Centered"
+                ]
+            },
+            "origin": {
+                "$ref": "#/Coordinate2D",
+                "description": "The origin of the fill relative to the project origin."
+            },
+            "matrix00": {
+                "type": "number",
+                "description": "X component of the primary distortion (direction) vector."
+            },
+            "matrix10": {
+                "type": "number",
+                "description": "Y component of the primary distortion (direction) vector."
+            },
+            "matrix01": {
+                "type": "number",
+                "description": "X component of the secondary distortion vector."
+            },
+            "matrix11": {
+                "type": "number",
+                "description": "Y component of the secondary distortion vector."
+            },
+            "innerRadius": {
+                "type": "number",
+                "description": "Radius for circular fill distortion, used when type is Centered."
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "type",
+            "origin",
+            "matrix00",
+            "matrix10",
+            "matrix01",
+            "matrix11",
+            "innerRadius"
+        ]
+    },
+    "OverriddenMaterial": {
+        "type": "object",
+        "description": "A surface material that may override the one inherited from the element's structure (building material, composite or profile).",
+        "properties": {
+            "overridden": {
+                "type": "boolean",
+                "description": "True if the material is overridden on the element level."
+            },
+            "attributeId": {
+                "$ref": "#/AttributeId"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "overridden"
+        ]
+    },
+    "OverriddenPen": {
+        "type": "object",
+        "description": "A pen index that may override the one inherited from the element's structure. On Archicad versions where the underlying element does not support this override, 'overridden' is always false.",
+        "properties": {
+            "overridden": {
+                "type": "boolean",
+                "description": "True if the pen is overridden on the element level."
+            },
+            "penIndex": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "overridden"
         ]
     }
 }


### PR DESCRIPTION
## Summary

Wall, Slab, Column and Beam already had Create/Get/Modify commands, but each one only covered a subset of the element's real Archicad fields - callers could place these elements but not fully read back or edit them (materials, pens, fills, story visibility, cross section, custom profiles, etc. were all missing). This normally completes the four element types end to end: every field returned by `GetDetailsOfElements` is now also settable via the matching Create/Modify command, and vice versa.

- **Wall**: referenceLineLocation, slant (`profileType` + slantAlpha/slantBeta), top offset/story, zoneRel, story visibility (+ isAutoOnStoryVisibility), reference/opposite/side materials, cut fill pens, and a working `structureType=Profile` (previously broken even at creation - the existing code forced an invalid polygonal plan shape that has nothing to do with a profiled cross section).
- **Slab**: referencePlaneLocation, top/side/bottom materials, cut fill pens, floor fill (pens, fill attribute, hatch orientation). Also fixes the `ModifySlabs` polygon-editing crash: outline/hole changes now go through `ACAPI_Polygon_InsertPolyNode/DeletePolyNode/InsertSubPoly/DeleteSubPoly` + `ACAPI_Element_ChangeMemo` instead of an unsafe from-scratch memo rebuild, version-gated to `ACAPI_Goodies` on pre-AC27 builds.
- **Column**: axis rotation, slant, wrapping, top offset/story, coreAnchor, cut fill pens, cover fill, and full cross section support that didn't exist before: width/depth/circleBased/isWidthAndHeightLinked/buildingMaterialId/profileId are now all readable and settable, including real profile-based ("complex profile") columns.
- **Beam**: beam shape, slant, flip, profile angle, anchor point, holes, cut fill pens, cover fill, and the same new cross section support as Column, including profile-based beams.

`CommonSchemaDefinitions.json` documents all of the above, including notes on the Archicad-side field interactions this had to reverse-engineer (height vs relativeTopStory, topOffset needing relativeTopStory on Wall, Core reference line locations needing Composite/Profile structure, isFlipped being a no-op on a circular column).

**Remaining known gap**, left out as a separate, larger chantier: floorIndex is still create-only for all four types (moving an existing element to another floor needs different handling than a plain field).

## Note on overlap with other open PRs

This branch was extracted from an older working tree and predates #463 ("SetDetailsOfElements: modify any element type..."), which restructures the `Modify*` command bodies and the `Apply*Details` dispatch. If #463 merges first, this PR will need a rebase - the field additions here are independent of that refactor's mechanics.

Also fixes the same `ModifySlabs` polygon crash as #504/#500 (this PR ports the #504 fix, already reviewed there).

## Test plan

- [x] AC29 build clean, live-tested: 84/84 checks in `test_wall_slab_column_beam_details.py`, covering every field above under maximalist combinations (curved/multi-hole slabs, all-fields-at-once Modify calls, profile-based columns/beams) plus the ModifySlabs crash regression
- [x] AC25 build clean
- [x] AC27 build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
