### PR TITLE
Report the navigator item's ID and its custom ID/name flags

### DIFF
--- a/archicad-addon/Examples/get_navigator_item_tree.py
+++ b/archicad-addon/Examples/get_navigator_item_tree.py
@@ -1,0 +1,36 @@
+import aclib
+
+# Tapir's own GetNavigatorItemTree takes a map id and reports the ID shown on
+# the navigator next to the name, plus the flags behind the View Settings
+# "Custom" / "By Project Map" radio buttons.
+navigatorItemTree = aclib.RunTapirCommand ('GetNavigatorItemTree', {
+    'navigatorMapId': 'PublicViewMap'
+})['navigatorItemTree']
+
+def CollectItems (item, collectedItems):
+    for child in item.get ('children', []):
+        navigatorItem = child['navigatorItem']
+        collectedItems.append (navigatorItem)
+        CollectItems (navigatorItem, collectedItems)
+    return collectedItems
+
+views = [
+    item for item in CollectItems (navigatorItemTree, [])
+    if item['type'] != 'FolderItem'
+]
+
+# The views whose ID or name was hand-written instead of following the Project
+# Map source. Comparing the strings to the source's cannot tell these apart: a
+# custom value typed identical to the source's looks inherited.
+overridden = [
+    view for view in views if view['customUiId'] or view['customName']
+]
+
+print ('{} of {} views have a custom ID or name:'.format (len (overridden), len (views)))
+for view in overridden:
+    print ('  {} {} (custom ID: {}, custom name: {}, independent: {})'.format (
+        view['uiId'],
+        view['name'],
+        view['customUiId'],
+        view['customName'],
+        view['isIndependent']))

--- a/archicad-addon/Examples/get_section_elements.py
+++ b/archicad-addon/Examples/get_section_elements.py
@@ -1,7 +1,7 @@
 import aclib
 
 # Pick the first section from the Project Map and resolve its database.
-navigatorTree = aclib.RunTapirCommand ('GetNavigatorItemTree', {
+navigatorTree = aclib.RunCommand ('API.GetNavigatorItemTree', {
     'navigatorTreeId': { 'type': 'ProjectMap' }
 })
 

--- a/archicad-addon/Sources/NavigatorCommands.cpp
+++ b/archicad-addon/Sources/NavigatorCommands.cpp
@@ -1491,6 +1491,16 @@ static GS::ObjectState NavigatorItemToObjectState (API_NavigatorItem item, API_N
     }
     itemOS.Add ("prefix", prefix);
 
+    // The ID shown next to the name on the navigator, and the two flags telling
+    // whether the item's ID and name are hand-written or inherited from the
+    // Project Map source - the View Settings "Custom" vs "By Project Map"
+    // radio buttons. Only the flags can tell the two apart: a custom ID typed
+    // identical to the source's is indistinguishable by comparing the strings.
+    itemOS.Add ("uiId",          GS::UniString (item.uiId));
+    itemOS.Add ("customUiId",    item.customUiId);
+    itemOS.Add ("customName",    item.customName);
+    itemOS.Add ("isIndependent", item.isIndependent);
+
     item.mapId = mapId;
     GS::Array<API_NavigatorItem> children;
     if (ACAPI_Navigator_GetNavigatorChildrenItems (&item, &children) == NoError && !children.IsEmpty ()) {


### PR DESCRIPTION
Fixes #538.

`NavigatorItemToObjectState` received the populated `API_NavigatorItem` but
serialised only `type`, `name`, `navigatorItemId` and a `prefix` that is filled
for stories only. `uiId`, `customUiId`, `customName` and `isIndependent` never
left the add-on — `customName` was even write-only, since
`CloneProjectMapItemToViewMap`, `CreateViewMapFolder` and `RenameNavigatorItem`
all set it and nothing read it back.

All four are now in every navigator item of the response:

```json
{
  "type": "ViewItem",
  "name": "Ground Floor Plan",
  "navigatorItemId": { "guid": "..." },
  "prefix": "",
  "uiId": "A-101",
  "customUiId": true,
  "customName": false,
  "isIndependent": false
}
```

As the issue explains, the two flags are the only exact answer to "is this
view's ID/name Custom or By Project Map?" — the View Settings radio buttons.
Comparing the view's strings to its Project Map source cannot distinguish
them, because a custom value typed identical to the source's reads as
inherited, so a naming-standard audit systematically under-reports the
overrides.

## Version gating

None needed: `uiId[128]`, `customUiId`, `customName` and `isIndependent` are
present with the same names and types in the AC25, AC26, AC27, AC28 and AC29
DevKit headers (checked in `APIdefs_Navigator.h` of each).

## Drive-by fix

`get_section_elements.py` (added in #535) called Tapir's `GetNavigatorItemTree`
through `aclib.RunTapirCommand` but passed the *official* command's parameters
(`navigatorTreeId`) and read the official command's response shape
(`navigatorTree.rootItem`). Tapir's command takes `navigatorMapId` and answers
with `navigatorItemTree`, so that example could never have run — the call would
have been rejected on the input schema. It now uses
`aclib.RunCommand('API.GetNavigatorItemTree', …)` like every other example that
walks a navigator tree. My mistake in #535.

## Not included

The Tapir `GetNavigatorItemTree` still has no response schema (it never
overrode `GetRawResponseSchema`), so the new fields are undocumented in the
command reference. Writing one means a self-referential `$ref` for the
`children` recursion; that is a separate change I would rather not fold into a
field addition, especially with #537 open.

The Grasshopper `NavigatorTree` component is unaffected: it calls the
*official* `API.GetNavigatorItemTree`, not Tapir's, so exposing these fields
there would mean switching it to the Tapir command and changing its inputs.

## Verification

- `cmake --build Build/AC29 --config RelWithDebInfo` → clean.
- Not verified live: the field values need a running Archicad with a View Map
  that has hand-overridden IDs. @pgalliford offered to test a build — the
  new `Examples/get_navigator_item_tree.py` prints exactly that audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### ✅ Live verification — passed

Archicad 29, add-on built from `8554be4`, untitled project from the default template. All 30 View Map items carry `uiId`, `customUiId`, `customName` and `isIndependent`, and the values vary — "Site" reads custom/custom while the plain stories read inherited with `uiId` "1.", "2.".
