### PR TITLE
Rename the polygon point-tree inputs to Vertices

### DIFF
--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateHatchesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateHatchesComponent.cs
@@ -21,7 +21,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
         private static readonly List<Field> FieldDefinitions = new List<Field>
         {
-            new Field("Polygons", "coordinates", FieldKind.PointsTree2D, "Outline points of each hatch (one branch per hatch, at least 3 points; only X and Y are used).", required: true, minPointsPerBranch: 3),
+            new Field("Vertices", "coordinates", FieldKind.PointsTree2D, "Outline points of each hatch (one branch per hatch, at least 3 points; only X and Y are used).", required: true, minPointsPerBranch: 3),
             new Field("ContourPenIndices", "contourPenIndex", FieldKind.Integer, "Pen index of the hatch contour."),
             new Field("FillPenIndices", "fillPenIndex", FieldKind.Integer, "Pen index of the fill."),
             new Field("FillBackgroundPenIndices", "fillBackgroundPenIndex", FieldKind.Integer, "Background pen index of the fill."),

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMeshesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateMeshesComponent.cs
@@ -21,7 +21,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
         private static readonly List<Field> FieldDefinitions = new List<Field>
         {
-            new Field("Polygons", "polygonCoordinates", FieldKind.PointsTree3D, "Boundary points of each mesh (one branch per mesh, at least 3 points).", required: true, minPointsPerBranch: 3),
+            new Field("Vertices", "polygonCoordinates", FieldKind.PointsTree3D, "Boundary points of each mesh (one branch per mesh, at least 3 points).", required: true, minPointsPerBranch: 3),
             new Field("Levels", "level", FieldKind.Number, "Z reference level of the mesh coordinates."),
             new Field("SkirtTypes", "skirtType", FieldKind.Text, "Skirt type: SurfaceOnlyWithoutSkirt, WithSkirt or SolidBodyWithSkirt."),
             new Field("SkirtLevels", "skirtLevel", FieldKind.Number, "Height of the mesh skirt."),

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateRoofsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateRoofsComponent.cs
@@ -21,7 +21,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
         private static readonly List<Field> FieldDefinitions = new List<Field>
         {
-            new Field("Polygons", "polygonCoordinates", FieldKind.PointsTree2D, "Outline points of each roof (one branch per roof, at least 3 points; only X and Y are used).", required: true, minPointsPerBranch: 3),
+            new Field("Vertices", "polygonCoordinates", FieldKind.PointsTree2D, "Outline points of each roof (one branch per roof, at least 3 points; only X and Y are used).", required: true, minPointsPerBranch: 3),
             new Field("Levels", "level", FieldKind.Number, "Reference level of the roof.", required: true),
             new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the roof."),
             new Field("EavesOverhangs", "eavesOverhang", FieldKind.Number, "Eaves overhang of the roof."),

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateSlabsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateSlabsComponent.cs
@@ -20,7 +20,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
         private static readonly List<Field> FieldDefinitions = new List<Field>
         {
-            new Field("Polygons", "polygonCoordinates", FieldKind.PointsTree2D, "Outline points of each slab (one branch per slab, at least 3 points; only X and Y are used).", required: true, minPointsPerBranch: 3),
+            new Field("Vertices", "polygonCoordinates", FieldKind.PointsTree2D, "Outline points of each slab (one branch per slab, at least 3 points; only X and Y are used).", required: true, minPointsPerBranch: 3),
             new Field("Levels", "level", FieldKind.Number, "The Z coordinate of the reference plane of the slab.", required: true),
             new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the slab."),
             new Field("ReferencePlaneLocations", "referencePlaneLocation", FieldKind.Text, "Reference plane location: Top, CoreTop, CoreBottom or Bottom."),

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateZonesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateZonesComponent.cs
@@ -34,14 +34,14 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Number string of each zone. Input only 1 to use the same value for all zones.");
 
             inManager.AddPointParameter(
-                "Polygons",
-                "Polygons",
+                "Vertices",
+                "Vertices",
                 "Outline points of each zone (one branch per zone, at least 3 points; only X and Y are used). Give either this or the ReferencePositions input.",
                 GH_ParamAccess.tree);
 
             InPoints(
                 "ReferencePositions",
-                "Reference position of each automatic zone (only X and Y are used). Give either this or the Polygons input.");
+                "Reference position of each automatic zone (only X and Y are used). Give either this or the Vertices input.");
 
             InTexts(
                 "AdditionalSettings",
@@ -104,7 +104,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             if ((polygonBranchCount == 0) == (referencePositions.Count == 0))
             {
                 this.AddError(
-                    "Give exactly one of the Polygons and ReferencePositions inputs.");
+                    "Give exactly one of the Vertices and ReferencePositions inputs.");
                 return;
             }
 
@@ -112,7 +112,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 polygonBranchCount != 1 && polygonBranchCount != zoneCount)
             {
                 this.AddError(
-                    "The number of branches in the Polygons input must be 1 or equal to the size of the input Names.");
+                    "The number of branches in the Vertices input must be 1 or equal to the size of the input Names.");
                 return;
             }
 


### PR DESCRIPTION
## Summary

Fixes #518. The slab creation input called `Polygons` in fact takes the polygon **vertices** (a tree of points, one branch per element), which reads as if a closed polygon or a polyline curve were expected.

The input is renamed to **`Vertices`** in every creation component that has it, not just CreateSlabs, so the naming stays consistent: `CreateSlabs`, `CreateRoofs`, `CreateMeshes`, `CreateHatches` and `CreateZones` (whose error messages are updated to match).

The `Polygons` **outputs** of `GetDetailsOfElements` are genuine `PolyCurve`s and keep their name.

Renaming a Grasshopper input is cosmetic — component GUIDs are unchanged and connections are held by index, so existing definitions keep working and simply show the new label.

## Test plan

- [x] `dotnet build TapirGrasshopperPlugin.sln` succeeds with 0 warnings/errors
- [ ] Open an existing definition using CreateSlabs and confirm the wire is intact under the new input name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
