### PR TITLE
Fix CreateLayerCombinations/ModifyLayerCombinations dropping per-layer stats

### DIFF
--- a/archicad-addon/Examples/test_layer_combination_stats.py
+++ b/archicad-addon/Examples/test_layer_combination_stats.py
@@ -1,0 +1,118 @@
+"""
+Live test for issue #513: CreateLayerCombinations/ModifyLayerCombinations (via
+overwriteExisting) silently ignored per-layer isHidden/isLocked/isWireframe/
+intersectionGroupNr - the created combination's name and layer membership were saved, but
+every per-layer stat came back as the default (visible, unlocked, not wireframe, group 1).
+
+Root cause: a layer combination's stat table is not sparse - Archicad expects one
+API_LayerStat entry per PROJECT layer (lNumb is documented as "the same value in all layer
+combinations", i.e. the project's total layer count), not just for the layers mentioned in
+the request. Supplying only a partial table made Archicad read past it into uninitialized
+memory for every layer not explicitly listed - confirmed live: those layers came back with
+scattered garbage flags (mostly isHidden=true, occasionally isWireframe=true), not the
+documented "new layers appear as visible and unlocked" default.
+
+Fix seeds a full stat table (every project layer, defaulted to visible/unlocked/group 1, or
+preserved from the existing combination when modifying) before applying the caller's
+overrides on top. A second, independent bug was found and fixed while testing this: the
+override step used GS::HashTable::Add, which is a no-op returning false when the key already
+exists (every key was already seeded) - Put is required to actually overwrite.
+"""
+import sys
+sys.path.insert(0, r'D:\ONEDRIVE\Documents\CODE PLUGINS\tapir-layercomb-fix\archicad-addon\Examples')
+import aclib
+
+def run(cmd, params=None):
+    return aclib.RunTapirCommand(cmd, params or {}, debug=False)
+
+passes = fails = 0
+created = []
+
+def check(label, expected, got):
+    global passes, fails
+    ok = (got == expected)
+    tag = 'PASS' if ok else 'FAIL'
+    if ok:
+        passes += 1
+    else:
+        fails += 1
+    print(f'  [{tag}] {label}  (expected={expected!r}, got={got!r})')
+
+def get_combination(guid):
+    return run('GetLayerCombinations', {'attributes': [{'attributeId': {'guid': guid}}]})['layerCombinations'][0]['layerCombination']
+
+def default_stat(layer_guid):
+    return {'attributeId': {'guid': layer_guid}, 'isHidden': False, 'isLocked': False, 'isWireframe': False, 'intersectionGroupNr': 1}
+
+layers = run('GetAttributesByType', {'attributeType': 'Layer'})['attributes']
+totalLayers = len(layers)
+print(f'SETUP -- project has {totalLayers} layers')
+print()
+
+print('TEST -- single targeted layer: flags apply to it, every other layer stays default')
+target = layers[5]['attributeId']
+r = run('CreateLayerCombinations', {'layerCombinationDataArray': [{
+    'name': 'TEST_single_layer',
+    'layers': [{'attributeId': target, 'isHidden': True, 'isLocked': True, 'isWireframe': True, 'intersectionGroupNr': 7}],
+}], 'overwriteExisting': False})
+check('CreateLayerCombinations succeeds', True, 'attributeId' in r['attributeIds'][0])
+guid = r['attributeIds'][0]['attributeId']['guid']
+created.append(guid)
+d = get_combination(guid)
+check('all project layers present in the combination', totalLayers, len(d['layers']))
+targeted = next(l for l in d['layers'] if l['attributeId']['guid'] == target['guid'])
+check('targeted layer got the requested flags', {'attributeId': target, 'isHidden': True, 'isLocked': True, 'isWireframe': True, 'intersectionGroupNr': 7}, targeted)
+untouched = [l for l in d['layers'] if l['attributeId']['guid'] != target['guid']]
+check('every other layer is still exactly default (no garbage)', True, all(l == default_stat(l['attributeId']['guid']) for l in untouched))
+print()
+
+print('TEST -- multiple layers targeted in one request, each gets only its own flags')
+r = run('CreateLayerCombinations', {'layerCombinationDataArray': [{
+    'name': 'TEST_multi_layer',
+    'layers': [
+        {'attributeId': layers[1]['attributeId'], 'isHidden': True},
+        {'attributeId': layers[2]['attributeId'], 'isLocked': True},
+        {'attributeId': layers[3]['attributeId'], 'isWireframe': True, 'intersectionGroupNr': 5},
+    ],
+}], 'overwriteExisting': False})
+guid2 = r['attributeIds'][0]['attributeId']['guid']
+created.append(guid2)
+d2 = get_combination(guid2)
+byGuid = {l['attributeId']['guid']: l for l in d2['layers']}
+check('layer[1] isHidden only', {'attributeId': layers[1]['attributeId'], 'isHidden': True, 'isLocked': False, 'isWireframe': False, 'intersectionGroupNr': 1}, byGuid[layers[1]['attributeId']['guid']])
+check('layer[2] isLocked only', {'attributeId': layers[2]['attributeId'], 'isHidden': False, 'isLocked': True, 'isWireframe': False, 'intersectionGroupNr': 1}, byGuid[layers[2]['attributeId']['guid']])
+check('layer[3] isWireframe + group 5', {'attributeId': layers[3]['attributeId'], 'isHidden': False, 'isLocked': False, 'isWireframe': True, 'intersectionGroupNr': 5}, byGuid[layers[3]['attributeId']['guid']])
+print()
+
+print('TEST -- full layer list with one flag flipped (matches the issue\'s own falsification test)')
+fullPayload = [{'attributeId': l['attributeId'], **({'isLocked': True} if i == 20 else {})} for i, l in enumerate(layers)]
+r = run('CreateLayerCombinations', {'layerCombinationDataArray': [{'name': 'TEST_full_list', 'layers': fullPayload}], 'overwriteExisting': False})
+guid3 = r['attributeIds'][0]['attributeId']['guid']
+created.append(guid3)
+d3 = get_combination(guid3)
+target3 = next(l for l in d3['layers'] if l['attributeId']['guid'] == layers[20]['attributeId']['guid'])
+check('the one flipped layer is isLocked', {'attributeId': layers[20]['attributeId'], 'isHidden': False, 'isLocked': True, 'isWireframe': False, 'intersectionGroupNr': 1}, target3)
+others3 = [l for l in d3['layers'] if l['attributeId']['guid'] != layers[20]['attributeId']['guid']]
+check('every other layer is still exactly default', True, all(l == default_stat(l['attributeId']['guid']) for l in others3))
+print()
+
+print('TEST -- modify (overwriteExisting): touching one layer preserves another layer\'s existing custom flags')
+r = run('CreateLayerCombinations', {'layerCombinationDataArray': [{
+    'attributeId': {'guid': guid},
+    'name': 'TEST_single_layer',
+    'layers': [{'attributeId': layers[10]['attributeId'], 'isLocked': True, 'intersectionGroupNr': 3}],
+}], 'overwriteExisting': True})
+check('ModifyLayerCombinations (overwriteExisting) succeeds', True, 'attributeId' in r['attributeIds'][0])
+d4 = get_combination(guid)
+byGuid4 = {l['attributeId']['guid']: l for l in d4['layers']}
+check('originally-targeted layer keeps its flags from before the modify', {'attributeId': target, 'isHidden': True, 'isLocked': True, 'isWireframe': True, 'intersectionGroupNr': 7}, byGuid4[target['guid']])
+check('newly-targeted layer got its new flags', {'attributeId': layers[10]['attributeId'], 'isHidden': False, 'isLocked': True, 'isWireframe': False, 'intersectionGroupNr': 3}, byGuid4[layers[10]['attributeId']['guid']])
+print()
+
+run('DeleteAttributes', {'attributesToDelete': [{'attributeType': 'LayerCombination', 'attributeId': {'attributeId': {'guid': g}}} for g in created]})
+
+print('=' * 60)
+print(f'BILAN :  {passes} PASS  |  {fails} FAIL')
+print('=' * 60)
+if fails:
+    sys.exit(1)

--- a/archicad-addon/Sources/AttributeCommands.cpp
+++ b/archicad-addon/Sources/AttributeCommands.cpp
@@ -3078,27 +3078,69 @@ GS::Optional<GS::UniString> CreateLayerCombinationsCommand::GetInputParametersSc
     })";
 }
 
+// A layer combination's stat table is NOT sparse: per the AC27 devkit's own remark on
+// API_LayerCombType, "the number of layers (the lNumb field) has the same value in all layer
+// combinations" - i.e. lNumb is the project's total layer count, not however many layers the
+// caller happens to mention, and Archicad expects one API_LayerStat entry per project layer, not
+// just for the ones being overridden. Confirmed live: populating layer_statItems with only the
+// requested layer(s) still reports lNumb layers back once read (Archicad fills in the rest
+// itself), but every layer we did NOT explicitly add came back with garbage/inconsistent flags
+// (mostly isHidden=true, one random layer with isWireframe=true, scattered with no pattern
+// matching the request) instead of the documented "new layers appear as unlocked and visible" -
+// i.e. Archicad reads past our sparse table into uninitialized memory for any layer index we
+// left out, rather than defaulting it. The fix is to always seed a full entry for every project
+// layer (visible/unlocked/not wireframe/group 1, matching a brand new layer's real defaults) and
+// only then apply the caller's overrides on top - mirroring how CreatePenTables/CreateProfiles
+// already seed a full table from a source attribute before overriding parts of it.
+static API_LayerStat DefaultLayerStat ()
+{
+    API_LayerStat layerStat = {};
+    layerStat.conClassId = 1;
+    return layerStat;
+}
+
 void CreateLayerCombinationsCommand::SetTypeSpecificParameters (const GS::ObjectState& parameters, API_Attribute& attribute, API_AttributeDef& attributeDef) const
 {
     GS::Array<GS::ObjectState> layers;
     parameters.Get ("layers", layers);
 
-    attribute.layerComb.lNumb = layers.GetSize ();
-
+    // Seed every project layer with a default stat, preferring the layer combination's own
+    // current table (if we are modifying one that already exists) so that layers not mentioned
+    // in this request keep whatever hidden/locked/wireframe/group state they already had, rather
+    // than being reset to defaults on every edit.
+    GS::HashTable<API_AttributeIndex, API_LayerStat> seedStats;
+    API_AttributeDef existingDef = {};
+    bool hasExistingDef = false;
+    if (attribute.header.index != APIInvalidAttributeIndex && ACAPI_Attribute_GetDef (API_LayerCombID, attribute.header.index, &existingDef) == NoError) {
+        hasExistingDef = true;
 #ifdef ServerMainVers_2700
-	attributeDef.layer_statItems = new GS::HashTable<API_AttributeIndex, API_LayerStat> ();
+        for (const auto& kv : *existingDef.layer_statItems) {
+#ifdef ServerMainVers_2800
+            seedStats.Add (kv.key, kv.value);
 #else
-	attributeDef.layer_statItems = (API_LayerStat **) BMAllocateHandle (attribute.layerComb.lNumb * sizeof (API_LayerStat), ALLOCATE_CLEAR, 0);
+            seedStats.Add (*kv.key, *kv.value);
 #endif
+        }
+#else
+        for (Int32 i = 0; i < attribute.layerComb.lNumb; ++i) {
+            const API_LayerStat& layerStat = (*existingDef.layer_statItems)[i];
+            seedStats.Add (layerStat.lInd, layerStat);
+        }
+#endif
+    }
 
-    size_t i = 0;
+    GS::Array<API_Attribute> allLayers;
+    ACAPI_Attribute_GetAttributesByType (API_LayerID, allLayers);
+    for (API_Attribute& layerAttr : allLayers) {
+        if (!seedStats.ContainsKey (layerAttr.header.index)) {
+            seedStats.Add (layerAttr.header.index, DefaultLayerStat ());
+        }
+        DisposeAttribute (layerAttr);
+    }
+
     for (const GS::ObjectState& layer : layers) {
-#ifdef ServerMainVers_2700
-        UNUSED_VARIABLE(i);
-		API_LayerStat layerStat = {};
-#else
-        API_LayerStat& layerStat = (*attributeDef.layer_statItems)[i++];
-#endif
+        API_LayerStat layerStat = DefaultLayerStat ();
+
         bool isHidden = false;
         layer.Get ("isHidden", isHidden);
         if (isHidden)
@@ -3114,18 +3156,39 @@ void CreateLayerCombinationsCommand::SetTypeSpecificParameters (const GS::Object
         if (isWireframe)
             layerStat.lFlags |= APILay_ForceToWire;
 
-        Int32 intersectionGroupNr = 0;
+        Int32 intersectionGroupNr = 1;
         layer.Get ("intersectionGroupNr", intersectionGroupNr);
         layerStat.conClassId = intersectionGroupNr;
 
         API_AttributeIndex layerIndex;
         if (GetAttributeIndexFromAttributeId (layer, API_LayerID, layerIndex)) {
-#ifdef ServerMainVers_2700
-            attributeDef.layer_statItems->Add (layerIndex, layerStat);
-#else
-            layerStat.lInd = layerIndex;
-#endif
+            // Put, not Add: this layer's key was already seeded above with a default stat (every
+            // project layer is seeded first), and GS::HashTable::Add is a no-op returning false
+            // when the key already exists - it does NOT overwrite. Confirmed live: using Add here
+            // silently dropped every override, leaving the seeded defaults in place even though
+            // the request came back accepted. Put unconditionally replaces the existing entry.
+            seedStats.Put (layerIndex, layerStat);
         }
+    }
+
+    attribute.layerComb.lNumb = static_cast<Int32> (seedStats.GetSize ());
+
+#ifdef ServerMainVers_2700
+    attributeDef.layer_statItems = new GS::HashTable<API_AttributeIndex, API_LayerStat> (seedStats);
+#else
+    attributeDef.layer_statItems = (API_LayerStat **) BMAllocateHandle (attribute.layerComb.lNumb * sizeof (API_LayerStat), ALLOCATE_CLEAR, 0);
+    Int32 i = 0;
+    for (const auto& kv : seedStats) {
+        // Pre-2700 GS::HashTable's const range-for pair exposes pointer members (unlike 2800+'s
+        // references) - matches the same distinction already handled above for existingDef.
+        API_LayerStat& layerStat = (*attributeDef.layer_statItems)[i++];
+        layerStat = *kv.value;
+        layerStat.lInd = *kv.key;
+    }
+#endif
+
+    if (hasExistingDef) {
+        ACAPI_DisposeAttrDefsHdls (&existingDef);
     }
 }
 


### PR DESCRIPTION
Closes #513.

## Summary

`CreateLayerCombinations` accepted per-layer `isHidden`/`isLocked`/`isWireframe`/`intersectionGroupNr`, but they were silently lost on both create and modify (`overwriteExisting`): only the combination's name and layer membership actually saved, every per-layer stat came back at its default (visible, unlocked, not wireframe, group 1) regardless of what was requested.

Two independent bugs were stacked in the same function, both confirmed live against a 59-layer test project.

**Main bug**: a layer combination's stat table is not sparse. The AC27 devkit's own remark on `API_LayerCombType` says `lNumb` "has the same value in all layer combinations" - i.e. it's the project's total layer count, and Archicad expects one `API_LayerStat` entry per project layer, not just for the ones a caller mentions. The existing code built `layer_statItems` with only the requested layer(s). Reading the combination back showed every layer NOT explicitly listed with scattered, inconsistent flags (mostly `isHidden=true`, one random layer `isWireframe=true`) instead of the documented "new layers appear as visible and unlocked" - Archicad was reading past the sparse table into uninitialized memory for any layer index it was never given.

**Fix**: seed a full entry for every project layer first (preferring the combination's own existing stat table as the seed when modifying, so untouched layers keep their existing state instead of being reset to defaults; falling back to enumerating every project layer via `ACAPI_Attribute_GetAttributesByType` for a brand new combination), then apply the caller's overrides on top - the same pattern `CreatePenTables`/`CreateProfiles` already use.

**Second bug**, found while testing the first fix: the override step used `GS::HashTable::Add`, which is a no-op returning `false` when the key already exists (every key was already seeded) - the requested overrides still never landed even with a fully seeded table. `Put` is required to unconditionally replace an existing entry.

## Test plan

- [x] Verified live on AC27 against the issue's exact repro plus every variant from its own falsification sweep (single layer, multiple layers in one request, the full 59-layer list with one flag flipped), plus modifying one layer while confirming another layer's already-set custom flags are preserved: 12/12 checks in the new `test_layer_combination_stats.py`
- [x] AC25 build clean
- [x] AC29 build clean
- [ ] AC26 not checked this round

🤖 Generated with [Claude Code](https://claude.com/claude-code)
