### PR TITLE
Register all commands before loading the palette singleton

### DIFF
--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -169,11 +169,6 @@ GSErrCode Initialize (void)
     err |= TapirPalette::RegisterPaletteControlCallBack ();
     err |= ScriptUIPalette::RegisterPaletteControlCallBack ();
 
-    // Forces the palette singleton (and its saved shortcut-slot preferences) to load immediately,
-    // so custom shortcut menu labels and the enabled state of the shortcut menu items are applied
-    // at startup rather than only after the user first opens the palette or triggers a shortcut.
-    TapirPalette::Instance ();
-
     { // Application Commands
         CommandGroup applicationCommands ("Application Commands");
         err |= RegisterCommand<GetAddOnVersionCommand> (
@@ -1216,6 +1211,21 @@ GSErrCode Initialize (void)
             "Generates files for the documentation. Used by Tapir developers only."
         );
         AddCommandGroup (developerCommands);
+    }
+
+    // Loading the palette singleton applies the custom shortcut menu labels and the enabled state
+    // of the shortcut menu items at startup, rather than only when the user first opens the
+    // palette or triggers a shortcut. It deliberately runs LAST and swallows every failure:
+    // constructing this DG::Palette from Initialize() aborted the rest of Initialize() on some
+    // configurations, which left every JSON command unregistered ("Archicad does not have the
+    // registered Add-On command", error 4010) while the add-on still looked healthy in the
+    // Add-On Manager and its menu worked - see #516. Registering the commands first makes that
+    // failure mode impossible; if the palette cannot be created this early, the shortcut labels
+    // are applied later, the first time the palette is actually used.
+    try {
+        TapirPalette::Instance ();
+    } catch (...) {
+        // Intentionally ignored: the menu labels are cosmetic, the commands above are not.
     }
 
     return err;


### PR DESCRIPTION
## Summary

Fixes #516 — on `main` (1.5.7) no JSON add-on command was registered at all: every `API.ExecuteAddOnCommand` returned `4010 Archicad does not have the registered Add-On command`, while the Add-On Manager, the Tapir menu and the About dialog all looked perfectly healthy. Reported independently by two users, both of whom had to downgrade to 1.5.2.

## Root cause

`Initialize()` forced the palette singleton *before* the command registrations:

```cpp
TapirPalette::Instance ();   // <- added in #479, purely to refresh shortcut menu labels
{ // Application Commands
    err |= RegisterCommand<GetAddOnVersionCommand> (...);
    ...
```

`TapirPalette` is a `DG::Palette`; constructing it that early aborts the remainder of `Initialize()` on some configurations (the reporter bisected it to exactly this line, and confirmed that removing it restores all commands). Because the menu handlers are installed *before* that line and every `RegisterCommand` call comes *after* it, the add-on kept a fully working UI while every JSON/Python/Grasshopper client was dead — a failure mode that gives no hint the palette is involved.

## Fix

The singleton load moves to the very end of `Initialize()`, after all command groups, and is wrapped so no failure can escape:

```cpp
try {
    TapirPalette::Instance ();
} catch (...) {
}
```

Commands are therefore always registered regardless of what the palette does. The palette load only affects the shortcut menu labels and their enabled state, which is cosmetic — if it fails, those are applied later, the first time the palette is actually opened or a shortcut is triggered (exactly the behavior before #479).

## Test plan

- [x] AC29 add-on build succeeds
- [x] Install the built add-on and confirm `GetAddOnVersion` responds (instead of error 4010), and that the shortcut menu labels/enabled states still appear at startup on a machine where the palette constructs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
