### PR TITLE
CreateMorphs/ModifyMorphs: allow open (non-closed) bodies, not just closed volumes

### DIFF
--- a/archicad-addon/Examples/test_morph_open_shells.py
+++ b/archicad-addon/Examples/test_morph_open_shells.py
@@ -1,0 +1,165 @@
+"""
+Live test: open (non-closed) Morph body geometry - previously impossible, CreateMorphs/
+ModifyMorphs required at least 4 vertices and 4 faces ("a closed volume") for ANY body,
+including bodyType Surface (an open shell, which has no closedness requirement at all).
+
+Covers: a single open face, a box missing one face, wireframe-only loops ("filled": false
+on a polygon entry), standalone wire edges (the "wireEdges" field, symmetric between Get
+and Create/Modify), and a mix of a filled face + wireframe edges in the same body. Also
+checks that Get's reported vertex indices - which Archicad is free to renumber after
+ACAPI_Body_Finish - stay internally self-consistent (decoding wireEdges/polygons through
+the ALSO-returned "vertices" coordinates, never assuming they match the caller's original
+input order).
+"""
+import sys
+sys.path.insert(0, r'D:\ONEDRIVE\Documents\CODE PLUGINS\tapir-morph-open\archicad-addon\Examples')
+import aclib
+
+def run(cmd, params=None):
+    return aclib.RunTapirCommand(cmd, params or {}, debug=False)
+
+passes = fails = 0
+created = []
+
+def check(label, expected, got):
+    global passes, fails
+    ok = (got == expected)
+    tag = 'PASS' if ok else 'FAIL'
+    if ok:
+        passes += 1
+    else:
+        fails += 1
+    print(f'  [{tag}] {label}  (expected={expected!r}, got={got!r})')
+
+def decode_edges(body, field):
+    """Return each edge as a pair of (x,y,z) tuples, resolved through body['vertices'] -
+    never compare raw indices directly, Archicad is free to renumber them after Finish."""
+    verts = body.get('vertices', [])
+    out = []
+    for e in body.get(field, []):
+        a, b = e['vertexIds']
+        va, vb = verts[a], verts[b]
+        out.append(frozenset([(va['x'], va['y'], va['z']), (vb['x'], vb['y'], vb['z'])]))
+    return out
+
+print('TEST -- single open quad face (bodyType Surface, previously rejected: needed >=4 faces)')
+r = run('CreateMorphs', {'morphsData': [{
+    'basePoint': {'x': 7000, 'y': 0, 'z': 0},
+    'body': {
+        'bodyType': 'Surface',
+        'vertices': [{'x': 0, 'y': 0, 'z': 0}, {'x': 2, 'y': 0, 'z': 0}, {'x': 2, 'y': 2, 'z': 0}, {'x': 0, 'y': 2, 'z': 0}],
+        'polygons': [{'vertexIds': [0, 1, 2, 3]}],
+    },
+}]})
+check('single-face CreateMorphs succeeds', True, 'elementId' in r['elements'][0])
+guid = r['elements'][0]['elementId']['guid']
+created.append(guid)
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid}}]})['detailsOfElements'][0]['details']
+body = d.get('body', {})
+check('isClosed is False (geometrically open)', False, body.get('isClosed'))
+check('1 polygon reported', 1, len(body.get('polygons', [])))
+print()
+
+print('TEST -- box missing one face (5 of 6 faces, open shell)')
+r = run('CreateMorphs', {'morphsData': [{
+    'basePoint': {'x': 7010, 'y': 0, 'z': 0},
+    'body': {
+        'bodyType': 'Surface',
+        'vertices': [
+            {'x': 0, 'y': 0, 'z': 0}, {'x': 2, 'y': 0, 'z': 0}, {'x': 2, 'y': 2, 'z': 0}, {'x': 0, 'y': 2, 'z': 0},
+            {'x': 0, 'y': 0, 'z': 2}, {'x': 2, 'y': 0, 'z': 2}, {'x': 2, 'y': 2, 'z': 2}, {'x': 0, 'y': 2, 'z': 2},
+        ],
+        'polygons': [
+            {'vertexIds': [0, 1, 2, 3]}, {'vertexIds': [4, 5, 1, 0]}, {'vertexIds': [5, 6, 2, 1]},
+            {'vertexIds': [6, 7, 3, 2]}, {'vertexIds': [7, 4, 0, 3]},
+        ],
+    },
+}]})
+guid = r['elements'][0]['elementId']['guid']
+created.append(guid)
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid}}]})['detailsOfElements'][0]['details']
+body = d.get('body', {})
+check('isClosed is False (one face missing)', False, body.get('isClosed'))
+check('5 polygons reported', 5, len(body.get('polygons', [])))
+print()
+
+print('TEST -- wireframe-only rectangle: "filled": false, no face at all')
+r = run('CreateMorphs', {'morphsData': [{
+    'basePoint': {'x': 7020, 'y': 0, 'z': 0},
+    'body': {
+        'bodyType': 'Surface',
+        'vertices': [{'x': 0, 'y': 0, 'z': 0}, {'x': 3, 'y': 0, 'z': 0}, {'x': 3, 'y': 2, 'z': 0}, {'x': 0, 'y': 2, 'z': 0}],
+        'polygons': [{'vertexIds': [0, 1, 2, 3], 'filled': False}],
+    },
+}]})
+guid = r['elements'][0]['elementId']['guid']
+created.append(guid)
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid}}]})['detailsOfElements'][0]['details']
+body = d.get('body', {})
+check('0 filled polygons reported (wireframe only)', 0, len(body.get('polygons', [])))
+edges = decode_edges(body, 'wireEdges')
+expectedEdges = {
+    frozenset([(0, 0, 0), (3, 0, 0)]), frozenset([(3, 0, 0), (3, 2, 0)]),
+    frozenset([(3, 2, 0), (0, 2, 0)]), frozenset([(0, 2, 0), (0, 0, 0)]),
+}
+check('all 4 rectangle sides present as wireEdges (decoded via coordinates)', expectedEdges, set(edges))
+print()
+
+print('TEST -- standalone wireEdges field, no polygons at all (round-trip Get -> Create shape)')
+r = run('CreateMorphs', {'morphsData': [{
+    'basePoint': {'x': 7030, 'y': 0, 'z': 0},
+    'body': {
+        'bodyType': 'Surface',
+        'vertices': [{'x': 0, 'y': 0, 'z': 0}, {'x': 3, 'y': 0, 'z': 0}, {'x': 3, 'y': 2, 'z': 0}, {'x': 0, 'y': 2, 'z': 0}],
+        'wireEdges': [{'vertexIds': [0, 1]}, {'vertexIds': [1, 2]}, {'vertexIds': [2, 3]}, {'vertexIds': [3, 0]}],
+    },
+}]})
+check('wireEdges-only CreateMorphs succeeds', True, 'elementId' in r['elements'][0])
+guid = r['elements'][0]['elementId']['guid']
+created.append(guid)
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid}}]})['detailsOfElements'][0]['details']
+body = d.get('body', {})
+check('0 polygons', 0, len(body.get('polygons', [])))
+edges = decode_edges(body, 'wireEdges')
+check('all 4 sides present as wireEdges', expectedEdges, set(edges))
+print()
+
+print('TEST -- pyramid: filled square base + 4 wireframe sides to the apex (mixed body)')
+r = run('CreateMorphs', {'morphsData': [{
+    'basePoint': {'x': 7040, 'y': 0, 'z': 0},
+    'body': {
+        'bodyType': 'Surface',
+        'vertices': [
+            {'x': 0, 'y': 0, 'z': 0}, {'x': 3, 'y': 0, 'z': 0}, {'x': 3, 'y': 3, 'z': 0}, {'x': 0, 'y': 3, 'z': 0},
+            {'x': 1.5, 'y': 1.5, 'z': 3},
+        ],
+        'polygons': [{'vertexIds': [0, 1, 2, 3], 'filled': True}],
+        'wireEdges': [{'vertexIds': [0, 4]}, {'vertexIds': [1, 4]}, {'vertexIds': [2, 4]}, {'vertexIds': [3, 4]}],
+    },
+}]})
+guid = r['elements'][0]['elementId']['guid']
+created.append(guid)
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid}}]})['detailsOfElements'][0]['details']
+body = d.get('body', {})
+check('isClosed is False (sides are wireframe, not real faces)', False, body.get('isClosed'))
+check('1 filled polygon (the base)', 1, len(body.get('polygons', [])))
+apex = (1.5, 1.5, 3.0)
+verts = body.get('vertices', [])
+apexIdx = next (i for i, v in enumerate (verts) if (v['x'], v['y'], v['z']) == apex)
+wireEndpoints = set ()
+for e in body.get('wireEdges', []):
+    a, b = e['vertexIds']
+    other = b if a == apexIdx else (a if b == apexIdx else None)
+    if other is not None:
+        v = verts[other]
+        wireEndpoints.add ((v['x'], v['y'], v['z']))
+check('4 wire edges all go from the apex to a distinct base corner', {(0, 0, 0), (3, 0, 0), (3, 3, 0), (0, 3, 0)}, wireEndpoints)
+print()
+
+run('DeleteElements', {'elements': [{'elementId': {'guid': g}} for g in created]})
+
+print('=' * 60)
+print(f'BILAN :  {passes} PASS  |  {fails} FAIL')
+print('=' * 60)
+if fails:
+    sys.exit(1)

--- a/archicad-addon/Examples/test_morph_open_shells.py
+++ b/archicad-addon/Examples/test_morph_open_shells.py
@@ -42,6 +42,32 @@ def decode_edges(body, field):
         out.append(frozenset([(va['x'], va['y'], va['z']), (vb['x'], vb['y'], vb['z'])]))
     return out
 
+print('TEST -- absolute minimum: 2 vertices, 1 standalone wire edge, no face at all')
+r = run('CreateMorphs', {'morphsData': [{
+    'basePoint': {'x': 6990, 'y': 0, 'z': 0},
+    'body': {
+        'bodyType': 'Surface',
+        'vertices': [{'x': 0, 'y': 0, 'z': 0}, {'x': 2, 'y': 0, 'z': 0}],
+        'wireEdges': [{'vertexIds': [0, 1]}],
+    },
+}]})
+check('single-edge CreateMorphs succeeds', True, 'elementId' in r['elements'][0])
+guid = r['elements'][0]['elementId']['guid']
+created.append(guid)
+d = run('GetDetailsOfElements', {'elements': [{'elementId': {'guid': guid}}]})['detailsOfElements'][0]['details']
+body = d.get('body', {})
+check('0 polygons', 0, len(body.get('polygons', [])))
+check('1 wire edge', 1, len(body.get('wireEdges', [])))
+print()
+
+print('TEST -- a lone vertex with no edge at all is rejected (confirmed an Archicad limitation, not Tapir)')
+r = run('CreateMorphs', {'morphsData': [{
+    'basePoint': {'x': 6980, 'y': 0, 'z': 0},
+    'body': {'bodyType': 'Surface', 'vertices': [{'x': 0, 'y': 0, 'z': 0}]},
+}]})
+check('lone-vertex CreateMorphs fails cleanly (no crash)', True, 'error' in r['elements'][0])
+print()
+
 print('TEST -- single open quad face (bodyType Surface, previously rejected: needed >=4 faces)')
 r = run('CreateMorphs', {'morphsData': [{
     'basePoint': {'x': 7000, 'y': 0, 'z': 0},

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -1665,9 +1665,26 @@ bool BuildMorphBodyFromGeometry (const GS::ObjectState& bodyOS, API_ElementMemo&
     bodyOS.Get ("vertices", verticesOS);
     GS::Array<GS::ObjectState> polygonsOS;
     bodyOS.Get ("polygons", polygonsOS);
+    GS::Array<GS::ObjectState> wireEdgesOS;
+    bodyOS.Get ("wireEdges", wireEdgesOS);
 
-    if (verticesOS.GetSize () < 4 || polygonsOS.GetSize () < 4) {
-        errorOut = "A Morph body needs at least 4 vertices and 4 faces to form a closed volume.";
+    // A Solid body needs at least a tetrahedron (4 vertices, 4 faces) to be a valid closed
+    // volume. A Surface body is an open shell - it has no closedness requirement at all, so a
+    // single face (3 vertices, 1 polygon), or even just a couple of standalone wireEdges with no
+    // face at all, is already a legitimate Morph. ACAPI_Body_* itself never enforces closedness
+    // (an edge is only ever required to have *at most* two side polygons, per its own doc -
+    // having zero or one is a normal open/boundary/standalone edge); the stricter floor below
+    // only applies when the caller actually asked for a Solid.
+    GS::UniString bodyTypeStr;
+    bodyOS.Get ("bodyType", bodyTypeStr);
+    const bool isSurfaceBody = (bodyTypeStr == "Surface");
+    if (isSurfaceBody) {
+        if (verticesOS.GetSize () < 2 || (polygonsOS.GetSize () < 1 && wireEdgesOS.GetSize () < 1)) {
+            errorOut = "A Morph body needs at least 2 vertices and 1 face or wire edge.";
+            return false;
+        }
+    } else if (verticesOS.GetSize () < 4 || polygonsOS.GetSize () < 4) {
+        errorOut = "A Solid Morph body needs at least 4 vertices and 4 faces to form a closed volume.";
         return false;
     }
 
@@ -1726,6 +1743,17 @@ bool BuildMorphBodyFromGeometry (const GS::ObjectState& bodyOS, API_ElementMemo&
             return false;
         }
 
+        bool filled = true;
+        polygonOS.Get ("filled", filled);
+        if (!filled) {
+            // Wire-only loop: the edges above still get created (so they're shared/reused
+            // correctly with any other face that also touches them), but no ACAPI_Body_AddPolygon
+            // call means no face fill - Modeler::MeshBody computes IsWireBody() from exactly this
+            // (a body with edges but no adjacent polygon on either side). holes/surfaceId make no
+            // sense without a fill, so they are not read for a wire loop.
+            continue;
+        }
+
         GS::Array<GS::ObjectState> holesOS;
         if (polygonOS.Get ("holes", holesOS)) {
             for (const GS::ObjectState& holeOS : holesOS) {
@@ -1769,6 +1797,26 @@ bool BuildMorphBodyFromGeometry (const GS::ObjectState& bodyOS, API_ElementMemo&
             errorOut = "Failed to build one of the morph's faces - check winding order and vertex indices.";
             return false;
         }
+    }
+
+    // Standalone edges with no face at all - the input-side counterpart of the "wireEdges" Get
+    // reports (see AddMorphBodyFromMemo): unlike a "filled": false polygon loop above (which is
+    // still a whole closed cycle of edges), these are individual segments, so they reuse
+    // GetOrAddEdge directly instead of going through resolveLoopEdges' loop-with-wraparound logic.
+    for (const GS::ObjectState& wireEdgeOS : wireEdgesOS) {
+        GS::Array<Int32> edgeVertexIds;
+        wireEdgeOS.Get ("vertexIds", edgeVertexIds);
+        if (edgeVertexIds.GetSize () != 2) {
+            errorOut = "Every wire edge needs exactly 2 vertex indices.";
+            return false;
+        }
+        const Int32 vFrom = edgeVertexIds[0];
+        const Int32 vTo = edgeVertexIds[1];
+        if (vFrom < 0 || (GS::UIndex) vFrom >= vertexIndices.GetSize () || vTo < 0 || (GS::UIndex) vTo >= vertexIndices.GetSize ()) {
+            errorOut = "A wire edge references a vertex index that is out of range.";
+            return false;
+        }
+        GetOrAddEdge (bodyData, vertexIndices[vFrom], vertexIndices[vTo], edgeCache);
     }
 
     if (ACAPI_Body_Finish (bodyData, &memo.morphBody, &memo.morphMaterialMapTable) != NoError) {
@@ -2366,6 +2414,7 @@ void AddMorphBodyFromMemo (const API_Element& elem, GS::ObjectState& typeSpecifi
 
     {
         GS::Array<GS::ObjectState> overrides;
+        GS::Array<GS::ObjectState> wireEdges;
         const ULong edgeCount = meshBody.GetEdgeCount ();
         for (ULong i = 0; i < edgeCount; ++i) {
             const EDGE& e = meshBody.GetConstEdge (i);
@@ -2373,6 +2422,21 @@ void AddMorphBodyFromMemo (const API_Element& elem, GS::ObjectState& typeSpecifi
             const bool hidden = attrs.IsInvisible ();
             const bool smooth = !attrs.IsSharp ();
             const bool silhouetteOnly = attrs.IsVisibleIfContour ();
+
+            // An edge with no adjacent polygon at all belongs to a wire-only loop (a "filled":
+            // false face in the input, or standalone edges some other tool created) - it never
+            // shows up in the "polygons" list above (which only ever walks GetPolygonCount()
+            // faces), so without this it would be entirely invisible to a caller: the vertices it
+            // references still appear in "vertices" (Archicad keeps its own separate vertex
+            // instances for wire geometry), but nothing would explain what they're for.
+            if (e.GetPolygonCount () == 0) {
+                GS::ObjectState wireEdge;
+                const auto& vertexIds = wireEdge.AddList<Int32> ("vertexIds");
+                vertexIds (static_cast<Int32> (e.vert1));
+                vertexIds (static_cast<Int32> (e.vert2));
+                wireEdges.Push (wireEdge);
+            }
+
             // Only emit an entry when it differs from the element-wide default, keeping
             // edgeOverrides sparse as documented in the schema.
             const bool defaultHidden = elem.morph.edgeType != APIMorphEdgeType_HardVisibleEdge;
@@ -2393,6 +2457,12 @@ void AddMorphBodyFromMemo (const API_Element& elem, GS::ObjectState& typeSpecifi
             const auto& edgeOverrides = body.AddList<GS::ObjectState> ("edgeOverrides");
             for (const auto& o : overrides) {
                 edgeOverrides (o);
+            }
+        }
+        if (!wireEdges.IsEmpty ()) {
+            const auto& wireEdgesList = body.AddList<GS::ObjectState> ("wireEdges");
+            for (const auto& w : wireEdges) {
+                wireEdgesList (w);
             }
         }
     }

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -1679,6 +1679,9 @@ bool BuildMorphBodyFromGeometry (const GS::ObjectState& bodyOS, API_ElementMemo&
     bodyOS.Get ("bodyType", bodyTypeStr);
     const bool isSurfaceBody = (bodyTypeStr == "Surface");
     if (isSurfaceBody) {
+        // Confirmed live: a lone vertex with no edge at all is rejected by Archicad itself
+        // (ACAPI_Element_Create fails outright) - a Morph needs at least one edge to exist as a
+        // valid element, whether that's a real face loop or just a single standalone wireEdge.
         if (verticesOS.GetSize () < 2 || (polygonsOS.GetSize () < 1 && wireEdgesOS.GetSize () < 1)) {
             errorOut = "A Morph body needs at least 2 vertices and 1 face or wire edge.";
             return false;

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -5286,15 +5286,15 @@
             },
             "vertices": {
                 "type": "array",
-                "description": "Flat, indexed vertex list, local to the Morph's own placement (not world coordinates).",
+                "description": "Flat, indexed vertex list, local to the Morph's own placement (not world coordinates). A Solid body needs at least 4 (a tetrahedron, the minimum closed volume); a Surface body has no closedness requirement and can be as few as 3 (a single triangular face) - enforced with a bodyType-aware error message, not by this minItems floor alone.",
                 "items": {
                     "$ref": "#/Coordinate3D"
                 },
-                "minItems": 4
+                "minItems": 3
             },
             "polygons": {
                 "type": "array",
-                "description": "One entry per face. Each face is a closed loop of vertex indices (into `vertices`), counterclockwise as seen from outside the body.",
+                "description": "One entry per face loop (into `vertices`), counterclockwise as seen from outside the body. Optional - a body made entirely of wireEdges (see below) needs none. Set \"filled\": false on an entry to create only that loop's edges (e.g. the outline of a pyramid's side faces) without an actual filled face.",
                 "items": {
                     "type": "object",
                     "properties": {
@@ -5305,6 +5305,10 @@
                                 "type": "integer"
                             },
                             "minItems": 3
+                        },
+                        "filled": {
+                            "type": "boolean",
+                            "description": "Defaults to true. Set to false to create only this loop's edges (a wireframe outline, e.g. a bare rectangle with no surface fill) without an actual face - holes/surfaceId are ignored in that case, since there is no fill for them to apply to."
                         },
                         "holes": {
                             "type": "array",
@@ -5335,8 +5339,28 @@
                     "required": [
                         "vertexIds"
                     ]
-                },
-                "minItems": 4
+                }
+            },
+            "wireEdges": {
+                "type": "array",
+                "description": "Standalone edges that belong to no face at all (e.g. a bare rectangle outline, or a pyramid with a filled base but wireframe-only sides - set \"filled\": false on a polygons entry for a whole closed loop like that instead, this is for individual edges not already covered by any polygon loop). Reported accurately by GetDetailsOfElements (every edge with zero adjacent faces); accepted back by CreateMorphs/ModifyMorphs. Identifies an edge by the (unordered) pair of vertex indices it connects - reuses whatever edge already exists between those two vertices if the polygons above happen to share it.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "vertexIds": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "vertexIds"
+                    ]
+                }
             },
             "edgeOverrides": {
                 "type": "array",
@@ -5374,8 +5398,7 @@
         },
         "additionalProperties": false,
         "required": [
-            "vertices",
-            "polygons"
+            "vertices"
         ]
     },
     "MorphDetails": {

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -5286,11 +5286,11 @@
             },
             "vertices": {
                 "type": "array",
-                "description": "Flat, indexed vertex list, local to the Morph's own placement (not world coordinates). A Solid body needs at least 4 (a tetrahedron, the minimum closed volume); a Surface body has no closedness requirement and can be as few as 3 (a single triangular face) - enforced with a bodyType-aware error message, not by this minItems floor alone.",
+                "description": "Flat, indexed vertex list, local to the Morph's own placement (not world coordinates). A Solid body needs at least 4 (a tetrahedron, the minimum closed volume); a Surface body has no closedness requirement at all - the minimum is 2 vertices joined by a single wireEdge (a lone vertex with no edge at all is rejected by Archicad itself, confirmed live) - enforced with a bodyType-aware error message, not by this minItems floor alone.",
                 "items": {
                     "$ref": "#/Coordinate3D"
                 },
-                "minItems": 3
+                "minItems": 2
             },
             "polygons": {
                 "type": "array",


### PR DESCRIPTION
## Summary

A Morph body could only ever be built as a closed volume: `CreateMorphs`/`ModifyMorphs` required at least 4 vertices and 4 faces (a tetrahedron) for ANY body, even for `bodyType: Surface` - which is Archicad's own open-shell body type and has no closedness requirement at all. `ACAPI_Body_*` itself never enforced this (an edge is only ever required to have *at most* two side polygons per its own doc - having zero or one is a normal open/boundary/standalone edge); this was Tapir's own validation being stricter than necessary.

- A Surface body's real minimum (confirmed live) is 2 vertices joined by a single edge - either a real face loop or just a standalone `wireEdge`. A lone vertex with no edge at all is rejected by Archicad itself (`ACAPI_Element_Create` fails), not something Tapir can work around.
- New `"filled": false` flag on a `polygons` entry: creates that loop's edges without an actual face (e.g. a wireframe rectangle outline, or a pyramid with a filled base but wireframe-only sides).
- New `"wireEdges"` field, symmetric between Get and Create/Modify (same shape as `edgeOverrides`/`polygons`): standalone edges belonging to no face at all. Previously these were entirely invisible on read - an edge with no adjacent polygon never appeared in `polygons`, so a caller reading back a body containing wire geometry had no way to know it was there, and the "extra" vertices Archicad keeps for those edges looked like unexplained bloat in the vertex list.

## Test plan

- [x] Verified live on AC27 (build + deploy + test): 17/17 checks in the new `test_morph_open_shells.py` - the absolute minimum (single edge, no face), a lone-vertex rejection, a single open face, a box missing a face, a wireframe-only loop, standalone `wireEdges` round-tripped through Create, and a mixed filled-base/wireframe-sides pyramid (also used to confirm Get's vertex indices - which Archicad is free to renumber after `ACAPI_Body_Finish` - stay internally consistent by decoding edges/polygons through the returned vertex coordinates rather than assuming they match the caller's original input order)
- [x] The pre-existing `create_modify_delete_morph.py` closed-box sample still runs clean, no regression on the ordinary case
- [ ] AC25/29 build not re-verified in this PR (iterated on AC27 only this session) - flagging for a maintainer/CI check before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
