### PR TITLE
Hand out the command responses the Grasshopper components were dropping

### DIFF
--- a/archicad-addon/Sources/AttributeCommands.cpp
+++ b/archicad-addon/Sources/AttributeCommands.cpp
@@ -2656,7 +2656,7 @@ GS::Optional<GS::UniString> CreateAttributesCommandBase::GetRawResponseSchema ()
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -3620,7 +3620,7 @@ GS::Optional<GS::UniString> CreateFillsCommand::GetRawResponseSchema () const
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -4478,7 +4478,7 @@ GS::Optional<GS::UniString> CreatePenTablesCommand::GetRawResponseSchema () cons
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -5000,7 +5000,7 @@ GS::Optional<GS::UniString> CreateProfilesCommand::GetRawResponseSchema () const
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -5324,7 +5324,7 @@ GS::Optional<GS::UniString> CreateCompositesCommand::GetRawResponseSchema () con
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,

--- a/archicad-addon/Sources/DocumentCreationCommands.cpp
+++ b/archicad-addon/Sources/DocumentCreationCommands.cpp
@@ -151,7 +151,7 @@ GS::Optional<GS::UniString> CreateDetailsCommand::GetInputParametersSchema () co
 
 GS::Optional<GS::UniString> CreateDetailsCommand::GetRawResponseSchema () const
 {
-    return R"({"type":"object","properties":{"databases":{"$ref":"#/Databases"}},"additionalProperties":false,"required":["databases"]})";
+    return R"({"type":"object","properties":{"databases":{"$ref":"#/DatabaseIdsOrErrors"}},"additionalProperties":false,"required":["databases"]})";
 }
 
 GS::ObjectState CreateDetailsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
@@ -585,7 +585,7 @@ GS::Optional<GS::UniString> CreateDrawingsCommand::GetInputParametersSchema () c
 
 GS::Optional<GS::UniString> CreateDrawingsCommand::GetRawResponseSchema () const
 {
-    return R"({"type":"object","properties":{"elements":{"$ref":"#/Elements"}},"additionalProperties":false,"required":["elements"]})";
+    return R"({"type":"object","properties":{"elements":{"$ref":"#/ElementIdsOrErrors"}},"additionalProperties":false,"required":["elements"]})";
 }
 
 // Creates a single Drawing from a "drawingsData"-shaped item (navigatorItemId, name, position,

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -23,7 +23,7 @@ GS::Optional<GS::UniString> CreateElementsCommandBase::GetRawResponseSchema () c
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -3723,7 +3723,7 @@ GS::Optional<GS::UniString> CreateWindowsCommand::GetRawResponseSchema () const
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -3865,7 +3865,7 @@ GS::Optional<GS::UniString> CreateDoorsCommand::GetRawResponseSchema () const
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -3999,7 +3999,7 @@ GS::Optional<GS::UniString> CreateOpeningsCommand::GetRawResponseSchema () const
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -4189,7 +4189,7 @@ GS::Optional<GS::UniString> CreateMorphsCommand::GetRawResponseSchema () const
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -4581,7 +4581,7 @@ GS::Optional<GS::UniString> CreateAssociativeDimensionsCommand::GetRawResponseSc
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -4746,7 +4746,7 @@ GS::Optional<GS::UniString> CreateAssociativeDimensionsOnSectionCommand::GetRawR
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -4869,7 +4869,7 @@ GS::Optional<GS::UniString> CreateWallThicknessDimensionsCommand::GetRawResponse
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -6259,7 +6259,7 @@ GS::Optional<GS::UniString> CreateSectionsCommand::GetRawResponseSchema () const
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -326,6 +326,44 @@
             "attributeId"
         ]
     },
+    "DatabaseIdOrError": {
+        "type": "object",
+        "description": "An Archicad database identifier or an error.",
+        "oneOf": [
+            {
+                "$ref": "#/DatabaseIdArrayItem"
+            },
+            {
+                "$ref": "#/ErrorItem"
+            }
+        ]
+    },
+    "DatabaseIdsOrErrors": {
+        "type": "array",
+        "description": "A list of Archicad database identifiers or errors.",
+        "items": {
+            "$ref": "#/DatabaseIdOrError"
+        }
+    },
+    "AttributeIdOrError": {
+        "type": "object",
+        "description": "An attribute identifier or an error.",
+        "oneOf": [
+            {
+                "$ref": "#/AttributeIdArrayItem"
+            },
+            {
+                "$ref": "#/ErrorItem"
+            }
+        ]
+    },
+    "AttributeIdsOrErrors": {
+        "type": "array",
+        "description": "A list of attribute identifiers or errors.",
+        "items": {
+            "$ref": "#/AttributeIdOrError"
+        }
+    },
     "AttributeId": {
         "type": "object",
         "description": "The identifier of an attribute.",

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -1843,7 +1843,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -1895,7 +1895,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -1951,7 +1951,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2025,7 +2025,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2101,7 +2101,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2146,7 +2146,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2189,7 +2189,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2224,7 +2224,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2330,7 +2330,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2410,7 +2410,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2462,7 +2462,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2517,7 +2517,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2551,7 +2551,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2656,7 +2656,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2734,7 +2734,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2800,7 +2800,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2876,7 +2876,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2942,7 +2942,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -2999,7 +2999,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -3086,7 +3086,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -3157,7 +3157,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -3249,7 +3249,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -3343,7 +3343,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -3456,7 +3456,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -3519,7 +3519,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -3588,7 +3588,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -5553,7 +5553,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -5612,7 +5612,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -5749,7 +5749,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -5927,7 +5927,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -6001,7 +6001,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -6084,7 +6084,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -6177,7 +6177,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -6426,7 +6426,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -6545,7 +6545,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -6664,7 +6664,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -6765,7 +6765,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "attributeIds": {
-                "$ref": "#/AttributeIds"
+                "$ref": "#/AttributeIdsOrErrors"
             }
         },
         "additionalProperties": false,
@@ -7728,7 +7728,7 @@ var gCommands = [{
         "additionalProperties": false,
         "required": ["detailsData"]
     },
-                "outputScheme": {"type":"object","properties":{"databases":{"$ref":"#/Databases"}},"additionalProperties":false,"required":["databases"]}
+                "outputScheme": {"type":"object","properties":{"databases":{"$ref":"#/DatabaseIdsOrErrors"}},"additionalProperties":false,"required":["databases"]}
             },{
                 "name": "CreateWorksheets",
                 "version": "1.4.0",
@@ -7752,7 +7752,7 @@ var gCommands = [{
         "additionalProperties": false,
         "required": ["worksheetsData"]
     },
-                "outputScheme": {"type":"object","properties":{"databases":{"$ref":"#/Databases"}},"additionalProperties":false,"required":["databases"]}
+                "outputScheme": {"type":"object","properties":{"databases":{"$ref":"#/DatabaseIdsOrErrors"}},"additionalProperties":false,"required":["databases"]}
             },{
                 "name": "CreateLayout",
                 "version": "1.4.0",
@@ -7794,7 +7794,7 @@ var gCommands = [{
         "additionalProperties": false,
         "required": ["layoutsData"]
     },
-                "outputScheme": {"type":"object","properties":{"databases":{"$ref":"#/Databases"}},"additionalProperties":false,"required":["databases"]}
+                "outputScheme": {"type":"object","properties":{"databases":{"$ref":"#/DatabaseIdsOrErrors"}},"additionalProperties":false,"required":["databases"]}
             },{
                 "name": "CreateLayoutSubset",
                 "version": "1.4.0",
@@ -7867,7 +7867,7 @@ var gCommands = [{
         "additionalProperties": false,
         "required": ["drawingsData"]
     },
-                "outputScheme": {"type":"object","properties":{"elements":{"$ref":"#/Elements"}},"additionalProperties":false,"required":["elements"]}
+                "outputScheme": {"type":"object","properties":{"elements":{"$ref":"#/ElementIdsOrErrors"}},"additionalProperties":false,"required":["elements"]}
             },{
                 "name": "ChangeDrawingLink",
                 "version": "1.5.7",
@@ -8427,7 +8427,7 @@ var gCommands = [{
         "type": "object",
         "properties": {
             "elements": {
-                "$ref": "#/Elements"
+                "$ref": "#/ElementIdsOrErrors"
             }
         },
         "additionalProperties": false,

--- a/docs/archicad-addon/common_schema_definitions.js
+++ b/docs/archicad-addon/common_schema_definitions.js
@@ -326,6 +326,44 @@ var gSchemaDefinitions = {
             "attributeId"
         ]
     },
+    "DatabaseIdOrError": {
+        "type": "object",
+        "description": "An Archicad database identifier or an error.",
+        "oneOf": [
+            {
+                "$ref": "#/DatabaseIdArrayItem"
+            },
+            {
+                "$ref": "#/ErrorItem"
+            }
+        ]
+    },
+    "DatabaseIdsOrErrors": {
+        "type": "array",
+        "description": "A list of Archicad database identifiers or errors.",
+        "items": {
+            "$ref": "#/DatabaseIdOrError"
+        }
+    },
+    "AttributeIdOrError": {
+        "type": "object",
+        "description": "An attribute identifier or an error.",
+        "oneOf": [
+            {
+                "$ref": "#/AttributeIdArrayItem"
+            },
+            {
+                "$ref": "#/ErrorItem"
+            }
+        ]
+    },
+    "AttributeIdsOrErrors": {
+        "type": "array",
+        "description": "A list of attribute identifiers or errors.",
+        "items": {
+            "$ref": "#/AttributeIdOrError"
+        }
+    },
     "AttributeId": {
         "type": "object",
         "description": "The identifier of an attribute.",

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/AttributeCreateJsonComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/AttributeCreateJsonComponent.cs
@@ -39,6 +39,11 @@ namespace TapirGrasshopperPlugin.Components.AttributesComponents
                 false);
         }
 
+        protected override void AddOutputs()
+        {
+            AttributeCreateResult.AddOutputs(this);
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -74,11 +79,18 @@ namespace TapirGrasshopperPlugin.Components.AttributesComponents
                 ["overwriteExisting"] = overwriteExisting
             };
 
-            TryGetCadResponse(
-                CommandName,
-                parameters,
-                ToAddOn,
-                out _);
+            if (!TryGetCadResponse(
+                    CommandName,
+                    parameters,
+                    ToAddOn,
+                    out JObject response))
+            {
+                return;
+            }
+
+            AttributeCreateResult.SetOutputs(
+                da,
+                response);
         }
     }
 }

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/AttributeCreateResult.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/AttributeCreateResult.cs
@@ -1,0 +1,68 @@
+using Grasshopper.Kernel;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using TapirGrasshopperPlugin.Types.Attributes;
+
+namespace TapirGrasshopperPlugin.Components.AttributesComponents
+{
+    // The attribute creator commands all answer with an "attributeIds" array holding
+    // one item per requested attribute - either the identifier of the created
+    // attribute or an error. Those identifiers are what the attribute inputs of the
+    // element components (buildingMaterialId, compositeId, profileId, fillId, ...)
+    // expect, so every creator component has to hand them out.
+    internal static class AttributeCreateResult
+    {
+        public static void AddOutputs(
+            Component component)
+        {
+            component.OutGenerics(
+                "AttributeGuids",
+                "Identifiers of the created attributes (empty for the failed ones).");
+
+            component.OutTexts(
+                "ErrorMessages",
+                "Error message of each attribute (empty when it was created successfully).");
+        }
+
+        public static void SetOutputs(
+            IGH_DataAccess da,
+            JObject response,
+            int guidsOutputIndex = 0,
+            int errorsOutputIndex = 1)
+        {
+            var attributeGuids = new List<AttributeGuidObject>();
+            var errorMessages = new List<string>();
+
+            if (response?["attributeIds"] is JArray attributeIds)
+            {
+                foreach (var item in attributeIds)
+                {
+                    var error = item?["error"];
+                    if (error != null)
+                    {
+                        attributeGuids.Add(null);
+                        errorMessages.Add(
+                            error["message"]?.ToString() ??
+                            "Failed to create the attribute.");
+                        continue;
+                    }
+
+                    var guid = item?["attributeId"]?["guid"]?.ToString();
+                    attributeGuids.Add(
+                        guid == null
+                            ? null
+                            : new AttributeGuidObject { Guid = guid });
+                    errorMessages.Add("");
+                }
+            }
+
+            da.SetDataList(
+                guidsOutputIndex,
+                attributeGuids);
+
+            da.SetDataList(
+                errorsOutputIndex,
+                errorMessages);
+        }
+    }
+}

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/DeleteAttributesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/DeleteAttributesComponent.cs
@@ -31,6 +31,12 @@ namespace TapirGrasshopperPlugin.Components.AttributesComponents
                 "Identifiers of the attributes to delete.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each attribute (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -71,10 +77,11 @@ namespace TapirGrasshopperPlugin.Components.AttributesComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/SetLayerCombinationsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/SetLayerCombinationsComponent.cs
@@ -52,6 +52,11 @@ namespace TapirGrasshopperPlugin.Components.AttributesComponents
                 "Intersection groups of the layers in the combinations.");
         }
 
+        protected override void AddOutputs()
+        {
+            AttributeCreateResult.AddOutputs(this);
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -210,10 +215,19 @@ namespace TapirGrasshopperPlugin.Components.AttributesComponents
                 index++;
             }
 
-            SetCadValues(
-                CommandName,
-                layerCombinationDataArray,
-                ToAddOn);
+            if (!TryGetCadResponse(
+                    CommandName,
+                    Newtonsoft.Json.Linq.JObject.FromObject(
+                        layerCombinationDataArray),
+                    ToAddOn,
+                    out var response))
+            {
+                return;
+            }
+
+            AttributeCreateResult.SetOutputs(
+                da,
+                response);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/SetLayersComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/AttributesComponents/SetLayersComponent.cs
@@ -45,6 +45,11 @@ namespace TapirGrasshopperPlugin.Components.AttributesComponents
                 "Intersection groups of the layers.");
         }
 
+        protected override void AddOutputs()
+        {
+            AttributeCreateResult.AddOutputs(this);
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -146,10 +151,18 @@ namespace TapirGrasshopperPlugin.Components.AttributesComponents
                 index++;
             }
 
-            SetCadValues(
-                CommandName,
-                layerDataArray,
-                ToAddOn);
+            if (!TryGetCadResponse(
+                    CommandName,
+                    Newtonsoft.Json.Linq.JObject.FromObject(layerDataArray),
+                    ToAddOn,
+                    out var response))
+            {
+                return;
+            }
+
+            AttributeCreateResult.SetOutputs(
+                da,
+                response);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ClassificationsComponents/DeleteClassificationItemsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ClassificationsComponents/DeleteClassificationItemsComponent.cs
@@ -27,6 +27,12 @@ namespace TapirGrasshopperPlugin.Components.ClassificationsComponents
                 "Identifiers of the classification items to delete.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each classification item (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -55,10 +61,11 @@ namespace TapirGrasshopperPlugin.Components.ClassificationsComponents
                     new ClassificationItemGuidWrapper { ClassificationItemId = id });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ClassificationsComponents/DeleteClassificationSystemsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ClassificationsComponents/DeleteClassificationSystemsComponent.cs
@@ -27,6 +27,12 @@ namespace TapirGrasshopperPlugin.Components.ClassificationsComponents
                 "Identifiers of the classification systems to delete.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each classification system (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -55,10 +61,11 @@ namespace TapirGrasshopperPlugin.Components.ClassificationsComponents
                     new ClassificationSystemGuidWrapper { ClassificationSystemId = id });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ClassificationsComponents/SetClassificationsOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ClassificationsComponents/SetClassificationsOfElementsComponent.cs
@@ -46,6 +46,12 @@ namespace TapirGrasshopperPlugin.Components.ClassificationsComponents
                 0);
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each element (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -115,10 +121,11 @@ namespace TapirGrasshopperPlugin.Components.ClassificationsComponents
                 elementClassifications.Add(elementClassification);
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 new { elementClassifications },
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/Component.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/Component.cs
@@ -587,6 +587,19 @@ namespace TapirGrasshopperPlugin.Components
                 GH_ParamAccess.list);
         }
 
+        // The commands report the failure of a single item in their
+        // executionResults array instead of failing the whole call, so the
+        // components have to hand those messages out - otherwise the failures
+        // are swallowed silently.
+        public void OutErrorMessages(
+            string description =
+                "Error message of each item (empty when the operation succeeded on it).")
+        {
+            OutTexts(
+                "ErrorMessages",
+                description);
+        }
+
         public void OutTextTree(
             string name,
             string description = "")
@@ -769,6 +782,104 @@ namespace TapirGrasshopperPlugin.Components
                 JObject.FromObject(commandParameters),
                 sendCommand,
                 out var result);
+        }
+
+        // Same as SetCadValues, but hands the per-item results of the command
+        // out through the ErrorMessages output added by OutErrorMessages.
+        protected void SetCadValuesWithErrorMessages(
+            string commandName,
+            object commandParameters,
+            Func<string, JObject, CommandResponse> sendCommand,
+            IGH_DataAccess da,
+            int outputIndex = 0)
+        {
+            if (!TryGetCadResponse(
+                    commandName,
+                    commandParameters == null
+                        ? new JObject()
+                        : JObject.FromObject(commandParameters),
+                    sendCommand,
+                    out var response))
+            {
+                return;
+            }
+
+            da.SetDataList(
+                outputIndex,
+                ExecutionResultsResponse.ErrorMessages(response));
+        }
+
+        // The creator commands answer with one item per requested item, holding
+        // either the identifier of the created item or an error. Hands the
+        // identifiers out through one output and the error messages through
+        // another, so a failed item does not shift the identifiers of the
+        // others.
+        protected void SetCreatedIdsAndErrorMessages<T>(
+            IGH_DataAccess da,
+            JObject response,
+            string arrayKey,
+            string idKey,
+            int idsOutputIndex = 0,
+            int errorsOutputIndex = 1)
+            where T : class
+        {
+            var ids = new List<T>();
+            var errorMessages = new List<string>();
+
+            if (response?[arrayKey] is JArray items)
+            {
+                foreach (var item in items)
+                {
+                    var error = item?["error"];
+                    if (error != null)
+                    {
+                        ids.Add(null);
+                        errorMessages.Add(
+                            error["message"]?.ToString() ?? "Unknown error.");
+                        continue;
+                    }
+
+                    ids.Add(item?[idKey]?.ToObject<T>());
+                    errorMessages.Add("");
+                }
+            }
+
+            da.SetDataList(
+                idsOutputIndex,
+                ids);
+
+            da.SetDataList(
+                errorsOutputIndex,
+                errorMessages);
+        }
+
+        // Same as SetCadValues, but hands the created identifiers and the
+        // per-item error messages out through the first two outputs.
+        protected void SetCadValuesWithCreatedIds<T>(
+            string commandName,
+            object commandParameters,
+            Func<string, JObject, CommandResponse> sendCommand,
+            IGH_DataAccess da,
+            string arrayKey,
+            string idKey)
+            where T : class
+        {
+            if (!TryGetCadResponse(
+                    commandName,
+                    commandParameters == null
+                        ? new JObject()
+                        : JObject.FromObject(commandParameters),
+                    sendCommand,
+                    out var response))
+            {
+                return;
+            }
+
+            SetCreatedIdsAndErrorMessages<T>(
+                da,
+                response,
+                arrayKey,
+                idKey);
         }
 
         protected bool TryGetConvertedCadValues<T>(

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/DesignOptionsComponents/CreateDesignOptionCombinationsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/DesignOptionsComponents/CreateDesignOptionCombinationsComponent.cs
@@ -32,6 +32,16 @@ namespace TapirGrasshopperPlugin.Components.DesignOptionsComponents
                 "Identifiers of the active design options for each combination (one branch per combination).");
         }
 
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "DesignOptionCombinationGuids",
+                "Identifier of each created design option combination.");
+
+            OutErrorMessages(
+                "Error message of each combination (empty when it was created successfully).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -81,10 +91,13 @@ namespace TapirGrasshopperPlugin.Components.DesignOptionsComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithCreatedIds<DesignOptionCombinationGuid>(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da,
+                "designOptionCombinationIdsOrErrors",
+                "designOptionCombinationId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/DesignOptionsComponents/CreateDesignOptionSetsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/DesignOptionsComponents/CreateDesignOptionSetsComponent.cs
@@ -25,6 +25,12 @@ namespace TapirGrasshopperPlugin.Components.DesignOptionsComponents
                 "Names of the design option sets to create.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each design option set (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -40,10 +46,11 @@ namespace TapirGrasshopperPlugin.Components.DesignOptionsComponents
                 DesignOptionSets = names
             };
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/DesignOptionsComponents/CreateDesignOptionsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/DesignOptionsComponents/CreateDesignOptionsComponent.cs
@@ -33,6 +33,16 @@ namespace TapirGrasshopperPlugin.Components.DesignOptionsComponents
                 "Names of the owner design option sets.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "DesignOptionGuids",
+                "Identifier of each created design option.");
+
+            OutErrorMessages(
+                "Error message of each design option (empty when it was created successfully).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -81,10 +91,13 @@ namespace TapirGrasshopperPlugin.Components.DesignOptionsComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithCreatedIds<DesignOptionGuid>(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da,
+                "designOptionIdsOrErrors",
+                "designOptionId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/DesignOptionsComponents/MoveDesignOptionsToAnotherSetComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/DesignOptionsComponents/MoveDesignOptionsToAnotherSetComponent.cs
@@ -31,6 +31,12 @@ namespace TapirGrasshopperPlugin.Components.DesignOptionsComponents
                 "Names of the target design option sets (input only 1 to move all design options into the same set).");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each design option (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -80,10 +86,11 @@ namespace TapirGrasshopperPlugin.Components.DesignOptionsComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/DesignOptionsComponents/MoveElementsToDesignOptionsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/DesignOptionsComponents/MoveElementsToDesignOptionsComponent.cs
@@ -34,6 +34,12 @@ namespace TapirGrasshopperPlugin.Components.DesignOptionsComponents
                 "Identifiers of the target design options (input only 1 to move all elements into the same design option).");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each element (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -93,10 +99,11 @@ namespace TapirGrasshopperPlugin.Components.DesignOptionsComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/DesignOptionsComponents/SetActiveDesignOptionsInCombinationsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/DesignOptionsComponents/SetActiveDesignOptionsInCombinationsComponent.cs
@@ -32,6 +32,12 @@ namespace TapirGrasshopperPlugin.Components.DesignOptionsComponents
                 "Identifiers of the active design options for each combination (one branch per combination).");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each design option combination (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -90,10 +96,11 @@ namespace TapirGrasshopperPlugin.Components.DesignOptionsComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ChangeSelectionComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ChangeSelectionComponent.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using TapirGrasshopperPlugin.Helps;
 using TapirGrasshopperPlugin.Types.Element;
+using TapirGrasshopperPlugin.Types.Generic;
 
 namespace TapirGrasshopperPlugin.Components.ElementsComponents
 {
@@ -39,6 +40,17 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                     0,
                     1
                 });
+        }
+
+        protected override void AddOutputs()
+        {
+            OutTexts(
+                "ErrorMessagesOfAdd",
+                "Error message of each element to add to the selection (empty when it succeeded).");
+
+            OutTexts(
+                "ErrorMessagesOfRemove",
+                "Error message of each element to remove from the selection (empty when it succeeded).");
         }
 
         protected override void Solve(
@@ -107,10 +119,26 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             };
 
 
-            SetCadValues(
-                CommandName,
-                parameters,
-                ToAddOn);
+            if (!TryGetCadResponse(
+                    CommandName,
+                    Newtonsoft.Json.Linq.JObject.FromObject(parameters),
+                    ToAddOn,
+                    out var response))
+            {
+                return;
+            }
+
+            da.SetDataList(
+                0,
+                ExecutionResultsResponse.ErrorMessages(
+                    response,
+                    "executionResultsOfAddToSelection"));
+
+            da.SetDataList(
+                1,
+                ExecutionResultsResponse.ErrorMessages(
+                    response,
+                    "executionResultsOfRemoveFromSelection"));
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateGroupsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateGroupsComponent.cs
@@ -29,6 +29,16 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 "Identifiers of the elements to group (one branch per group).");
         }
 
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "GroupGuids",
+                "Identifier of each created group.");
+
+            OutErrorMessages(
+                "Error message of each group (empty when it was created successfully).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -70,10 +80,13 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                     new ElementGroupParameters { Elements = elements });
             }
 
-            SetCadValues(
+            SetCadValuesWithCreatedIds<GroupGuid>(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da,
+                "groupGuids",
+                "groupId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetDetailsOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/GetDetailsOfElementsComponent.cs
@@ -96,6 +96,11 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             OutIntegers(
                 "DrawOrders",
                 "Drawing orders.");
+
+            OutCurveTree(
+                "FloorPlanPolygons",
+                "The cut-fill polygons of each element as drawn on the floor plan " +
+                "(one branch per element, empty for the elements without a cut fill).");
         }
 
         protected override void ManageResponse(
@@ -107,6 +112,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             var storyIndices = new List<int>();
             var layerIndices = new List<int>();
             var drawIndices = new List<int>();
+            var floorPlanPolygonsTree = new DataTree<PolyCurve>();
 
             for (var i = 0; i < response.DetailsOfElements.Count; i++)
             {
@@ -126,6 +132,25 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 storyIndices.Add(detailsOfElement.FloorIndex);
                 layerIndices.Add(detailsOfElement.LayerIndex);
                 drawIndices.Add(detailsOfElement.DrawIndex);
+
+                var floorPlanPolygons = new List<PolyCurve>();
+                if (detailsOfElement.FloorPlanPolygons != null)
+                {
+                    foreach (var polygon in detailsOfElement.FloorPlanPolygons)
+                    {
+                        floorPlanPolygons.Add(
+                            Helps.Convert.ToPolyCurve(
+                                polygon.Coordinates,
+                                new List<Arc>(),
+                                0.0));
+                    }
+                }
+
+                // One branch per element, so the branch index matches the
+                // ElementGuids output even when an element has no cut fill.
+                floorPlanPolygonsTree.AddRange(
+                    floorPlanPolygons,
+                    new GH_Path(validElements.Count));
             }
 
             da.SetDataList(
@@ -146,6 +171,9 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             da.SetDataList(
                 5,
                 drawIndices);
+            da.SetDataTree(
+                6,
+                floorPlanPolygonsTree);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/MoveElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/MoveElementsComponent.cs
@@ -35,6 +35,12 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 false);
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each element (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -92,10 +98,11 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/RotateElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/RotateElementsComponent.cs
@@ -43,6 +43,12 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                 false);
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each element (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -131,10 +137,11 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/SetSuspendGroupsModeComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/SetSuspendGroupsModeComponent.cs
@@ -39,11 +39,25 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
             var parameters = new JObject { ["suspendGroups"] = suspend };
 
-            TryGetCadResponse(
-                CommandName,
-                parameters,
-                ToAddOn,
-                out _);
+            if (!TryGetCadResponse(
+                    CommandName,
+                    parameters,
+                    ToAddOn,
+                    out JObject response))
+            {
+                return;
+            }
+
+            // The command reports a failed switch in its executionResult
+            // instead of failing the call itself.
+            var result = response["executionResult"];
+            if (result != null &&
+                (bool?)result["success"] != true)
+            {
+                this.AddError(
+                    result["error"]?["message"]?.ToString() ??
+                    "Failed to change the Suspend Groups mode.");
+            }
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/FavoritesComponents/ApplyFavoritesToElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/FavoritesComponents/ApplyFavoritesToElementsComponent.cs
@@ -52,6 +52,12 @@ namespace TapirGrasshopperPlugin.Components.FavoritesComponents
                 true);
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each element (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -109,10 +115,11 @@ namespace TapirGrasshopperPlugin.Components.FavoritesComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/FavoritesComponents/DeleteFavoritesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/FavoritesComponents/DeleteFavoritesComponent.cs
@@ -25,6 +25,12 @@ namespace TapirGrasshopperPlugin.Components.FavoritesComponents
                 "Names of the Favorites to delete.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each favorite (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -40,10 +46,11 @@ namespace TapirGrasshopperPlugin.Components.FavoritesComponents
                 Favorites = names
             };
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/FavoritesComponents/ImportFavoritesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/FavoritesComponents/ImportFavoritesComponent.cs
@@ -40,6 +40,14 @@ namespace TapirGrasshopperPlugin.Components.FavoritesComponents
             SetOptionality(new[] { 1, 2, 3 });
         }
 
+        protected override void AddOutputs()
+        {
+            OutText(
+                "FirstConflictName",
+                "Name of the first conflicting favorite - filled only when the " +
+                "import stopped on a name conflict with the Error conflict policy.");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -77,10 +85,18 @@ namespace TapirGrasshopperPlugin.Components.FavoritesComponents
                 input.ConflictPolicy = conflictPolicy;
             }
 
-            SetCadValues(
-                CommandName,
-                input,
-                ToAddOn);
+            if (!TryGetCadResponse(
+                    CommandName,
+                    Newtonsoft.Json.Linq.JObject.FromObject(input),
+                    ToAddOn,
+                    out var response))
+            {
+                return;
+            }
+
+            da.SetData(
+                0,
+                response["firstConflictName"]?.ToString() ?? "");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/FavoritesComponents/RenameFavoritesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/FavoritesComponents/RenameFavoritesComponent.cs
@@ -29,6 +29,12 @@ namespace TapirGrasshopperPlugin.Components.FavoritesComponents
                 "New names of the Favorites.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each favorite (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -68,10 +74,11 @@ namespace TapirGrasshopperPlugin.Components.FavoritesComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/FavoritesComponents/UpdateFavoritesFromElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/FavoritesComponents/UpdateFavoritesFromElementsComponent.cs
@@ -32,6 +32,12 @@ namespace TapirGrasshopperPlugin.Components.FavoritesComponents
                 "Names of the existing Favorites to update.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each favorite (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -79,10 +85,11 @@ namespace TapirGrasshopperPlugin.Components.FavoritesComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/CreateKeynoteFoldersComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/CreateKeynoteFoldersComponent.cs
@@ -40,6 +40,16 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
             SetOptionality(2);
         }
 
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "KeynoteFolderGuids",
+                "Identifier of each created keynote folder.");
+
+            OutErrorMessages(
+                "Error message of each folder (empty when it was created successfully).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -109,11 +119,13 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
 
             var parameters = new JObject { ["foldersData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithCreatedIds<KeynoteFolderGuid>(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da,
+                "keynoteFolderIdsOrErrors",
+                "keynoteFolderId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/CreateKeynoteItemsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/CreateKeynoteItemsComponent.cs
@@ -48,6 +48,16 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
             SetOptionality(new[] { 1, 2, 3, 4 });
         }
 
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "KeynoteItemGuids",
+                "Identifier of each created keynote item.");
+
+            OutErrorMessages(
+                "Error message of each item (empty when it was created successfully).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -133,11 +143,13 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
 
             var parameters = new JObject { ["itemsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithCreatedIds<KeynoteItemGuid>(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da,
+                "keynoteItemIdsOrErrors",
+                "keynoteItemId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/CreateKeynoteLabelsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/CreateKeynoteLabelsComponent.cs
@@ -5,6 +5,7 @@ using Rhino.Geometry;
 using System;
 using System.Collections.Generic;
 using TapirGrasshopperPlugin.Helps;
+using TapirGrasshopperPlugin.Types.Element;
 using TapirGrasshopperPlugin.Types.GuidObjects;
 using TapirGrasshopperPlugin.Types.Keynotes;
 
@@ -39,6 +40,16 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
                 "Applied to all labels. Optional; defaults to all fields.");
 
             SetOptionality(2);
+        }
+
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "ElementGuids",
+                "Identifier of each created keynote label.");
+
+            OutErrorMessages(
+                "Error message of each keynote label (empty when it was created successfully).");
         }
 
         protected override void Solve(
@@ -107,11 +118,13 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
 
             var parameters = new JObject { ["labelsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithCreatedIds<ElementGuid>(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da,
+                "elements",
+                "elementId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/DeleteKeynoteFoldersComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/DeleteKeynoteFoldersComponent.cs
@@ -26,6 +26,12 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
                 "Identifiers of the keynote folders to delete.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each keynote folder (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -36,11 +42,11 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
                 return;
             }
 
-            TryGetCadResponse(
+            SetCadValuesWithErrorMessages(
                 CommandName,
-                JObject.FromObject(input),
+                input,
                 ToAddOn,
-                out _);
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/DeleteKeynoteItemsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/DeleteKeynoteItemsComponent.cs
@@ -26,6 +26,12 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
                 "Identifiers of the keynote items to delete.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each keynote item (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -36,11 +42,11 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
                 return;
             }
 
-            TryGetCadResponse(
+            SetCadValuesWithErrorMessages(
                 CommandName,
-                JObject.FromObject(input),
+                input,
                 ToAddOn,
-                out _);
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/ModifyKeynoteFoldersComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/ModifyKeynoteFoldersComponent.cs
@@ -43,6 +43,12 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
             SetOptionality(new[] { 1, 2, 3 });
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each keynote folder (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -107,11 +113,11 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
 
             var parameters = new JObject { ["foldersData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/ModifyKeynoteItemsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/KeynotesComponents/ModifyKeynoteItemsComponent.cs
@@ -47,6 +47,12 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
             SetOptionality(new[] { 1, 2, 3, 4 });
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each keynote item (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -118,11 +124,11 @@ namespace TapirGrasshopperPlugin.Components.KeynotesComponents
 
             var parameters = new JObject { ["itemsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/LibraryComponents/AddFilesToEmbeddedLibraryComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/LibraryComponents/AddFilesToEmbeddedLibraryComponent.cs
@@ -29,6 +29,12 @@ namespace TapirGrasshopperPlugin.Components.LibraryComponents
                 "Relative paths of the new files inside the embedded library.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each file (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -68,10 +74,11 @@ namespace TapirGrasshopperPlugin.Components.LibraryComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/MEPComponents/ConnectMEPElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/MEPComponents/ConnectMEPElementsComponent.cs
@@ -35,6 +35,24 @@ namespace TapirGrasshopperPlugin.Components.MEPComponents
                 "(input only 1 to connect all routes to the same element).");
         }
 
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "DeletedRoutingElementGuids",
+                "Identifier of the routing element deleted by merging, for each connection.");
+
+            OutGenerics(
+                "SplitRoutingElementGuids",
+                "Identifier of the routing element created by splitting, for each connection.");
+
+            OutGenerics(
+                "CreatedBranchGuids",
+                "Identifier of the branch element created by the connection, for each connection.");
+
+            OutErrorMessages(
+                "Error message of each connection (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -95,11 +113,46 @@ namespace TapirGrasshopperPlugin.Components.MEPComponents
 
             var parameters = new JObject { ["connectionsData"] = items };
 
-            TryGetCadResponse(
-                CommandName,
-                parameters,
-                ToAddOn,
-                out _);
+            if (!TryGetCadResponse(
+                    CommandName,
+                    parameters,
+                    ToAddOn,
+                    out JObject response))
+            {
+                return;
+            }
+
+            // Each connection answers with the ids of the elements it changed:
+            // any of the three can be missing when the connection did not need
+            // that operation, so they are kept in separate outputs.
+            var deletedIds = new List<ElementGuid>();
+            var splitIds = new List<ElementGuid>();
+            var branchIds = new List<ElementGuid>();
+            var errorMessages = new List<string>();
+
+            if (response["connectionResults"] is JArray results)
+            {
+                foreach (var result in results)
+                {
+                    var error = result?["error"];
+                    errorMessages.Add(
+                        error == null
+                            ? ""
+                            : error["message"]?.ToString() ?? "Unknown error.");
+
+                    deletedIds.Add(
+                        result?["deletedRoutingElementId"]?.ToObject<ElementGuid>());
+                    splitIds.Add(
+                        result?["splitRoutingElementId"]?.ToObject<ElementGuid>());
+                    branchIds.Add(
+                        result?["createdBranchId"]?.ToObject<ElementGuid>());
+                }
+            }
+
+            da.SetDataList(0, deletedIds);
+            da.SetDataList(1, splitIds);
+            da.SetDataList(2, branchIds);
+            da.SetDataList(3, errorMessages);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/MEPComponents/CreateMEPElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/MEPComponents/CreateMEPElementsComponent.cs
@@ -4,6 +4,7 @@ using Rhino.Geometry;
 using System;
 using System.Collections.Generic;
 using TapirGrasshopperPlugin.Helps;
+using TapirGrasshopperPlugin.Types.Element;
 
 namespace TapirGrasshopperPlugin.Components.MEPComponents
 {
@@ -45,6 +46,16 @@ namespace TapirGrasshopperPlugin.Components.MEPComponents
                 "Rotation vector of each element (input only 1 to use the same rotation for all). Optional.");
 
             SetOptionality(new[] { 2, 3, 4 });
+        }
+
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "ElementGuids",
+                "Identifier of each created MEP element.");
+
+            OutErrorMessages(
+                "Error message of each MEP element (empty when it was created successfully).");
         }
 
         protected override void Solve(
@@ -136,11 +147,13 @@ namespace TapirGrasshopperPlugin.Components.MEPComponents
 
             var parameters = new JObject { ["elementsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithCreatedIds<ElementGuid>(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da,
+                "elements",
+                "elementId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/MEPComponents/CreateMEPRoutingElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/MEPComponents/CreateMEPRoutingElementsComponent.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using TapirGrasshopperPlugin.Helps;
 using TapirGrasshopperPlugin.Types.Attributes;
+using TapirGrasshopperPlugin.Types.Element;
 using TapirGrasshopperPlugin.Types.GuidObjects;
 
 namespace TapirGrasshopperPlugin.Components.MEPComponents
@@ -53,6 +54,16 @@ namespace TapirGrasshopperPlugin.Components.MEPComponents
                 "MEP system attribute of each route (input only 1 to use the same system for all). Optional.");
 
             SetOptionality(new[] { 2, 3, 4, 5 });
+        }
+
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "ElementGuids",
+                "Identifier of each created routing element.");
+
+            OutErrorMessages(
+                "Error message of each routing element (empty when it was created successfully).");
         }
 
         protected override void Solve(
@@ -175,11 +186,13 @@ namespace TapirGrasshopperPlugin.Components.MEPComponents
 
             var parameters = new JObject { ["routingElementsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithCreatedIds<ElementGuid>(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da,
+                "elements",
+                "elementId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/MEPComponents/ModifyMEPRoutingElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/MEPComponents/ModifyMEPRoutingElementsComponent.cs
@@ -57,6 +57,12 @@ namespace TapirGrasshopperPlugin.Components.MEPComponents
             SetOptionality(new[] { 1, 2, 3, 4, 5 });
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each routing element (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -163,11 +169,11 @@ namespace TapirGrasshopperPlugin.Components.MEPComponents
 
             var parameters = new JObject { ["routingElementsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ModifyElementsComponentBase.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ModifyElementsComponentBase.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using TapirGrasshopperPlugin.Helps;
 using TapirGrasshopperPlugin.Types.Attributes;
 using TapirGrasshopperPlugin.Types.Element;
+using TapirGrasshopperPlugin.Types.Generic;
 using TapirGrasshopperPlugin.Types.GuidObjects;
 
 namespace TapirGrasshopperPlugin.Components
@@ -138,6 +139,13 @@ namespace TapirGrasshopperPlugin.Components
                 "One JSON object per element with further optional settings matching the " +
                 "command's documented item schema. Input only 1 to use the same settings for all. Optional.");
             SetOptionality(index);
+        }
+
+        protected override void AddOutputs()
+        {
+            OutTexts(
+                "ErrorMessages",
+                "Error message of each element (empty when it was modified successfully).");
         }
 
         private bool TryApply<T>(
@@ -290,11 +298,18 @@ namespace TapirGrasshopperPlugin.Components
 
             var parameters = new JObject { [ArrayKey] = items };
 
-            TryGetCadResponse(
-                CommandName,
-                parameters,
-                ToAddOn,
-                out _);
+            if (!TryGetCadResponse(
+                    CommandName,
+                    parameters,
+                    ToAddOn,
+                    out JObject response))
+            {
+                return;
+            }
+
+            da.SetDataList(
+                0,
+                ExecutionResultsResponse.ErrorMessages(response));
         }
     }
 }

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CloneProjectMapItemToViewMapComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CloneProjectMapItemToViewMapComponent.cs
@@ -33,6 +33,16 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
             SetOptionality(1);
         }
 
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "NavigatorItemGuids",
+                "Identifier of each created item.");
+
+            OutErrorMessages(
+                "Error message of each item (empty when it was created successfully).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -79,10 +89,13 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithCreatedIds<NavigatorGuid>(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da,
+                "navigatorItems",
+                "navigatorItemId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateDetailsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateDetailsComponent.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using TapirGrasshopperPlugin.Helps;
+using TapirGrasshopperPlugin.Types.Navigator;
 
 namespace TapirGrasshopperPlugin.Components.NavigatorComponents
 {
@@ -27,6 +28,16 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
             InTexts(
                 "ReferenceIds",
                 "Reference ids of the details to create.");
+        }
+
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "DatabaseGuids",
+                "Identifier of each created detail.");
+
+            OutErrorMessages(
+                "Error message of each detail (empty when it was created successfully).");
         }
 
         protected override void Solve(
@@ -66,11 +77,13 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
 
             var parameters = new JObject { ["detailsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithCreatedIds<DatabaseGuidObject>(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da,
+                "databases",
+                "databaseId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateDrawingsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateDrawingsComponent.cs
@@ -6,6 +6,7 @@ using Rhino.Geometry;
 using System;
 using System.Collections.Generic;
 using TapirGrasshopperPlugin.Helps;
+using TapirGrasshopperPlugin.Types.Element;
 using TapirGrasshopperPlugin.Types.GuidObjects;
 using TapirGrasshopperPlugin.Types.Navigator;
 
@@ -50,6 +51,16 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
                 "Clip polygon points for each drawing (one branch per drawing, at least 3 points; empty branch = no clipping). Optional.");
 
             SetOptionality(new[] { 3, 4, 5 });
+        }
+
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "ElementGuids",
+                "Identifier of each created drawing.");
+
+            OutErrorMessages(
+                "Error message of each drawing (empty when it was created successfully).");
         }
 
         protected override void Solve(
@@ -192,11 +203,13 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
 
             var parameters = new JObject { ["drawingsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithCreatedIds<ElementGuid>(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da,
+                "elements",
+                "elementId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateLayoutComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateLayoutComponent.cs
@@ -49,6 +49,16 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
             SetOptionality(new[] { 1, 2, 3, 4 });
         }
 
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "DatabaseGuids",
+                "Identifier of each created layout.");
+
+            OutErrorMessages(
+                "Error message of each layout (empty when it was created successfully).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -144,11 +154,13 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
 
             var parameters = new JObject { ["layoutsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithCreatedIds<DatabaseGuidObject>(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da,
+                "databases",
+                "databaseId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateSectionsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateSectionsComponent.cs
@@ -4,6 +4,7 @@ using Rhino.Geometry;
 using System;
 using System.Collections.Generic;
 using TapirGrasshopperPlugin.Helps;
+using TapirGrasshopperPlugin.Types.Element;
 
 namespace TapirGrasshopperPlugin.Components.NavigatorComponents
 {
@@ -42,6 +43,16 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
                 "Floor index of each section (input only 1 to use the same floor for all). Optional.");
 
             SetOptionality(new[] { 2, 3, 4 });
+        }
+
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "ElementGuids",
+                "Identifier of each created section.");
+
+            OutErrorMessages(
+                "Error message of each section (empty when it was created successfully).");
         }
 
         protected override void Solve(
@@ -128,11 +139,13 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
 
             var parameters = new JObject { ["sectionsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithCreatedIds<ElementGuid>(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da,
+                "elements",
+                "elementId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateViewsInViewMapComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateViewsInViewMapComponent.cs
@@ -38,6 +38,16 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
             SetOptionality(new[] { 1, 2 });
         }
 
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "NavigatorItemGuids",
+                "Identifier of each created view.");
+
+            OutErrorMessages(
+                "Error message of each view (empty when it was created successfully).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -106,11 +116,13 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
 
             var parameters = new JObject { ["viewsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithCreatedIds<NavigatorGuid>(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da,
+                "navigatorItems",
+                "navigatorItemId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateWorksheetsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/CreateWorksheetsComponent.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using TapirGrasshopperPlugin.Helps;
+using TapirGrasshopperPlugin.Types.Navigator;
 
 namespace TapirGrasshopperPlugin.Components.NavigatorComponents
 {
@@ -27,6 +28,16 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
             InTexts(
                 "ReferenceIds",
                 "Reference ids of the worksheets to create.");
+        }
+
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "DatabaseGuids",
+                "Identifier of each created worksheet.");
+
+            OutErrorMessages(
+                "Error message of each worksheet (empty when it was created successfully).");
         }
 
         protected override void Solve(
@@ -66,11 +77,13 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
 
             var parameters = new JObject { ["worksheetsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithCreatedIds<DatabaseGuidObject>(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da,
+                "databases",
+                "databaseId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/DeleteNavigatorItemsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/DeleteNavigatorItemsComponent.cs
@@ -24,6 +24,12 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
                 "Identifier of navigator items to delete.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each navigator item (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -34,10 +40,11 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
                 return;
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToArchicad);
+                ToArchicad,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/SetLayoutSettingsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/SetLayoutSettingsComponent.cs
@@ -28,6 +28,12 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
                 "One JSON object per layout with the settings to change (see component description).");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each layout (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -55,11 +61,11 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
 
             var parameters = new JObject { ["layoutsData"] = items };
 
-            TryGetCadResponse(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 parameters,
                 ToAddOn,
-                out _);
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/SetViewRotationComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/NavigatorComponents/SetViewRotationComponent.cs
@@ -31,6 +31,12 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
                 "View rotation angles in radians (parallel to NavigatorItemGuids).");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each element (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -77,10 +83,11 @@ namespace TapirGrasshopperPlugin.Components.NavigatorComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ProjectComponents/CreateProjectInfoFieldsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ProjectComponents/CreateProjectInfoFieldsComponent.cs
@@ -31,6 +31,21 @@ namespace TapirGrasshopperPlugin.Components.ProjectComponents
             SetOptionality(1);
         }
 
+        protected override void AddOutputs()
+        {
+            OutTexts(
+                "Ids",
+                "Id of each project info field of the project after the creation.");
+
+            OutTexts(
+                "Names",
+                "Display name of each project info field.");
+
+            OutTexts(
+                "Values",
+                "Value of each project info field.");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -79,10 +94,34 @@ namespace TapirGrasshopperPlugin.Components.ProjectComponents
                     });
             }
 
-            SetCadValues(
-                CommandName,
-                input,
-                ToAddOn);
+            if (!TryGetCadResponse(
+                    CommandName,
+                    Newtonsoft.Json.Linq.JObject.FromObject(input),
+                    ToAddOn,
+                    out var response))
+            {
+                return;
+            }
+
+            // The command answers with every project info field of the project,
+            // including the ids Archicad generated for the new ones.
+            var ids = new List<string>();
+            var fieldNames = new List<string>();
+            var fieldValues = new List<string>();
+
+            if (response["fields"] is Newtonsoft.Json.Linq.JArray fields)
+            {
+                foreach (var field in fields)
+                {
+                    ids.Add(field["projectInfoId"]?.ToString() ?? "");
+                    fieldNames.Add(field["projectInfoName"]?.ToString() ?? "");
+                    fieldValues.Add(field["projectInfoValue"]?.ToString() ?? "");
+                }
+            }
+
+            da.SetDataList(0, ids);
+            da.SetDataList(1, fieldNames);
+            da.SetDataList(2, fieldValues);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ProjectComponents/DeleteProjectInfoFieldsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ProjectComponents/DeleteProjectInfoFieldsComponent.cs
@@ -25,6 +25,12 @@ namespace TapirGrasshopperPlugin.Components.ProjectComponents
                 "Ids of the custom project info fields to delete (ids starting with 'autotext-').");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each project info field (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -40,10 +46,11 @@ namespace TapirGrasshopperPlugin.Components.ProjectComponents
                 ProjectInfoIds = ids
             };
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/CreatePropertyGroupsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/CreatePropertyGroupsComponent.cs
@@ -31,6 +31,16 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
             SetOptionality(1);
         }
 
+        protected override void AddOutputs()
+        {
+            OutGenerics(
+                "PropertyGroupGuids",
+                "Identifier of each created property group.");
+
+            OutErrorMessages(
+                "Error message of each property group (empty when it was created successfully).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -82,10 +92,13 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithCreatedIds<PropertyGroupGuidObject>(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da,
+                "propertyGroupIds",
+                "propertyGroupId");
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/DeletePropertyDefinitionsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/DeletePropertyDefinitionsComponent.cs
@@ -27,6 +27,12 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
                 "Identifiers of the property definitions to delete.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each property definition (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -55,10 +61,11 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
                     new PropertyGuidWrapper { PropertyId = id });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/DeletePropertyGroupsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/DeletePropertyGroupsComponent.cs
@@ -27,6 +27,12 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
                 "Identifiers of the property groups to delete.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each property group (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -55,10 +61,11 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
                     new PropertyGroupGuidWrapper { PropertyGroupId = id });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/SetPropertyValuesOfAttributesComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/SetPropertyValuesOfAttributesComponent.cs
@@ -36,6 +36,12 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
                 "The new property values (input only 1 to use the same value for all attributes).");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each property value (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -113,10 +119,11 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/SetPropertyValuesOfElementsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/SetPropertyValuesOfElementsComponent.cs
@@ -35,6 +35,12 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
                 "Single value or list of values to set for the corresponding elements.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each property value (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -88,10 +94,11 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
                 input.ElementPropertyValues.Add(elemPropertyValue);
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/UpdatePropertyDefinitionsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/PropertiesComponents/UpdatePropertyDefinitionsComponent.cs
@@ -35,6 +35,12 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
                 GH_ParamAccess.tree);
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each property definition (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -91,10 +97,11 @@ namespace TapirGrasshopperPlugin.Components.PropertiesComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/CreateSolidElementLinksComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/CreateSolidElementLinksComponent.cs
@@ -36,6 +36,12 @@ namespace TapirGrasshopperPlugin.Components.SolidOperationComponents
                 "The solid operation type: Subtraction, SubtractionUpwards, SubtractionDownwards, Intersection or Addition.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each operation (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -91,10 +97,11 @@ namespace TapirGrasshopperPlugin.Components.SolidOperationComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/RemoveSolidElementLinksComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/SolidOperationComponents/RemoveSolidElementLinksComponent.cs
@@ -32,6 +32,12 @@ namespace TapirGrasshopperPlugin.Components.SolidOperationComponents
                 "Identifiers of the operator elements.");
         }
 
+        protected override void AddOutputs()
+        {
+            OutErrorMessages(
+                "Error message of each operation (empty when it succeeded).");
+        }
+
         protected override void Solve(
             IGH_DataAccess da)
         {
@@ -77,10 +83,11 @@ namespace TapirGrasshopperPlugin.Components.SolidOperationComponents
                     });
             }
 
-            SetCadValues(
+            SetCadValuesWithErrorMessages(
                 CommandName,
                 input,
-                ToAddOn);
+                ToAddOn,
+                da);
         }
 
         protected override System.Drawing.Bitmap Icon =>

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Types/Element/ElementData.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Types/Element/ElementData.cs
@@ -100,6 +100,17 @@ namespace TapirGrasshopperPlugin.Types.Element
 
         [JsonProperty("details")]
         public JObject Details;
+
+        // The cut-fill polygons as drawn on the floor plan (wall joins resolved
+        // by Archicad). Absent for elements without a cut fill.
+        [JsonProperty("floorPlanPolygons")]
+        public List<FloorPlanPolygon> FloorPlanPolygons;
+    }
+
+    public class FloorPlanPolygon
+    {
+        [JsonProperty("coordinates")]
+        public List<Point2D> Coordinates;
     }
 
     public class DetailsOfElementsObj

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Types/Generic/ExecutionResult.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Types/Generic/ExecutionResult.cs
@@ -43,6 +43,34 @@ namespace TapirGrasshopperPlugin.Types.Generic
 
             return response;
         }
+
+        // Maps the per-item executionResults of a response to one message per
+        // item: empty for the items that succeeded, the error message for the
+        // failed ones. The commands report the failure of a single item this
+        // way instead of failing the whole call, so a component that ignores
+        // this array swallows the failures silently.
+        public static List<string> ErrorMessages(
+            JObject response,
+            string arrayKey = "executionResults")
+        {
+            var messages = new List<string>();
+
+            if (!(response?[arrayKey] is JArray results))
+            {
+                return messages;
+            }
+
+            foreach (var result in results)
+            {
+                messages.Add(
+                    (bool?)result["success"] == true
+                        ? ""
+                        : result["error"]?["message"]?.ToString() ??
+                          "Unknown error.");
+            }
+
+            return messages;
+        }
     }
 
     public class ExecutionResultResponse


### PR DESCRIPTION
Follow-up of the command ↔ component synchronization check. The inputs turned
out to be in sync everywhere and no command is missing its component, but a
large group of components threw the response away.

## What was lost

| Components | Lost from the response |
| --- | --- |
| the 11 `Modify*` element components | `executionResults` — a failed element looked exactly like a successful one |
| the 9 attribute creators, `SetLayers`, `SetLayerCombinations` | `attributeIds` — the ids the element components need for `buildingMaterialId` / `compositeId` / `profileId` / `fillId`, so the created attributes were unusable |
| `CreateGroups`, `CreatePropertyGroups`, `CreateDesignOptions`, `CreateDesignOptionCombinations`, `CreateKeynoteFolders`, `CreateKeynoteItems`, `CreateKeynoteLabels`, `CreateSections`, `CreateDetails`, `CreateLayout`, `CreateWorksheets`, `CreateDrawings`, `CreateViewsInViewMap`, `CloneProjectMapItemToViewMap`, `CreateMEPElements`, `CreateMEPRoutingElements`, `CreateProjectInfoFields` | the identifiers of everything they created |
| `ConnectMEPElements` | the deleted / split / created branch element ids |
| `ImportFavorites` | `firstConflictName` |
| `ChangeSelection` | both execution result lists |
| `SetSuspendGroupsMode` | its `executionResult` (now reported as a component error) |
| 31 further components | `executionResults` |
| `GetDetailsOfElements` | `floorPlanPolygons` |

## How

Each of them now has the matching output. The shared bases fix a whole family
at once (`ModifyElementsComponentBase` → 11 components,
`AttributeCreateJsonComponent` → 9), and the repeating mapping lives in
`Component.SetCadValuesWithErrorMessages` / `SetCadValuesWithCreatedIds` and
`ExecutionResultsResponse.ErrorMessages`, so a component that reports per-item
results is a two-line change from here on.

A failed item yields an empty identifier at its own index and the message in
`ErrorMessages` at the same index, so the outputs stay aligned with the inputs.

## Schemas

The audit also caught the response schemas lying about the same thing: the
attribute, element, drawing and database creators report a per-item failure as
an error item, but their schemas declared the strict identifier item only
(`additionalProperties: false`), so a partially failed response did not match
its own schema. They now use the `*OrErrors` unions —
`AttributeIdsOrErrors` and `DatabaseIdsOrErrors` are new in the shared
definitions, `ElementIdsOrErrors` already existed. The generated docs are
regenerated accordingly.

## Verification

- `cmake --build Build/AC29 --config RelWithDebInfo` → clean.
- `dotnet build TapirGrasshopperPlugin.sln` → 0 warnings, 0 errors.
- `CommonSchemaDefinitions.json` passes the strict duplicate-key check and every
  `$ref` resolves.
- Not verified live: the new outputs need a running Archicad to confirm the
  values, in particular the `floorPlanPolygons` curves and the MEP connection
  results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### ✅ Live verification — passed

Archicad 29, add-on built from `8554be4`, untitled project from the default template. `floorPlanPolygons` returns the wall footprint; the attribute creators return `attributeIds` and a per-item `"Already exists."` error; `Modify*` returns per-element `executionResults`; and `ConnectMEPElements` reports all three result shapes — `deletedRoutingElementId` on a merge, `splitRoutingElementId` + `createdBranchId` on a branch, and a per-connection error otherwise.
