### PR TITLE
fix(beams): make slantAngle effective and expose profileAngle

### DIFF
--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -748,7 +748,8 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                 typeSpecificDetails.Add ("endCoordinate", Create2DCoordinateObjectState (elem.beam.endC));
                 typeSpecificDetails.Add ("level", elem.beam.level);
                 typeSpecificDetails.Add ("offset", elem.beam.offset);
-                typeSpecificDetails.Add ("slantAngle", elem.beam.slantAngle);
+                typeSpecificDetails.Add ("slantAngle", elem.beam.isSlanted ? elem.beam.slantAngle : 0.0);
+                typeSpecificDetails.Add ("profileAngle", elem.beam.profileAngle);
                 typeSpecificDetails.Add ("arcAngle", elem.beam.curveAngle);
                 typeSpecificDetails.Add ("verticalCurveHeight", elem.beam.verticalCurveHeight);
                 break;

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -1449,7 +1449,15 @@ bool ApplyBeamDetails (API_Element& element, API_Element& mask, const GS::Object
     auto slantAngle = GetOptionalDouble (details, "slantAngle");
     if (slantAngle.HasValue ()) {
         element.beam.slantAngle = slantAngle.Get ();
+        element.beam.isSlanted = slantAngle.Get () != 0.0;
         ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, slantAngle);
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, isSlanted);
+        changed = true;
+    }
+    auto profileAngle = GetOptionalDouble (details, "profileAngle");
+    if (profileAngle.HasValue ()) {
+        element.beam.profileAngle = profileAngle.Get ();
+        ACAPI_ELEMENT_MASK_SET (mask, API_BeamType, profileAngle);
         changed = true;
     }
     auto arcAngle = GetOptionalDouble (details, "arcAngle");
@@ -2542,7 +2550,8 @@ GS::Optional<GS::UniString> CreateBeamsCommand::GetInputParametersSchema () cons
                         "floorIndex": { "type": "integer", "description": "Optional floor index. If omitted, derived from zCoordinate." },
                         "zCoordinate": { "type": "number" },
                         "offset": { "type": "number" },
-                        "slantAngle": { "type": "number" },
+                        "slantAngle": { "type": "number", "description": "Slant angle in radians. A non-zero value switches the beam to slanted mode; 0 makes it horizontal." },
+                        "profileAngle": { "type": "number", "description": "Profile rotation angle around the beam axis in radians." },
                         "arcAngle": { "type": "number" },
                         "verticalCurveHeight": { "type": "number" },
                         "width": {
@@ -2596,6 +2605,11 @@ GS::Optional<GS::ObjectState> CreateBeamsCommand::SetTypeSpecificParameters (API
     auto slantAngle = GetOptionalDouble (parameters, "slantAngle");
     if (slantAngle.HasValue ()) {
         element.beam.slantAngle = slantAngle.Get ();
+        element.beam.isSlanted = slantAngle.Get () != 0.0;
+    }
+    auto profileAngle = GetOptionalDouble (parameters, "profileAngle");
+    if (profileAngle.HasValue ()) {
+        element.beam.profileAngle = profileAngle.Get ();
     }
     auto arcAngle = GetOptionalDouble (parameters, "arcAngle");
     if (arcAngle.HasValue ()) {
@@ -4177,7 +4191,8 @@ GS::Optional<GS::UniString> ModifyBeamsCommand::GetInputParametersSchema () cons
                         "endCoordinate": { "$ref": "#/Coordinate2D" },
                         "level": { "type": "number" },
                         "offset": { "type": "number" },
-                        "slantAngle": { "type": "number" },
+                        "slantAngle": { "type": "number", "description": "Slant angle in radians. A non-zero value switches the beam to slanted mode; 0 makes it horizontal." },
+                        "profileAngle": { "type": "number", "description": "Profile rotation angle around the beam axis in radians." },
                         "arcAngle": { "type": "number" },
                         "verticalCurveHeight": { "type": "number" }
                     },

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -4301,6 +4301,10 @@
                 "type": "number",
                 "description": "The slant angle of the beam in radians."
             },
+            "profileAngle": {
+                "type": "number",
+                "description": "The profile rotation angle of the beam around its axis in radians."
+            },
             "arcAngle": {
                 "type": "number",
                 "description": "The arc angle of the (horizontally) curved beam in radians."
@@ -4318,6 +4322,7 @@
             "level",
             "offset",
             "slantAngle",
+            "profileAngle",
             "arcAngle",
             "verticalCurveHeight"
         ]


### PR DESCRIPTION
## Summary

Fixes #508. Two related beam problems:

1. **`slantAngle` reported success but had no effect.** `CreateBeams` and `ApplyBeamDetails` wrote `element.beam.slantAngle` (ModifyBeams also set the mask bit) but never touched `API_BeamType::isSlanted`, so Archicad kept the beam in horizontal mode and silently discarded the angle. Now `isSlanted` is set together with `slantAngle` in both commands (non-zero → slanted, `0` → horizontal).
2. **`profileAngle` was not exposed at all.** Added to `CreateBeams` and `ModifyBeams` (radians) — the beam counterpart of the column's `axisRotationAngle` — and returned from `GetDetailsOfElements` (`BeamDetails` schema extended). The returned `slantAngle` now also respects `isSlanted`, so a horizontal beam reads `0` instead of a stale angle.

## Testing (live against AC28, Win)

| Case | Result |
|---|---|
| `CreateBeams` `slantAngle: 0.3` over a 6 m beam | ✅ bbox z-extent 2.14 (≈ tan(0.3)·6 + height; was 0.3 = horizontal before) — readback `slantAngle: 0.3` |
| `CreateBeams` `profileAngle: 0.785` (45°, 0.2×0.4 profile) | ✅ cross-section envelope 0.424/0.424 (= exact 45° rotation of the profile) — readback `0.785` |
| `ModifyBeams` `slantAngle: 0.2` + `profileAngle: 0.5` on a horizontal beam | ✅ both applied and read back; bbox confirms the slope |

Built clean on AC28 (Win, VS2019).

🤖 Generated with [Claude Code](https://claude.com/claude-code)