### PR TITLE
fix(dimensions): verify created dimensions exist instead of returning ghost GUIDs

### DIFF
--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -3771,6 +3771,16 @@ GS::ObjectState CreateAssociativeDimensionsCommand::Execute (const GS::ObjectSta
                 continue;
             }
 
+            // With a section/elevation window active, ACAPI_Element_Create can report success
+            // and hand back a GUID although no dimension was created in any database (#510).
+            // Verify the element really exists before reporting it to the caller.
+            API_Element createdElement = {};
+            createdElement.header.guid = element.header.guid;
+            if (ACAPI_Element_Get (&createdElement) != NoError) {
+                elements.Push (CreateErrorResponse (APIERR_GENERAL, "The dimension was not created (is a section or elevation window active? Activate a floor plan window and retry)."));
+                continue;
+            }
+
             elements.Push (CreateElementIdObjectState (element.header.guid));
         }
     });
@@ -4055,6 +4065,17 @@ GS::ObjectState CreateWallThicknessDimensionsCommand::Execute (const GS::ObjectS
                 elements.Push (CreateErrorResponse (err, "Failed to create wall thickness dimension."));
                 continue;
             }
+
+            // Same ghost-guid failure mode as CreateAssociativeDimensions (#510): with a
+            // section/elevation window active the create reports success although nothing
+            // was created in any database. Verify before reporting the id.
+            API_Element createdElement = {};
+            createdElement.header.guid = element.header.guid;
+            if (ACAPI_Element_Get (&createdElement) != NoError) {
+                elements.Push (CreateErrorResponse (APIERR_GENERAL, "The dimension was not created (is a section or elevation window active? Activate a floor plan window and retry)."));
+                continue;
+            }
+
             elements.Push (CreateElementIdObjectState (element.header.guid));
         }
     });


### PR DESCRIPTION
## Summary

Fixes #510. With a section or elevation window active, `ACAPI_Element_Create` for a floor-plan dimension can report success and hand back a GUID although **no element was created in any database**. `CreateWallThicknessDimensions` (and `CreateAssociativeDimensions`, which shares the failure mode) then returned that ghost GUID to the caller, who had no way to detect the failure.

## Change

After a successful create, load the element back via `ACAPI_Element_Get`. If it does not exist, return a controlled per-item error pointing at the active-window cause ("is a section or elevation window active? Activate a floor plan window and retry") instead of a non-existent id. Applied to both `CreateWallThicknessDimensions` and `CreateAssociativeDimensions`.

An alternative would be to switch to the floor-plan database before creating (and restore afterwards) so the call works from any window — happy to build that instead if preferred; the post-create check felt like the least invasive correct behaviour.

## Testing (live against AC28, Win)

- Normal path (floor plan active): wall-thickness dimension still created and returned normally — the guard does not fire on success.
- The ghost scenario is environment-dependent (reported on AC29/CZE with a section window active); the guard is a conservative post-check that can only convert a ghost GUID into a clean error, never affect a successful create.

Built clean on AC28 (Win, VS2019).

🤖 Generated with [Claude Code](https://claude.com/claude-code)