### PR TITLE
Accept floating point index values in SetDetailsOfElements

### DIFF
--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -1465,6 +1465,24 @@ static GS::HashTable<API_Guid, API_Guid> BuildOpeningToHostMap (const GS::HashSe
     return result;
 }
 
+// JSON has no separate integer type, so clients routinely send 2.0 where an index is
+// expected. GS::ObjectState::Get with an integer target rejects such a value, which used to
+// drop the field without any error (#530). These accept a floating point value as well and
+// round it to the nearest integer.
+template <typename IntType>
+static bool GetIndexValue (const GS::ObjectState& os, const char* fieldName, IntType& target)
+{
+    if (os.Get (fieldName, target)) {
+        return true;
+    }
+    double doubleValue = 0.0;
+    if (os.Get (fieldName, doubleValue)) {
+        target = static_cast<IntType> (doubleValue < 0.0 ? doubleValue - 0.5 : doubleValue + 0.5);
+        return true;
+    }
+    return false;
+}
+
 GS::ObjectState SetDetailsOfElementsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
 {
     GS::Array<GS::ObjectState> elementsWithDetails;
@@ -1482,7 +1500,7 @@ GS::ObjectState SetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
         const GS::ObjectState* det = ewd.Get ("details");
         if (eid == nullptr || det == nullptr) continue;
         short tgt = -1;
-        det->Get ("drawIndex", tgt);
+        GetIndexValue (*det, "drawIndex", tgt);
         if (tgt > 0 && tgt <= 7) continue;   // 1-7: no host needed
         API_Element hdr = {};
         hdr.header.guid = GetGuidFromObjectState (*eid);
@@ -1532,18 +1550,18 @@ GS::ObjectState SetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
             API_Element mask = {};
             ACAPI_ELEMENT_MASK_CLEAR (mask);
             bool hasElementChanges = false;
-            if (details->Get ("floorIndex", elem.header.floorInd)) {
+            if (GetIndexValue (*details, "floorIndex", elem.header.floorInd)) {
                 ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, floorInd);
                 hasElementChanges = true;
             }
             Int32 layerIndex;
-            if (details->Get ("layerIndex", layerIndex)) {
+            if (GetIndexValue (*details, "layerIndex", layerIndex)) {
                 elem.header.layer = ACAPI_CreateAttributeIndex (layerIndex);
                 ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, layer);
                 hasElementChanges = true;
             }
             short drwIndexTarget = -1;
-            details->Get ("drawIndex", drwIndexTarget);
+            GetIndexValue (*details, "drawIndex", drwIndexTarget);
 
             const GS::ObjectState* typeSpecificDetails = details->Get ("typeSpecificDetails");
             if (typeSpecificDetails != nullptr) {

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -13,6 +13,7 @@
 #endif
 
 #include <algorithm>
+#include <cmath>
 
 // Shared "line-family settings" fields present on Line/PolyLine/Arc/Circle/Spline
 // (API_LineType/API_PolyLineType/API_ArcType/API_SplineType all share this exact shape).
@@ -1467,8 +1468,9 @@ static GS::HashTable<API_Guid, API_Guid> BuildOpeningToHostMap (const GS::HashSe
 
 // JSON has no separate integer type, so clients routinely send 2.0 where an index is
 // expected. GS::ObjectState::Get with an integer target rejects such a value, which used to
-// drop the field without any error (#530). These accept a floating point value as well and
-// round it to the nearest integer.
+// drop the field without any error (#530). This accepts a floating point value as well and
+// floors it - std::floor, not truncation, so a negative index (stories below 0) rounds the
+// same way as a positive one.
 template <typename IntType>
 static bool GetIndexValue (const GS::ObjectState& os, const char* fieldName, IntType& target)
 {
@@ -1477,7 +1479,7 @@ static bool GetIndexValue (const GS::ObjectState& os, const char* fieldName, Int
     }
     double doubleValue = 0.0;
     if (os.Get (fieldName, doubleValue)) {
-        target = static_cast<IntType> (doubleValue < 0.0 ? doubleValue - 0.5 : doubleValue + 0.5);
+        target = static_cast<IntType> (std::floor (doubleValue));
         return true;
     }
     return false;


### PR DESCRIPTION
## Summary

Fixes #530. `SetDetailsOfElements` silently ignored `floorIndex`, `layerIndex` and `drawIndex` when they arrived as JSON floats (`2.0` instead of `2`), while still reporting success.

## Root cause

JSON has no separate integer type, so many clients send whole numbers as floats. The three fields were read straight into integer targets:

```cpp
if (details->Get ("floorIndex", elem.header.floorInd)) {   // short&  -> false for 2.0
Int32 layerIndex;
if (details->Get ("layerIndex", layerIndex)) {             // Int32&  -> false for 2.0
details->Get ("drawIndex", drwIndexTarget);                // short&  -> false for 2.0
```

`GS::ObjectState::Get` returns `false` when the stored value is a double, so the field was skipped and no mask bit was set — no error, no change. As the reporter noted, the published schema calls these `"type": "integer"`, but the documentation renders them as numbers, which makes the trap easy to walk into.

## Fix

A small `GetIndexValue` helper reads the integer target first and falls back to reading a double and **flooring** it. Used for all four index reads in the file (the three above plus the draw-order pass). Integers keep working exactly as before.

`std::floor` rather than a cast: truncation rounds toward zero, so a negative index — stories below 0 are ordinary — would go the other way from a positive one (`-1.4` → `-1` instead of `-2`).

## Test plan

- [x] AC29 add-on build succeeds
- [ ] Live: `SetDetailsOfElements` with `{"floorIndex": 1.0, "layerIndex": 3.0, "drawIndex": 2.0}` on an Object moves it to that story/layer/draw order, matching the integer form
- [ ] Live: a fractional value floors consistently in both directions (`1.4` → `1`, `-1.4` → `-2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### ✅ Live verification — passed

Archicad 29, add-on built from `8554be4`, untitled project from the default template. `SetDetailsOfElements` with `drawIndex: 2.7` → `2`.
