### PR TITLE
Revert the anyOf response schema wrapper

### DIFF
--- a/archicad-addon/Sources/3DCutPlaneCommands.cpp
+++ b/archicad-addon/Sources/3DCutPlaneCommands.cpp
@@ -99,7 +99,7 @@ GS::Optional<GS::UniString> Set3DCutPlanesCommand::GetInputParametersSchema () c
 }
 
 
-GS::Optional<GS::UniString> Set3DCutPlanesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> Set3DCutPlanesCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"

--- a/archicad-addon/Sources/3DCutPlaneCommands.hpp
+++ b/archicad-addon/Sources/3DCutPlaneCommands.hpp
@@ -8,6 +8,6 @@ public:
     Set3DCutPlanesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -52,7 +52,7 @@ GSErrCode RegisterCommand (CommandGroup& group, const GS::UniString& version, co
         description,
         version,
         command->GetInputParametersSchema (),
-        command->GetRawResponseSchema ())
+        command->GetResponseSchema ())
     );
 
     GSErrCode err = ACAPI_AddOnAddOnCommunication_InstallAddOnCommandHandler (command.Pass ());

--- a/archicad-addon/Sources/ApplicationCommands.cpp
+++ b/archicad-addon/Sources/ApplicationCommands.cpp
@@ -63,7 +63,7 @@ GS::String GetAddOnVersionCommand::GetName () const
     return "GetAddOnVersion";
 }
 
-GS::Optional<GS::UniString> GetAddOnVersionCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetAddOnVersionCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -96,7 +96,7 @@ GS::String GetArchicadLocationCommand::GetName () const
     return "GetArchicadLocation";
 }
 
-GS::Optional<GS::UniString> GetArchicadLocationCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetArchicadLocationCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -134,7 +134,7 @@ GS::String QuitArchicadCommand::GetName () const
     return "QuitArchicad";
 }
 
-GS::Optional<GS::UniString> QuitArchicadCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> QuitArchicadCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -166,7 +166,7 @@ GS::String GetCurrentWindowTypeCommand::GetName () const
     return "GetCurrentWindowType";
 }
 
-GS::Optional<GS::UniString> GetCurrentWindowTypeCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetCurrentWindowTypeCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -301,7 +301,7 @@ GS::Optional<GS::UniString> ChangeWindowCommand::GetInputParametersSchema () con
     })";
 }
 
-GS::Optional<GS::UniString> ChangeWindowCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ChangeWindowCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -459,7 +459,7 @@ GS::Optional<GS::UniString> ShowAlertCommand::GetInputParametersSchema () const
     })";
 }
 
-GS::Optional<GS::UniString> ShowAlertCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ShowAlertCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -529,7 +529,7 @@ GS::Optional<GS::UniString> GetSpecialFoldersCommand::GetInputParametersSchema (
     })";
 }
 
-GS::Optional<GS::UniString> GetSpecialFoldersCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetSpecialFoldersCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -649,7 +649,7 @@ GS::String GetUserGSIDCommand::GetName () const
     return "GetUserGSID";
 }
 
-GS::Optional<GS::UniString> GetUserGSIDCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetUserGSIDCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/ApplicationCommands.hpp
+++ b/archicad-addon/Sources/ApplicationCommands.hpp
@@ -7,7 +7,7 @@ class GetAddOnVersionCommand : public CommandBase
 public:
     GetAddOnVersionCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -16,7 +16,7 @@ class GetArchicadLocationCommand : public CommandBase
 public:
     GetArchicadLocationCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -25,7 +25,7 @@ class QuitArchicadCommand : public CommandBase
 public:
     QuitArchicadCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -34,7 +34,7 @@ class GetCurrentWindowTypeCommand : public CommandBase
 public:
     GetCurrentWindowTypeCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -44,7 +44,7 @@ public:
     ChangeWindowCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -54,7 +54,7 @@ public:
     ShowAlertCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -64,7 +64,7 @@ public:
     GetSpecialFoldersCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -73,6 +73,6 @@ class GetUserGSIDCommand : public CommandBase
 public:
     GetUserGSIDCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/AttributeCommands.cpp
+++ b/archicad-addon/Sources/AttributeCommands.cpp
@@ -129,7 +129,7 @@ GS::Optional<GS::UniString> GetAttributesByTypeCommand::GetInputParametersSchema
     })";
 }
 
-GS::Optional<GS::UniString> GetAttributesByTypeCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetAttributesByTypeCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/AttributeHeadersOrError"
@@ -192,7 +192,7 @@ GS::Optional<GS::UniString> GetBuildingMaterialPhysicalPropertiesCommand::GetInp
     })";
 }
 
-GS::Optional<GS::UniString> GetBuildingMaterialPhysicalPropertiesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetBuildingMaterialPhysicalPropertiesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -273,7 +273,7 @@ GS::Optional<GS::UniString> GetLayerCombinationsCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> GetLayerCombinationsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetLayerCombinationsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -405,7 +405,7 @@ GS::Optional<GS::UniString> GetLinesCommand::GetInputParametersSchema () const
     })";
 }
 
-GS::Optional<GS::UniString> GetLinesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetLinesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -574,7 +574,7 @@ GS::Optional<GS::UniString> GetFillsCommand::GetInputParametersSchema () const
     })";
 }
 
-GS::Optional<GS::UniString> GetFillsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetFillsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -764,7 +764,7 @@ GS::Optional<GS::UniString> GetZoneCategoriesCommand::GetInputParametersSchema (
     })";
 }
 
-GS::Optional<GS::UniString> GetZoneCategoriesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetZoneCategoriesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -866,7 +866,7 @@ GS::Optional<GS::UniString> GetMEPSystemsCommand::GetInputParametersSchema () co
     })";
 }
 
-GS::Optional<GS::UniString> GetMEPSystemsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetMEPSystemsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -997,7 +997,7 @@ GS::Optional<GS::UniString> GetPenTablesCommand::GetInputParametersSchema () con
     })";
 }
 
-GS::Optional<GS::UniString> GetPenTablesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetPenTablesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1159,7 +1159,7 @@ GS::Optional<GS::UniString> GetProfilesCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> GetProfilesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetProfilesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -2004,7 +2004,7 @@ GS::Optional<GS::UniString> GetCompositesCommand::GetInputParametersSchema () co
     })";
 }
 
-GS::Optional<GS::UniString> GetCompositesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetCompositesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -2166,7 +2166,7 @@ GS::Optional<GS::UniString> GetSurfacesCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> GetSurfacesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetSurfacesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -2313,7 +2313,7 @@ GS::Optional<GS::UniString> GetLayersCommand::GetInputParametersSchema () const
     })";
 }
 
-GS::Optional<GS::UniString> GetLayersCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetLayersCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -2421,7 +2421,7 @@ GS::Optional<GS::UniString> GetBuildingMaterialsCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> GetBuildingMaterialsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetBuildingMaterialsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -2576,7 +2576,7 @@ GS::Optional<GS::UniString> DeleteAttributesCommand::GetInputParametersSchema ()
     })";
 }
 
-GS::Optional<GS::UniString> DeleteAttributesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DeleteAttributesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -2650,7 +2650,7 @@ GS::String CreateAttributesCommandBase::GetName () const
     return commandName;
 }
 
-GS::Optional<GS::UniString> CreateAttributesCommandBase::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateAttributesCommandBase::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -3614,7 +3614,7 @@ GS::Optional<GS::UniString> CreateFillsCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> CreateFillsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateFillsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -4472,7 +4472,7 @@ GS::Optional<GS::UniString> CreatePenTablesCommand::GetInputParametersSchema () 
     })";
 }
 
-GS::Optional<GS::UniString> CreatePenTablesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreatePenTablesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -4994,7 +4994,7 @@ GS::Optional<GS::UniString> CreateProfilesCommand::GetInputParametersSchema () c
     })";
 }
 
-GS::Optional<GS::UniString> CreateProfilesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateProfilesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -5318,7 +5318,7 @@ GS::Optional<GS::UniString> CreateCompositesCommand::GetInputParametersSchema ()
     })SCHEMA";
 }
 
-GS::Optional<GS::UniString> CreateCompositesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateCompositesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/AttributeCommands.hpp
+++ b/archicad-addon/Sources/AttributeCommands.hpp
@@ -8,7 +8,7 @@ public:
     GetAttributesByTypeCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -18,7 +18,7 @@ public:
     GetBuildingMaterialPhysicalPropertiesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -28,7 +28,7 @@ public:
     GetLayerCombinationsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -38,7 +38,7 @@ public:
     GetLinesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -48,7 +48,7 @@ public:
     GetFillsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -58,7 +58,7 @@ public:
     GetZoneCategoriesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -68,7 +68,7 @@ public:
     GetMEPSystemsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -80,7 +80,7 @@ public:
     GetPenTablesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -90,7 +90,7 @@ public:
     GetProfilesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -100,7 +100,7 @@ public:
     GetCompositesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -110,7 +110,7 @@ public:
     GetSurfacesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -120,7 +120,7 @@ public:
     GetLayersCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -130,7 +130,7 @@ public:
     GetBuildingMaterialsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -140,7 +140,7 @@ public:
     DeleteAttributesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -149,7 +149,7 @@ class CreateAttributesCommandBase : public CommandBase
 public:
     CreateAttributesCommandBase (const GS::String& commandName, API_AttrTypeID attrTypeID, const GS::String& arrayFieldName);
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 protected:
     virtual void SetTypeSpecificParameters (const GS::ObjectState& parameters, API_Attribute& attribute, API_AttributeDef& attributeDef) const = 0;
@@ -197,7 +197,7 @@ public:
     CreateFillsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -234,7 +234,7 @@ public:
     CreatePenTablesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -244,7 +244,7 @@ public:
     CreateProfilesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -254,6 +254,6 @@ public:
     CreateCompositesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/ClassificationCommands.cpp
+++ b/archicad-addon/Sources/ClassificationCommands.cpp
@@ -35,7 +35,7 @@ GS::Optional<GS::UniString> GetClassificationsOfElementsCommand::GetInputParamet
     })";
 }
 
-GS::Optional<GS::UniString> GetClassificationsOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetClassificationsOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -129,7 +129,7 @@ GS::Optional<GS::UniString> SetClassificationsOfElementsCommand::GetInputParamet
     })";
 }
 
-GS::Optional<GS::UniString> SetClassificationsOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> SetClassificationsOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -236,7 +236,7 @@ GS::Optional<GS::UniString> CreateClassificationSystemsCommand::GetInputParamete
     })";
 }
 
-GS::Optional<GS::UniString> CreateClassificationSystemsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateClassificationSystemsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -356,7 +356,7 @@ GS::Optional<GS::UniString> CreateClassificationItemsCommand::GetInputParameters
     })";
 }
 
-GS::Optional<GS::UniString> CreateClassificationItemsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateClassificationItemsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -451,7 +451,7 @@ GS::Optional<GS::UniString> DeleteClassificationSystemsCommand::GetInputParamete
     })";
 }
 
-GS::Optional<GS::UniString> DeleteClassificationSystemsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DeleteClassificationSystemsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -526,7 +526,7 @@ GS::Optional<GS::UniString> DeleteClassificationItemsCommand::GetInputParameters
     })";
 }
 
-GS::Optional<GS::UniString> DeleteClassificationItemsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DeleteClassificationItemsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/ClassificationCommands.hpp
+++ b/archicad-addon/Sources/ClassificationCommands.hpp
@@ -8,7 +8,7 @@ public:
     GetClassificationsOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -18,7 +18,7 @@ public:
     SetClassificationsOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -28,7 +28,7 @@ public:
     CreateClassificationSystemsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -38,7 +38,7 @@ public:
     CreateClassificationItemsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -48,7 +48,7 @@ public:
     DeleteClassificationSystemsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -58,6 +58,6 @@ public:
     DeleteClassificationItemsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/CommandBase.cpp
+++ b/archicad-addon/Sources/CommandBase.cpp
@@ -47,42 +47,9 @@ GS::Optional<GS::UniString> CommandBase::GetInputParametersSchema () const
     return {};
 }
 
-GS::Optional<GS::UniString> CommandBase::GetRawResponseSchema () const
-{
-    return {};
-}
-
 GS::Optional<GS::UniString> CommandBase::GetResponseSchema () const
 {
-    const GS::Optional<GS::UniString> rawSchema = GetRawResponseSchema ();
-    if (!rawSchema.HasValue ()) {
-        return rawSchema;
-    }
-
-    // Failing commands return {"error": {code, message}} as the whole response,
-    // which the raw schemas (with "additionalProperties": false) forbid - Archicad
-    // would then discard the response with schema validation error 4009 and the
-    // actual error message would never reach the caller. The error alternative is
-    // inlined (not a #/ErrorItem reference) because commands constructed with
-    // CommonSchema::NotUsed provide no schema definitions to resolve it from.
-    // anyOf (not oneOf) on purpose: some raw schemas already allow an error object
-    // themselves, and a response matching two alternatives must stay valid.
-    return GS::UniString (R"({ "anyOf": [ )") + rawSchema.Get () + R"(, {
-        "type": "object",
-        "properties": {
-            "error": {
-                "type": "object",
-                "properties": {
-                    "code": { "type": "integer" },
-                    "message": { "type": "string" }
-                },
-                "additionalProperties": false,
-                "required": [ "code", "message" ]
-            }
-        },
-        "additionalProperties": false,
-        "required": [ "error" ]
-    } ] })";
+    return {};
 }
 
 GS::ObjectState CreateErrorResponse (GSErrCode errorCode, const GS::UniString& errorMessage)

--- a/archicad-addon/Sources/CommandBase.hpp
+++ b/archicad-addon/Sources/CommandBase.hpp
@@ -29,12 +29,7 @@ public:
 #endif
     virtual GS::Optional<GS::UniString> GetSchemaDefinitions () const override final;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    // The API-facing response schema: the command's raw schema extended with the
-    // error response alternative, so Archicad does not reject the add-on's own
-    // {"error": {...}} responses (schema validation error 4009). Commands override
-    // GetRawResponseSchema instead.
-    virtual GS::Optional<GS::UniString> GetResponseSchema () const override final;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
 
 private:
     CommonSchema mCommonSchema;

--- a/archicad-addon/Sources/DesignOptionCommands.cpp
+++ b/archicad-addon/Sources/DesignOptionCommands.cpp
@@ -28,7 +28,7 @@ GS::String GetDesignOptionsCommand::GetName () const
     return "GetDesignOptions";
 }
 
-GS::Optional<GS::UniString> GetDesignOptionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetDesignOptionsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -88,7 +88,7 @@ GS::String GetDesignOptionSetsCommand::GetName () const
     return "GetDesignOptionSets";
 }
 
-GS::Optional<GS::UniString> GetDesignOptionSetsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetDesignOptionSetsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -176,7 +176,7 @@ GS::String GetDesignOptionCombinationsCommand::GetName () const
     return "GetDesignOptionCombinations";
 }
 
-GS::Optional<GS::UniString> GetDesignOptionCombinationsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetDesignOptionCombinationsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -301,7 +301,7 @@ GS::Optional<GS::UniString> GetElementsOfDesignOptionsCommand::GetInputParameter
     })";
 }
 
-GS::Optional<GS::UniString> GetElementsOfDesignOptionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetElementsOfDesignOptionsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -403,7 +403,7 @@ GS::Optional<GS::UniString> GetDesignOptionForElementsCommand::GetInputParameter
     })";
 }
 
-GS::Optional<GS::UniString> GetDesignOptionForElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetDesignOptionForElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -535,7 +535,7 @@ GS::Optional<GS::UniString> CreateDesignOptionSetsCommand::GetInputParametersSch
     })";
 }
 
-GS::Optional<GS::UniString> CreateDesignOptionSetsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateDesignOptionSetsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -631,7 +631,7 @@ GS::Optional<GS::UniString> CreateDesignOptionsCommand::GetInputParametersSchema
     })";
 }
 
-GS::Optional<GS::UniString> CreateDesignOptionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateDesignOptionsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -756,7 +756,7 @@ GS::Optional<GS::UniString> CreateDesignOptionCombinationsCommand::GetInputParam
     })";
 }
 
-GS::Optional<GS::UniString> CreateDesignOptionCombinationsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateDesignOptionCombinationsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -890,7 +890,7 @@ GS::Optional<GS::UniString> SetActiveDesignOptionsInCombinationsCommand::GetInpu
     })";
 }
 
-GS::Optional<GS::UniString> SetActiveDesignOptionsInCombinationsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> SetActiveDesignOptionsInCombinationsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1033,7 +1033,7 @@ GS::Optional<GS::UniString> MoveElementsToDesignOptionsCommand::GetInputParamete
     })";
 }
 
-GS::Optional<GS::UniString> MoveElementsToDesignOptionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> MoveElementsToDesignOptionsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1147,7 +1147,7 @@ GS::Optional<GS::UniString> MoveDesignOptionsToAnotherSetCommand::GetInputParame
     })";
 }
 
-GS::Optional<GS::UniString> MoveDesignOptionsToAnotherSetCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> MoveDesignOptionsToAnotherSetCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/DesignOptionCommands.hpp
+++ b/archicad-addon/Sources/DesignOptionCommands.hpp
@@ -7,7 +7,7 @@ class GetDesignOptionsCommand : public CommandBase
 public:
     GetDesignOptionsCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -16,7 +16,7 @@ class GetDesignOptionSetsCommand : public CommandBase
 public:
     GetDesignOptionSetsCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -25,7 +25,7 @@ class GetDesignOptionCombinationsCommand : public CommandBase
 public:
     GetDesignOptionCombinationsCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -35,7 +35,7 @@ public:
     GetElementsOfDesignOptionsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -45,7 +45,7 @@ public:
     GetDesignOptionForElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -55,7 +55,7 @@ public:
     CreateDesignOptionSetsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -65,7 +65,7 @@ public:
     CreateDesignOptionsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -75,7 +75,7 @@ public:
     CreateDesignOptionCombinationsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -85,7 +85,7 @@ public:
     SetActiveDesignOptionsInCombinationsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -95,7 +95,7 @@ public:
     MoveElementsToDesignOptionsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -105,6 +105,6 @@ public:
     MoveDesignOptionsToAnotherSetCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/DeveloperTools.cpp
+++ b/archicad-addon/Sources/DeveloperTools.cpp
@@ -124,7 +124,7 @@ GS::Optional<GS::UniString> GenerateDocumentationCommand::GetInputParametersSche
     })";
 }
 
-GS::Optional<GS::UniString> GenerateDocumentationCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GenerateDocumentationCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"

--- a/archicad-addon/Sources/DeveloperTools.hpp
+++ b/archicad-addon/Sources/DeveloperTools.hpp
@@ -37,7 +37,7 @@ public:
 
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 

--- a/archicad-addon/Sources/DocumentCreationCommands.cpp
+++ b/archicad-addon/Sources/DocumentCreationCommands.cpp
@@ -149,7 +149,7 @@ GS::Optional<GS::UniString> CreateDetailsCommand::GetInputParametersSchema () co
     })";
 }
 
-GS::Optional<GS::UniString> CreateDetailsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateDetailsCommand::GetResponseSchema () const
 {
     return R"({"type":"object","properties":{"databases":{"$ref":"#/DatabaseIdsOrErrors"}},"additionalProperties":false,"required":["databases"]})";
 }
@@ -213,9 +213,9 @@ GS::Optional<GS::UniString> CreateWorksheetsCommand::GetInputParametersSchema ()
     })";
 }
 
-GS::Optional<GS::UniString> CreateWorksheetsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateWorksheetsCommand::GetResponseSchema () const
 {
-    return CreateDetailsCommand ().GetRawResponseSchema ();
+    return CreateDetailsCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState CreateWorksheetsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
@@ -295,9 +295,9 @@ GS::Optional<GS::UniString> CreateLayoutCommand::GetInputParametersSchema () con
     })";
 }
 
-GS::Optional<GS::UniString> CreateLayoutCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateLayoutCommand::GetResponseSchema () const
 {
-    return CreateDetailsCommand ().GetRawResponseSchema ();
+    return CreateDetailsCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState CreateLayoutCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
@@ -454,7 +454,7 @@ GS::Optional<GS::UniString> CreateLayoutSubsetCommand::GetInputParametersSchema 
     })";
 }
 
-GS::Optional<GS::UniString> CreateLayoutSubsetCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateLayoutSubsetCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -583,7 +583,7 @@ GS::Optional<GS::UniString> CreateDrawingsCommand::GetInputParametersSchema () c
     })";
 }
 
-GS::Optional<GS::UniString> CreateDrawingsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateDrawingsCommand::GetResponseSchema () const
 {
     return R"({"type":"object","properties":{"elements":{"$ref":"#/ElementIdsOrErrors"}},"additionalProperties":false,"required":["elements"]})";
 }
@@ -779,7 +779,7 @@ GS::Optional<GS::UniString> ChangeDrawingLinkCommand::GetInputParametersSchema (
     })";
 }
 
-GS::Optional<GS::UniString> ChangeDrawingLinkCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ChangeDrawingLinkCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -955,7 +955,7 @@ GS::Optional<GS::UniString> GetLayoutSettingsCommand::GetInputParametersSchema (
     })";
 }
 
-GS::Optional<GS::UniString> GetLayoutSettingsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetLayoutSettingsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1143,7 +1143,7 @@ GS::Optional<GS::UniString> SetLayoutSettingsCommand::GetInputParametersSchema (
     })";
 }
 
-GS::Optional<GS::UniString> SetLayoutSettingsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> SetLayoutSettingsCommand::GetResponseSchema () const
 {
     return R"({"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]})";
 }
@@ -1307,7 +1307,7 @@ GS::Optional<GS::UniString> GetLayoutCustomSchemeCommand::GetInputParametersSche
     return GS::NoValue;
 }
 
-GS::Optional<GS::UniString> GetLayoutCustomSchemeCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetLayoutCustomSchemeCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/DocumentCreationCommands.hpp
+++ b/archicad-addon/Sources/DocumentCreationCommands.hpp
@@ -8,7 +8,7 @@ public:
     CreateDetailsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -18,7 +18,7 @@ public:
     CreateWorksheetsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -28,7 +28,7 @@ public:
     CreateLayoutCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -38,7 +38,7 @@ public:
     CreateLayoutSubsetCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -48,7 +48,7 @@ public:
     CreateDrawingsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -58,7 +58,7 @@ public:
     ChangeDrawingLinkCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -68,7 +68,7 @@ public:
     GetLayoutSettingsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -78,7 +78,7 @@ public:
     SetLayoutSettingsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -88,6 +88,6 @@ public:
     GetLayoutCustomSchemeCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -271,7 +271,7 @@ GS::Optional<GS::UniString> GetSectionElementsCommand::GetInputParametersSchema 
     })";
 }
 
-GS::Optional<GS::UniString> GetSectionElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetSectionElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -384,7 +384,7 @@ GS::Optional<GS::UniString> GetElementsByTypeCommand::GetInputParametersSchema (
     })";
 }
 
-GS::Optional<GS::UniString> GetElementsByTypeCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetElementsByTypeCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ElementsWithExecutionResultsOrError"
@@ -485,7 +485,7 @@ GS::Optional<GS::UniString> GetDetailsOfElementsCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> GetDetailsOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetDetailsOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1423,7 +1423,7 @@ GS::Optional<GS::UniString> SetDetailsOfElementsCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> SetDetailsOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> SetDetailsOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -2173,7 +2173,7 @@ GS::String GetSelectedElementsCommand::GetName () const
     return "GetSelectedElements";
 }
 
-GS::Optional<GS::UniString> GetSelectedElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetSelectedElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -2240,7 +2240,7 @@ GS::Optional<GS::UniString> ChangeSelectionOfElementsCommand::GetInputParameters
     })";
 }
 
-GS::Optional<GS::UniString> ChangeSelectionOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ChangeSelectionOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -2330,7 +2330,7 @@ GS::Optional<GS::UniString> GetSubelementsOfHierarchicalElementsCommand::GetInpu
     })";
 }
 
-GS::Optional<GS::UniString> GetSubelementsOfHierarchicalElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetSubelementsOfHierarchicalElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -2551,7 +2551,7 @@ GS::Optional<GS::UniString> GetConnectedElementsCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> GetConnectedElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetConnectedElementsCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ConnectedElementsOrError"
@@ -2630,7 +2630,7 @@ GS::Optional<GS::UniString> GetRelationsOfElementsCommand::GetInputParametersSch
     })";
 }
 
-GS::Optional<GS::UniString> GetRelationsOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetRelationsOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -2942,7 +2942,7 @@ GS::Optional<GS::UniString> GetZoneBoundariesCommand::GetInputParametersSchema (
     })";
 }
 
-GS::Optional<GS::UniString> GetZoneBoundariesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetZoneBoundariesCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ZoneBoundariesOrError"
@@ -3064,7 +3064,7 @@ GS::Optional<GS::UniString> UpdateZonesCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> UpdateZonesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> UpdateZonesCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -3144,7 +3144,7 @@ GS::Optional<GS::UniString> GetCollisionsCommand::GetInputParametersSchema () co
     })";
 }
 
-GS::Optional<GS::UniString> GetCollisionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetCollisionsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -3296,7 +3296,7 @@ GS::Optional<GS::UniString> MoveElementsCommand::GetInputParametersSchema () con
     })";
 }
 
-GS::Optional<GS::UniString> MoveElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> MoveElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -3459,7 +3459,7 @@ GS::Optional<GS::UniString> RotateElementsCommand::GetInputParametersSchema () c
     })";
 }
 
-GS::Optional<GS::UniString> RotateElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> RotateElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -3562,7 +3562,7 @@ GS::Optional<GS::UniString> FilterElementsCommand::GetInputParametersSchema () c
     })";
 }
 
-GS::Optional<GS::UniString> FilterElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> FilterElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -3667,7 +3667,7 @@ GS::Optional<GS::UniString> HighlightElementsCommand::GetInputParametersSchema (
     })";
 }
 
-GS::Optional<GS::UniString> HighlightElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> HighlightElementsCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -3850,7 +3850,7 @@ GS::Optional<GS::UniString> Get3DBoundingBoxesCommand::GetInputParametersSchema 
     })";
 }
 
-GS::Optional<GS::UniString> Get3DBoundingBoxesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> Get3DBoundingBoxesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -3939,7 +3939,7 @@ GS::Optional<GS::UniString> DeleteElementsCommand::GetInputParametersSchema () c
     })";
 }
 
-GS::Optional<GS::UniString> DeleteElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DeleteElementsCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -3990,7 +3990,7 @@ GS::Optional<GS::UniString> LockElementsCommand::GetInputParametersSchema () con
     })";
 }
 
-GS::Optional<GS::UniString> LockElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> LockElementsCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -4040,7 +4040,7 @@ GS::Optional<GS::UniString> UnlockElementsCommand::GetInputParametersSchema () c
     })";
 }
 
-GS::Optional<GS::UniString> UnlockElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> UnlockElementsCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -4108,7 +4108,7 @@ GS::Optional<GS::UniString> GetElementPreviewImageCommand::GetInputParametersSch
     })";
 }
 
-GS::Optional<GS::UniString> GetElementPreviewImageCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetElementPreviewImageCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -4228,7 +4228,7 @@ GS::Optional<GS::UniString> GetRoomImageCommand::GetInputParametersSchema () con
     })";
 }
 
-GS::Optional<GS::UniString> GetRoomImageCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetRoomImageCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/ElementCommands.hpp
+++ b/archicad-addon/Sources/ElementCommands.hpp
@@ -8,7 +8,7 @@ public:
     GetElementsByTypeCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -25,7 +25,7 @@ public:
     GetDetailsOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -35,7 +35,7 @@ public:
     SetDetailsOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -44,7 +44,7 @@ class GetSelectedElementsCommand : public CommandBase
 public:
     GetSelectedElementsCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -54,7 +54,7 @@ public:
     ChangeSelectionOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -64,7 +64,7 @@ public:
     GetSubelementsOfHierarchicalElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -74,7 +74,7 @@ public:
     GetConnectedElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -84,7 +84,7 @@ public:
     GetSectionElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -94,7 +94,7 @@ public:
     GetRelationsOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -104,7 +104,7 @@ public:
     GetZoneBoundariesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -114,7 +114,7 @@ public:
     UpdateZonesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -124,7 +124,7 @@ public:
     GetCollisionsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -134,7 +134,7 @@ public:
     MoveElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -144,7 +144,7 @@ public:
     RotateElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -154,7 +154,7 @@ public:
     FilterElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -164,7 +164,7 @@ public:
     HighlightElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -174,7 +174,7 @@ public:
     Get3DBoundingBoxesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -184,7 +184,7 @@ public:
     DeleteElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -194,7 +194,7 @@ public:
     LockElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -204,7 +204,7 @@ public:
     UnlockElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -214,7 +214,7 @@ public:
     GetElementPreviewImageCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -224,7 +224,7 @@ public:
     GetRoomImageCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 

--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -17,7 +17,7 @@ GS::String CreateElementsCommandBase::GetName () const
     return commandName;
 }
 
-GS::Optional<GS::UniString> CreateElementsCommandBase::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateElementsCommandBase::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1991,7 +1991,7 @@ GS::Optional<GS::UniString> ModifyObjectsCommand::GetInputParametersSchema () co
     return BuildLibraryPartBasedModifySchema ("objectsWithDetails", false);
 }
 
-GS::Optional<GS::UniString> ModifyObjectsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyObjectsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -2027,7 +2027,7 @@ GS::Optional<GS::UniString> ModifyLampsCommand::GetInputParametersSchema () cons
     return BuildLibraryPartBasedModifySchema ("lampsWithDetails", true);
 }
 
-GS::Optional<GS::UniString> ModifyLampsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyLampsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/ElementCreationCommands.hpp
+++ b/archicad-addon/Sources/ElementCreationCommands.hpp
@@ -7,7 +7,7 @@ class CreateElementsCommandBase : public CommandBase
 public:
     CreateElementsCommandBase (const GS::String& commandName, API_ElemTypeID elemTypeID, const GS::String& arrayFieldName);
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 protected:
     virtual GS::Optional<GS::ObjectState> SetTypeSpecificParameters (API_Element& element, API_ElementMemo& memo, const Stories& stories, const GS::ObjectState& parameters) const = 0;
@@ -143,7 +143,7 @@ public:
     ModifyObjectsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -153,6 +153,6 @@ public:
     ModifyLampsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/ElementGDLParameterCommands.cpp
+++ b/archicad-addon/Sources/ElementGDLParameterCommands.cpp
@@ -380,7 +380,7 @@ GS::Optional<GS::UniString> GetGDLParametersOfElementsCommand::GetInputParameter
 })";
 }
 
-GS::Optional<GS::UniString> GetGDLParametersOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetGDLParametersOfElementsCommand::GetResponseSchema () const
 {
     return R"({
     "type": "object",
@@ -674,7 +674,7 @@ GS::Optional<GS::UniString> SetGDLParametersOfElementsCommand::GetInputParameter
 })";
 }
 
-GS::Optional<GS::UniString> SetGDLParametersOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> SetGDLParametersOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/ElementGDLParameterCommands.hpp
+++ b/archicad-addon/Sources/ElementGDLParameterCommands.hpp
@@ -8,7 +8,7 @@ public:
     GetGDLParametersOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -18,7 +18,7 @@ public:
     SetGDLParametersOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 
 private:

--- a/archicad-addon/Sources/ElementGroupingCommands.cpp
+++ b/archicad-addon/Sources/ElementGroupingCommands.cpp
@@ -49,7 +49,7 @@ GS::Optional<GS::UniString> CreateGroupsCommand::GetInputParametersSchema() cons
     })";
 }
 
-GS::Optional<GS::UniString> CreateGroupsCommand::GetRawResponseSchema() const
+GS::Optional<GS::UniString> CreateGroupsCommand::GetResponseSchema() const
 {
     return R"({
         "type": "object",
@@ -156,7 +156,7 @@ GS::Optional<GS::UniString> GetGroupsOfElementsCommand::GetInputParametersSchema
     })";
 }
 
-GS::Optional<GS::UniString> GetGroupsOfElementsCommand::GetRawResponseSchema() const
+GS::Optional<GS::UniString> GetGroupsOfElementsCommand::GetResponseSchema() const
 {
     return R"({
         "type": "object",
@@ -242,7 +242,7 @@ GS::Optional<GS::UniString> GetElementsOfGroupsCommand::GetInputParametersSchema
     })";
 }
 
-GS::Optional<GS::UniString> GetElementsOfGroupsCommand::GetRawResponseSchema() const
+GS::Optional<GS::UniString> GetElementsOfGroupsCommand::GetResponseSchema() const
 {
     return R"({
         "type": "object",
@@ -307,7 +307,7 @@ GS::String GetSuspendGroupsModeCommand::GetName() const
     return "GetSuspendGroupsMode";
 }
 
-GS::Optional<GS::UniString> GetSuspendGroupsModeCommand::GetRawResponseSchema() const
+GS::Optional<GS::UniString> GetSuspendGroupsModeCommand::GetResponseSchema() const
 {
     return R"({
         "type": "object",
@@ -362,7 +362,7 @@ GS::Optional<GS::UniString> SetSuspendGroupsModeCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> SetSuspendGroupsModeCommand::GetRawResponseSchema() const
+GS::Optional<GS::UniString> SetSuspendGroupsModeCommand::GetResponseSchema() const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/ElementGroupingCommands.hpp
+++ b/archicad-addon/Sources/ElementGroupingCommands.hpp
@@ -8,7 +8,7 @@ public:
     CreateGroupsCommand();
     virtual GS::String GetName() const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema() const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema() const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema() const override;
     virtual GS::ObjectState Execute(const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -18,7 +18,7 @@ public:
     GetGroupsOfElementsCommand();
     virtual GS::String GetName() const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema() const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema() const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema() const override;
     virtual GS::ObjectState Execute(const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -28,7 +28,7 @@ public:
     GetElementsOfGroupsCommand();
     virtual GS::String GetName() const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema() const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema() const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema() const override;
     virtual GS::ObjectState Execute(const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -37,7 +37,7 @@ class GetSuspendGroupsModeCommand : public CommandBase
 public:
     GetSuspendGroupsModeCommand();
     virtual GS::String GetName() const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema() const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema() const override;
     virtual GS::ObjectState Execute(const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -47,6 +47,6 @@ public:
     SetSuspendGroupsModeCommand();
     virtual GS::String GetName() const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema() const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema() const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema() const override;
     virtual GS::ObjectState Execute(const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -3717,7 +3717,7 @@ GS::Optional<GS::UniString> CreateWindowsCommand::GetInputParametersSchema () co
     })";
 }
 
-GS::Optional<GS::UniString> CreateWindowsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateWindowsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -3859,7 +3859,7 @@ GS::Optional<GS::UniString> CreateDoorsCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> CreateDoorsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateDoorsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -3993,7 +3993,7 @@ GS::Optional<GS::UniString> CreateOpeningsCommand::GetInputParametersSchema () c
     })";
 }
 
-GS::Optional<GS::UniString> CreateOpeningsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateOpeningsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -4183,7 +4183,7 @@ GS::Optional<GS::UniString> CreateMorphsCommand::GetInputParametersSchema () con
     })";
 }
 
-GS::Optional<GS::UniString> CreateMorphsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateMorphsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -4413,9 +4413,9 @@ GS::Optional<GS::UniString> CreateRoofsCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> CreateRoofsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateRoofsCommand::GetResponseSchema () const
 {
-    return CreateMorphsCommand ().GetRawResponseSchema ();
+    return CreateMorphsCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState CreateRoofsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
@@ -4575,7 +4575,7 @@ GS::Optional<GS::UniString> CreateAssociativeDimensionsCommand::GetInputParamete
     })";
 }
 
-GS::Optional<GS::UniString> CreateAssociativeDimensionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateAssociativeDimensionsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -4740,7 +4740,7 @@ GS::Optional<GS::UniString> CreateAssociativeDimensionsOnSectionCommand::GetInpu
     })";
 }
 
-GS::Optional<GS::UniString> CreateAssociativeDimensionsOnSectionCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateAssociativeDimensionsOnSectionCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -4863,7 +4863,7 @@ GS::Optional<GS::UniString> CreateWallThicknessDimensionsCommand::GetInputParame
     })";
 }
 
-GS::Optional<GS::UniString> CreateWallThicknessDimensionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateWallThicknessDimensionsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -5048,7 +5048,7 @@ GS::Optional<GS::UniString> ModifyWallsCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> ModifyWallsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyWallsCommand::GetResponseSchema () const
 {
     return R"({"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]})";
 }
@@ -5163,9 +5163,9 @@ GS::Optional<GS::UniString> ModifyBeamsCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> ModifyBeamsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyBeamsCommand::GetResponseSchema () const
 {
-    return ModifyWallsCommand ().GetRawResponseSchema ();
+    return ModifyWallsCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState ModifyBeamsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
@@ -5321,9 +5321,9 @@ GS::Optional<GS::UniString> ModifySlabsCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> ModifySlabsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifySlabsCommand::GetResponseSchema () const
 {
-    return ModifyWallsCommand ().GetRawResponseSchema ();
+    return ModifyWallsCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState ModifySlabsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
@@ -5491,9 +5491,9 @@ GS::Optional<GS::UniString> ModifyRoofsCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> ModifyRoofsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyRoofsCommand::GetResponseSchema () const
 {
-    return ModifyWallsCommand ().GetRawResponseSchema ();
+    return ModifyWallsCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState ModifyRoofsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
@@ -5616,7 +5616,7 @@ GS::Optional<GS::UniString> GetDimensionDataCommand::GetInputParametersSchema ()
     })";
 }
 
-GS::Optional<GS::UniString> GetDimensionDataCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetDimensionDataCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -5770,9 +5770,9 @@ GS::Optional<GS::UniString> ModifyColumnsCommand::GetInputParametersSchema () co
     })";
 }
 
-GS::Optional<GS::UniString> ModifyColumnsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyColumnsCommand::GetResponseSchema () const
 {
-    return ModifyWallsCommand ().GetRawResponseSchema ();
+    return ModifyWallsCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState ModifyColumnsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
@@ -5866,9 +5866,9 @@ GS::Optional<GS::UniString> ModifyWindowsCommand::GetInputParametersSchema () co
     })";
 }
 
-GS::Optional<GS::UniString> ModifyWindowsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyWindowsCommand::GetResponseSchema () const
 {
-    return ModifyWallsCommand ().GetRawResponseSchema ();
+    return ModifyWallsCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState ModifyWindowsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
@@ -5946,9 +5946,9 @@ GS::Optional<GS::UniString> ModifyDoorsCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> ModifyDoorsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyDoorsCommand::GetResponseSchema () const
 {
-    return ModifyWallsCommand ().GetRawResponseSchema ();
+    return ModifyWallsCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState ModifyDoorsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
@@ -6090,9 +6090,9 @@ GS::Optional<GS::UniString> ModifyMorphsCommand::GetInputParametersSchema () con
     })";
 }
 
-GS::Optional<GS::UniString> ModifyMorphsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyMorphsCommand::GetResponseSchema () const
 {
-    return ModifyWallsCommand ().GetRawResponseSchema ();
+    return ModifyWallsCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState ModifyMorphsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl&) const
@@ -6253,7 +6253,7 @@ GS::Optional<GS::UniString> CreateSectionsCommand::GetInputParametersSchema () c
     })";
 }
 
-GS::Optional<GS::UniString> CreateSectionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateSectionsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -6590,7 +6590,7 @@ GS::Optional<GS::UniString> ModifyMeshesCommand::GetInputParametersSchema () con
 })";
 }
 
-GS::Optional<GS::UniString> ModifyMeshesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyMeshesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/ExtendedElementCommands.hpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.hpp
@@ -46,7 +46,7 @@ public:
     CreateWindowsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -56,7 +56,7 @@ public:
     CreateDoorsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -66,7 +66,7 @@ public:
     CreateOpeningsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -76,7 +76,7 @@ public:
     CreateMorphsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -86,7 +86,7 @@ public:
     CreateRoofsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -96,7 +96,7 @@ public:
     CreateAssociativeDimensionsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -106,7 +106,7 @@ public:
     CreateAssociativeDimensionsOnSectionCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -116,7 +116,7 @@ public:
     CreateWallThicknessDimensionsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -126,7 +126,7 @@ public:
     ModifyWallsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -136,7 +136,7 @@ public:
     ModifyBeamsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -146,7 +146,7 @@ public:
     ModifySlabsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -156,7 +156,7 @@ public:
     ModifyColumnsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -166,7 +166,7 @@ public:
     ModifyWindowsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -176,7 +176,7 @@ public:
     ModifyMorphsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -186,7 +186,7 @@ public:
     ModifyRoofsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -196,7 +196,7 @@ public:
     ModifyDoorsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -206,7 +206,7 @@ public:
     CreateSectionsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -216,7 +216,7 @@ public:
     GetDimensionDataCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -226,6 +226,6 @@ public:
     ModifyMeshesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/FavoritesCommands.cpp
+++ b/archicad-addon/Sources/FavoritesCommands.cpp
@@ -30,7 +30,7 @@ GS::Optional<GS::UniString> GetFavoritesByTypeCommand::GetInputParametersSchema 
     })";
 }
 
-GS::Optional<GS::UniString> GetFavoritesByTypeCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetFavoritesByTypeCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/FavoritesOrError"
@@ -113,7 +113,7 @@ GS::Optional<GS::UniString> GetFavoritePreviewImageCommand::GetInputParametersSc
     })";
 }
 
-GS::Optional<GS::UniString> GetFavoritePreviewImageCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetFavoritePreviewImageCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -210,7 +210,7 @@ GS::Optional<GS::UniString> ApplyFavoritesToElementDefaultsCommand::GetInputPara
     })";
 }
 
-GS::Optional<GS::UniString> ApplyFavoritesToElementDefaultsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ApplyFavoritesToElementDefaultsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -328,7 +328,7 @@ GS::Optional<GS::UniString> CreateFavoritesFromElementsCommand::GetInputParamete
     })";
 }
 
-GS::Optional<GS::UniString> CreateFavoritesFromElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateFavoritesFromElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -499,7 +499,7 @@ GS::Optional<GS::UniString> ImportFavoritesCommand::GetInputParametersSchema () 
     })";
 }
 
-GS::Optional<GS::UniString> ImportFavoritesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ImportFavoritesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -591,7 +591,7 @@ GS::Optional<GS::UniString> ExportFavoritesCommand::GetInputParametersSchema () 
     })";
 }
 
-GS::Optional<GS::UniString> ExportFavoritesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ExportFavoritesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -696,7 +696,7 @@ GS::Optional<GS::UniString> ApplyFavoritesToElementsCommand::GetInputParametersS
     })";
 }
 
-GS::Optional<GS::UniString> ApplyFavoritesToElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ApplyFavoritesToElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -865,7 +865,7 @@ GS::Optional<GS::UniString> UpdateFavoritesFromElementsCommand::GetInputParamete
     })";
 }
 
-GS::Optional<GS::UniString> UpdateFavoritesFromElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> UpdateFavoritesFromElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -960,7 +960,7 @@ GS::Optional<GS::UniString> RenameFavoritesCommand::GetInputParametersSchema () 
     })";
 }
 
-GS::Optional<GS::UniString> RenameFavoritesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> RenameFavoritesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1025,7 +1025,7 @@ GS::Optional<GS::UniString> DeleteFavoritesCommand::GetInputParametersSchema () 
     })";
 }
 
-GS::Optional<GS::UniString> DeleteFavoritesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DeleteFavoritesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/FavoritesCommands.hpp
+++ b/archicad-addon/Sources/FavoritesCommands.hpp
@@ -8,7 +8,7 @@ public:
     GetFavoritesByTypeCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -18,7 +18,7 @@ public:
     GetFavoritePreviewImageCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -28,7 +28,7 @@ public:
     ApplyFavoritesToElementDefaultsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -38,7 +38,7 @@ public:
     CreateFavoritesFromElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -48,7 +48,7 @@ public:
     ImportFavoritesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -58,7 +58,7 @@ public:
     ExportFavoritesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -68,7 +68,7 @@ public:
     ApplyFavoritesToElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -78,7 +78,7 @@ public:
     UpdateFavoritesFromElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -88,7 +88,7 @@ public:
     RenameFavoritesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -98,6 +98,6 @@ public:
     DeleteFavoritesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/IFCCommands.cpp
+++ b/archicad-addon/Sources/IFCCommands.cpp
@@ -41,7 +41,7 @@ GS::Optional<GS::UniString> GetElementsByIFCIdsCommand::GetInputParametersSchema
     })";
 }
 
-GS::Optional<GS::UniString> GetElementsByIFCIdsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetElementsByIFCIdsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -123,7 +123,7 @@ GS::Optional<GS::UniString> GetIFCIdsOfElementsCommand::GetInputParametersSchema
     })";
 }
 
-GS::Optional<GS::UniString> GetIFCIdsOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetIFCIdsOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -221,7 +221,7 @@ GS::Optional<GS::UniString> GetIFCTypeOfElementsCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> GetIFCTypeOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetIFCTypeOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -319,7 +319,7 @@ GS::Optional<GS::UniString> GetIFCPropertiesOfElementsCommand::GetInputParameter
     })";
 }
 
-GS::Optional<GS::UniString> GetIFCPropertiesOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetIFCPropertiesOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/IFCCommands.hpp
+++ b/archicad-addon/Sources/IFCCommands.hpp
@@ -8,7 +8,7 @@ public:
     GetElementsByIFCIdsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -18,7 +18,7 @@ public:
     GetIFCIdsOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -28,7 +28,7 @@ public:
     GetIFCTypeOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -38,6 +38,6 @@ public:
     GetIFCPropertiesOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/IssueCommands.cpp
+++ b/archicad-addon/Sources/IssueCommands.cpp
@@ -103,7 +103,7 @@ GS::Optional<GS::UniString> CreateIssueCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> CreateIssueCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateIssueCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -176,7 +176,7 @@ GS::Optional<GS::UniString> DeleteIssueCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> DeleteIssueCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DeleteIssueCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -215,7 +215,7 @@ GS::String GetIssuesCommand::GetName () const
     return "GetIssues";
 }
 
-GS::Optional<GS::UniString> GetIssuesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetIssuesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -342,7 +342,7 @@ GS::Optional<GS::UniString> AddCommentToIssueCommand::GetInputParametersSchema (
     })";
 }
 
-GS::Optional<GS::UniString> AddCommentToIssueCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> AddCommentToIssueCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -418,7 +418,7 @@ GS::Optional<GS::UniString> GetCommentsFromIssueCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> GetCommentsFromIssueCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetCommentsFromIssueCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -531,7 +531,7 @@ GS::Optional<GS::UniString> AttachElementsToIssueCommand::GetInputParametersSche
     })";
 }
 
-GS::Optional<GS::UniString> AttachElementsToIssueCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> AttachElementsToIssueCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -606,7 +606,7 @@ GS::Optional<GS::UniString> DetachElementsFromIssueCommand::GetInputParametersSc
     })";
 }
 
-GS::Optional<GS::UniString> DetachElementsFromIssueCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DetachElementsFromIssueCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -665,7 +665,7 @@ GS::Optional<GS::UniString> GetElementsAttachedToIssueCommand::GetInputParameter
     })";
 }
 
-GS::Optional<GS::UniString> GetElementsAttachedToIssueCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetElementsAttachedToIssueCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -748,7 +748,7 @@ GS::Optional<GS::UniString> ExportIssuesToBCFCommand::GetInputParametersSchema (
     })";
 }
 
-GS::Optional<GS::UniString> ExportIssuesToBCFCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ExportIssuesToBCFCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -822,7 +822,7 @@ GS::Optional<GS::UniString> ImportIssuesFromBCFCommand::GetInputParametersSchema
     })";
 }
 
-GS::Optional<GS::UniString> ImportIssuesFromBCFCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ImportIssuesFromBCFCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"

--- a/archicad-addon/Sources/IssueCommands.hpp
+++ b/archicad-addon/Sources/IssueCommands.hpp
@@ -8,7 +8,7 @@ public:
     CreateIssueCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -18,7 +18,7 @@ public:
     DeleteIssueCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -27,7 +27,7 @@ class GetIssuesCommand : public CommandBase
 public:
     GetIssuesCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -37,7 +37,7 @@ public:
     AddCommentToIssueCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -47,7 +47,7 @@ public:
     GetCommentsFromIssueCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -57,7 +57,7 @@ public:
     AttachElementsToIssueCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -67,7 +67,7 @@ public:
     DetachElementsFromIssueCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -77,7 +77,7 @@ public:
     GetElementsAttachedToIssueCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -87,7 +87,7 @@ public:
     ExportIssuesToBCFCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -97,6 +97,6 @@ public:
     ImportIssuesFromBCFCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/KeynoteCommands.cpp
+++ b/archicad-addon/Sources/KeynoteCommands.cpp
@@ -130,7 +130,7 @@ GS::String GetKeynoteTreeCommand::GetName () const
     return "GetKeynoteTree";
 }
 
-GS::Optional<GS::UniString> GetKeynoteTreeCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetKeynoteTreeCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -228,7 +228,7 @@ GS::Optional<GS::UniString> GetKeynoteAutoTextsCommand::GetInputParametersSchema
     })";
 }
 
-GS::Optional<GS::UniString> GetKeynoteAutoTextsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetKeynoteAutoTextsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -335,7 +335,7 @@ GS::Optional<GS::UniString> CreateKeynoteFoldersCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> CreateKeynoteFoldersCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateKeynoteFoldersCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -457,7 +457,7 @@ GS::Optional<GS::UniString> CreateKeynoteItemsCommand::GetInputParametersSchema 
     })";
 }
 
-GS::Optional<GS::UniString> CreateKeynoteItemsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateKeynoteItemsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -587,7 +587,7 @@ GS::Optional<GS::UniString> ModifyKeynoteFoldersCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> ModifyKeynoteFoldersCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyKeynoteFoldersCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -717,9 +717,9 @@ GS::Optional<GS::UniString> ModifyKeynoteItemsCommand::GetInputParametersSchema 
     })";
 }
 
-GS::Optional<GS::UniString> ModifyKeynoteItemsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyKeynoteItemsCommand::GetResponseSchema () const
 {
-    return ModifyKeynoteFoldersCommand ().GetRawResponseSchema ();
+    return ModifyKeynoteFoldersCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState ModifyKeynoteItemsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
@@ -820,9 +820,9 @@ GS::Optional<GS::UniString> DeleteKeynoteFoldersCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> DeleteKeynoteFoldersCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DeleteKeynoteFoldersCommand::GetResponseSchema () const
 {
-    return ModifyKeynoteFoldersCommand ().GetRawResponseSchema ();
+    return ModifyKeynoteFoldersCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState DeleteKeynoteFoldersCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
@@ -912,9 +912,9 @@ GS::Optional<GS::UniString> DeleteKeynoteItemsCommand::GetInputParametersSchema 
     })";
 }
 
-GS::Optional<GS::UniString> DeleteKeynoteItemsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DeleteKeynoteItemsCommand::GetResponseSchema () const
 {
-    return ModifyKeynoteFoldersCommand ().GetRawResponseSchema ();
+    return ModifyKeynoteFoldersCommand ().GetResponseSchema ();
 }
 
 GS::ObjectState DeleteKeynoteItemsCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
@@ -1014,7 +1014,7 @@ GS::Optional<GS::UniString> CreateKeynoteLabelsCommand::GetInputParametersSchema
     })";
 }
 
-GS::Optional<GS::UniString> CreateKeynoteLabelsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateKeynoteLabelsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/KeynoteCommands.hpp
+++ b/archicad-addon/Sources/KeynoteCommands.hpp
@@ -7,7 +7,7 @@ class GetKeynoteTreeCommand : public CommandBase
 public:
     GetKeynoteTreeCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -17,7 +17,7 @@ public:
     GetKeynoteAutoTextsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -27,7 +27,7 @@ public:
     CreateKeynoteFoldersCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -37,7 +37,7 @@ public:
     CreateKeynoteItemsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -47,7 +47,7 @@ public:
     ModifyKeynoteFoldersCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -57,7 +57,7 @@ public:
     ModifyKeynoteItemsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -67,7 +67,7 @@ public:
     DeleteKeynoteFoldersCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -77,7 +77,7 @@ public:
     DeleteKeynoteItemsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -87,6 +87,6 @@ public:
     CreateKeynoteLabelsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/LibraryCommands.cpp
+++ b/archicad-addon/Sources/LibraryCommands.cpp
@@ -31,7 +31,7 @@ GS::Optional<GS::UniString> AddFilesToEmbeddedLibraryCommand::GetInputParameters
     })";
 }
 
-GS::Optional<GS::UniString> AddFilesToEmbeddedLibraryCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> AddFilesToEmbeddedLibraryCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -139,7 +139,7 @@ GS::ObjectState AddFilesToEmbeddedLibraryCommand::Execute (const GS::ObjectState
     return response;
 }
 
-GS::Optional<GS::UniString> GetLibrariesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetLibrariesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -276,7 +276,7 @@ GS::String ReloadLibrariesCommand::GetName () const
     return "ReloadLibraries";
 }
 
-GS::Optional<GS::UniString> ReloadLibrariesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ReloadLibrariesCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -317,7 +317,7 @@ GS::Optional<GS::UniString> GetAvailableLibraryPartsCommand::GetInputParametersS
     })";
 }
 
-GS::Optional<GS::UniString> GetAvailableLibraryPartsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetAvailableLibraryPartsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/LibraryCommands.hpp
+++ b/archicad-addon/Sources/LibraryCommands.hpp
@@ -8,7 +8,7 @@ public:
     AddFilesToEmbeddedLibraryCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -17,7 +17,7 @@ class GetLibrariesCommand : public CommandBase
 public:
     GetLibrariesCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -26,7 +26,7 @@ class ReloadLibrariesCommand : public CommandBase
 public:
     ReloadLibrariesCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 class GetAvailableLibraryPartsCommand : public CommandBase
@@ -35,6 +35,6 @@ public:
     GetAvailableLibraryPartsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/MEPCommands.cpp
+++ b/archicad-addon/Sources/MEPCommands.cpp
@@ -190,7 +190,7 @@ GS::Optional<GS::UniString> GetMEPElementsCommand::GetInputParametersSchema () c
     })";
 }
 
-GS::Optional<GS::UniString> GetMEPElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetMEPElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -303,7 +303,7 @@ GS::Optional<GS::UniString> GetMEPRoutingElementsCommand::GetInputParametersSche
     })";
 }
 
-GS::Optional<GS::UniString> GetMEPRoutingElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetMEPRoutingElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -410,7 +410,7 @@ GS::Optional<GS::UniString> GetMEPPortsCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> GetMEPPortsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetMEPPortsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -500,7 +500,7 @@ GS::String GetMEPDistributionSystemsCommand::GetName () const
     return "GetMEPDistributionSystems";
 }
 
-GS::Optional<GS::UniString> GetMEPDistributionSystemsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetMEPDistributionSystemsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -642,7 +642,7 @@ GS::Optional<GS::UniString> CreateMEPRoutingElementsCommand::GetInputParametersS
     })";
 }
 
-GS::Optional<GS::UniString> CreateMEPRoutingElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateMEPRoutingElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -811,7 +811,7 @@ GS::Optional<GS::UniString> CreateMEPElementsCommand::GetInputParametersSchema (
     })";
 }
 
-GS::Optional<GS::UniString> CreateMEPElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateMEPElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -979,7 +979,7 @@ GS::Optional<GS::UniString> ModifyMEPRoutingElementsCommand::GetInputParametersS
     })";
 }
 
-GS::Optional<GS::UniString> ModifyMEPRoutingElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ModifyMEPRoutingElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1138,7 +1138,7 @@ GS::Optional<GS::UniString> ConnectMEPElementsCommand::GetInputParametersSchema 
     })";
 }
 
-GS::Optional<GS::UniString> ConnectMEPElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ConnectMEPElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1245,7 +1245,7 @@ GS::Optional<GS::UniString> GetMEPPreferenceTablesCommand::GetInputParametersSch
     })";
 }
 
-GS::Optional<GS::UniString> GetMEPPreferenceTablesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetMEPPreferenceTablesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/MEPCommands.hpp
+++ b/archicad-addon/Sources/MEPCommands.hpp
@@ -8,7 +8,7 @@ public:
     GetMEPElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -18,7 +18,7 @@ public:
     GetMEPRoutingElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -28,7 +28,7 @@ public:
     GetMEPPortsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -37,7 +37,7 @@ class GetMEPDistributionSystemsCommand : public CommandBase
 public:
     GetMEPDistributionSystemsCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -47,7 +47,7 @@ public:
     CreateMEPRoutingElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -57,7 +57,7 @@ public:
     CreateMEPElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -67,7 +67,7 @@ public:
     ModifyMEPRoutingElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -77,7 +77,7 @@ public:
     ConnectMEPElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -87,6 +87,6 @@ public:
     GetMEPPreferenceTablesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/NavigatorCommands.cpp
+++ b/archicad-addon/Sources/NavigatorCommands.cpp
@@ -135,7 +135,7 @@ GS::Optional<GS::UniString> UpdateDrawingsCommand::GetInputParametersSchema() co
 })";
 }
 
-GS::Optional<GS::UniString> UpdateDrawingsCommand::GetRawResponseSchema() const
+GS::Optional<GS::UniString> UpdateDrawingsCommand::GetResponseSchema() const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -185,7 +185,7 @@ GS::Optional<GS::UniString> GetDatabaseIdFromNavigatorItemIdCommand::GetInputPar
 })";
 }
 
-GS::Optional<GS::UniString> GetDatabaseIdFromNavigatorItemIdCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetDatabaseIdFromNavigatorItemIdCommand::GetResponseSchema () const
 {
     return R"({
     "type": "object",
@@ -245,7 +245,7 @@ GS::String GetModelViewOptionsCommand::GetName () const
     return "GetModelViewOptions";
 }
 
-GS::Optional<GS::UniString> GetModelViewOptionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetModelViewOptionsCommand::GetResponseSchema () const
 {
     return R"({
     "type": "object",
@@ -338,7 +338,7 @@ GS::Optional<GS::UniString> GetViewSettingsCommand::GetInputParametersSchema () 
     })";
 }
 
-GS::Optional<GS::UniString> GetViewSettingsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetViewSettingsCommand::GetResponseSchema () const
 {
     return R"({
     "type": "object",
@@ -483,7 +483,7 @@ GS::Optional<GS::UniString> SetViewSettingsCommand::GetInputParametersSchema () 
     })";
 }
 
-GS::Optional<GS::UniString> SetViewSettingsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> SetViewSettingsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -621,7 +621,7 @@ GS::Optional<GS::UniString> GetView2DTransformationsCommand::GetInputParametersS
     })";
 }
 
-GS::Optional<GS::UniString> GetView2DTransformationsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetView2DTransformationsCommand::GetResponseSchema () const
 {
     return R"({
     "type": "object",
@@ -775,7 +775,7 @@ GS::Optional<GS::UniString> SetViewRotationCommand::GetInputParametersSchema () 
     })";
 }
 
-GS::Optional<GS::UniString> SetViewRotationCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> SetViewRotationCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -895,7 +895,7 @@ GS::Optional<GS::UniString> FitInWindowCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> FitInWindowCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> FitInWindowCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -962,7 +962,7 @@ GS::Optional<GS::UniString> CloneProjectMapItemToViewMapCommand::GetInputParamet
     })";
 }
 
-GS::Optional<GS::UniString> CloneProjectMapItemToViewMapCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CloneProjectMapItemToViewMapCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1071,7 +1071,7 @@ GS::Optional<GS::UniString> CreateViewsInViewMapCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> CreateViewsInViewMapCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateViewsInViewMapCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1187,7 +1187,7 @@ GS::Optional<GS::UniString> CreateViewMapFolderCommand::GetInputParametersSchema
     })";
 }
 
-GS::Optional<GS::UniString> CreateViewMapFolderCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateViewMapFolderCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1257,7 +1257,7 @@ GS::Optional<GS::UniString> MoveNavigatorItemCommand::GetInputParametersSchema (
     })";
 }
 
-GS::Optional<GS::UniString> MoveNavigatorItemCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> MoveNavigatorItemCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -1320,7 +1320,7 @@ GS::Optional<GS::UniString> RenameNavigatorItemCommand::GetInputParametersSchema
     })";
 }
 
-GS::Optional<GS::UniString> RenameNavigatorItemCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> RenameNavigatorItemCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -1393,7 +1393,7 @@ GS::Optional<GS::UniString> DeleteNavigatorItemsCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> DeleteNavigatorItemsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DeleteNavigatorItemsCommand::GetResponseSchema () const
 {
     return R"({"type":"object","properties":{"executionResults":{"$ref":"#/ExecutionResults"}},"additionalProperties":false,"required":["executionResults"]})";
 }

--- a/archicad-addon/Sources/NavigatorCommands.hpp
+++ b/archicad-addon/Sources/NavigatorCommands.hpp
@@ -17,7 +17,7 @@ public:
     UpdateDrawingsCommand();
     virtual GS::String GetName() const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema() const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema() const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema() const override;
     virtual GS::ObjectState Execute(const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -27,7 +27,7 @@ public:
     GetDatabaseIdFromNavigatorItemIdCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -36,7 +36,7 @@ class GetModelViewOptionsCommand : public CommandBase
 public:
     GetModelViewOptionsCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -46,7 +46,7 @@ public:
     GetViewSettingsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -56,7 +56,7 @@ public:
     SetViewSettingsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -66,7 +66,7 @@ public:
     GetView2DTransformationsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -76,7 +76,7 @@ public:
     SetViewRotationCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -86,7 +86,7 @@ public:
     FitInWindowCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -96,7 +96,7 @@ public:
     CloneProjectMapItemToViewMapCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -106,7 +106,7 @@ public:
     CreateViewsInViewMapCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -116,7 +116,7 @@ public:
     CreateViewMapFolderCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -126,7 +126,7 @@ public:
     MoveNavigatorItemCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -136,7 +136,7 @@ public:
     RenameNavigatorItemCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -146,7 +146,7 @@ public:
     DeleteNavigatorItemsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 

--- a/archicad-addon/Sources/NotificationCommands.cpp
+++ b/archicad-addon/Sources/NotificationCommands.cpp
@@ -131,7 +131,7 @@ GS::Optional<GS::UniString> AddElementNotificationClientCommand::GetInputParamet
     })";
 }
 
-GS::Optional<GS::UniString> AddElementNotificationClientCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> AddElementNotificationClientCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -383,7 +383,7 @@ GS::Optional<GS::UniString> RemoveElementNotificationClientCommand::GetInputPara
     })";
 }
 
-GS::Optional<GS::UniString> RemoveElementNotificationClientCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> RemoveElementNotificationClientCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"

--- a/archicad-addon/Sources/NotificationCommands.hpp
+++ b/archicad-addon/Sources/NotificationCommands.hpp
@@ -59,7 +59,7 @@ public:
     AddElementNotificationClientCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 
     static void SendEventToNotificationClient (ElementEventType eventType, const GS::ObjectState& os);
@@ -90,6 +90,6 @@ public:
     RemoveElementNotificationClientCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -11,7 +11,7 @@ GS::String GetProjectInfoCommand::GetName () const
     return "GetProjectInfo";
 }
 
-GS::Optional<GS::UniString> GetProjectInfoCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetProjectInfoCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -84,7 +84,7 @@ GS::String GetProjectInfoFieldsCommand::GetName () const
     return "GetProjectInfoFields";
 }
 
-GS::Optional<GS::UniString> GetProjectInfoFieldsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetProjectInfoFieldsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -238,7 +238,7 @@ GS::Optional<GS::UniString> CreateProjectInfoFieldsCommand::GetInputParametersSc
     })";
 }
 
-GS::Optional<GS::UniString> CreateProjectInfoFieldsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateProjectInfoFieldsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -341,7 +341,7 @@ GS::Optional<GS::UniString> DeleteProjectInfoFieldsCommand::GetInputParametersSc
     })";
 }
 
-GS::Optional<GS::UniString> DeleteProjectInfoFieldsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DeleteProjectInfoFieldsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -403,7 +403,7 @@ GS::String GetHotlinksCommand::GetName () const
     return "GetHotlinks";
 }
 
-GS::Optional<GS::UniString> GetHotlinksCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetHotlinksCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -483,7 +483,7 @@ GS::String GetStoriesCommand::GetName () const
     return "GetStories";
 }
 
-GS::Optional<GS::UniString> GetStoriesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetStoriesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -586,7 +586,7 @@ GS::Optional<GS::UniString> SetStoriesCommand::GetInputParametersSchema () const
     })";
 }
 
-GS::Optional<GS::UniString> SetStoriesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> SetStoriesCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -775,7 +775,7 @@ GS::Optional<GS::UniString> OpenProjectCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> OpenProjectCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> OpenProjectCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -830,7 +830,7 @@ GS::String CloseProjectCommand::GetName () const
     return "CloseProject";
 }
 
-GS::Optional<GS::UniString> CloseProjectCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CloseProjectCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -856,7 +856,7 @@ GS::String SaveProjectCommand::GetName () const
     return "SaveProject";
 }
 
-GS::Optional<GS::UniString> SaveProjectCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> SaveProjectCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -882,7 +882,7 @@ GS::String GetGeoLocationCommand::GetName () const
     return "GetGeoLocation";
 }
 
-GS::Optional<GS::UniString> GetGeoLocationCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetGeoLocationCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1126,7 +1126,7 @@ GS::Optional<GS::UniString> SetGeoLocationCommand::GetInputParametersSchema () c
     })";
 }
 
-GS::Optional<GS::UniString> SetGeoLocationCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> SetGeoLocationCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -1190,7 +1190,7 @@ GS::String GetCalculationUnitsCommand::GetName () const
     return "GetCalculationUnits";
 }
 
-GS::Optional<GS::UniString> GetCalculationUnitsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetCalculationUnitsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1425,7 +1425,7 @@ GS::Optional<GS::UniString> IFCFileOperationCommand::GetInputParametersSchema ()
     })";
 }
 
-GS::Optional<GS::UniString> IFCFileOperationCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> IFCFileOperationCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -1531,7 +1531,7 @@ GS::Optional<GS::UniString> PrintViewCommand::GetInputParametersSchema () const
     })";
 }
 
-GS::Optional<GS::UniString> PrintViewCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> PrintViewCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -1597,7 +1597,7 @@ GS::Optional<GS::UniString> RebuildViewCommand::GetInputParametersSchema () cons
     })";
 }
 
-GS::Optional<GS::UniString> RebuildViewCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> RebuildViewCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"

--- a/archicad-addon/Sources/ProjectCommands.hpp
+++ b/archicad-addon/Sources/ProjectCommands.hpp
@@ -7,7 +7,7 @@ class GetProjectInfoCommand : public CommandBase
 public:
     GetProjectInfoCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -16,7 +16,7 @@ class GetProjectInfoFieldsCommand : public CommandBase
 public:
     GetProjectInfoFieldsCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -35,7 +35,7 @@ public:
     CreateProjectInfoFieldsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -45,7 +45,7 @@ public:
     DeleteProjectInfoFieldsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -54,7 +54,7 @@ class GetHotlinksCommand : public CommandBase
 public:
     GetHotlinksCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -63,7 +63,7 @@ class GetStoriesCommand : public CommandBase
 public:
     GetStoriesCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -73,7 +73,7 @@ public:
     SetStoriesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -83,7 +83,7 @@ public:
     OpenProjectCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -92,7 +92,7 @@ class CloseProjectCommand : public CommandBase
 public:
     CloseProjectCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -101,7 +101,7 @@ class SaveProjectCommand : public CommandBase
 public:
     SaveProjectCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -110,7 +110,7 @@ class GetGeoLocationCommand : public CommandBase
 public:
     GetGeoLocationCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -120,7 +120,7 @@ public:
     SetGeoLocationCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -129,7 +129,7 @@ class GetCalculationUnitsCommand : public CommandBase
 public:
     GetCalculationUnitsCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -139,7 +139,7 @@ public:
     IFCFileOperationCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -149,7 +149,7 @@ public:
     PrintViewCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -159,6 +159,6 @@ public:
     RebuildViewCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/PropertyCommands.cpp
+++ b/archicad-addon/Sources/PropertyCommands.cpp
@@ -166,7 +166,7 @@ GS::String GetAllPropertiesCommand::GetName () const
     return "GetAllProperties";
 }
 
-GS::Optional<GS::UniString> GetAllPropertiesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetAllPropertiesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -297,7 +297,7 @@ GS::Optional<GS::UniString> GetPropertyValuesOfElementsCommand::GetInputParamete
     })";
 }
 
-GS::Optional<GS::UniString> GetPropertyValuesOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetPropertyValuesOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -425,7 +425,7 @@ GS::Optional<GS::UniString> SetPropertyValuesOfElementsCommand::GetInputParamete
     })";
 }
 
-GS::Optional<GS::UniString> SetPropertyValuesOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> SetPropertyValuesOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -574,7 +574,7 @@ GS::Optional<GS::UniString> GetPropertyValuesOfAttributesCommand::GetInputParame
     })";
 }
 
-GS::Optional<GS::UniString> GetPropertyValuesOfAttributesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetPropertyValuesOfAttributesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -680,7 +680,7 @@ GS::Optional<GS::UniString> SetPropertyValuesOfAttributesCommand::GetInputParame
     })";
 }
 
-GS::Optional<GS::UniString> SetPropertyValuesOfAttributesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> SetPropertyValuesOfAttributesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -831,7 +831,7 @@ GS::Optional<GS::UniString> CreatePropertyGroupsCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> CreatePropertyGroupsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreatePropertyGroupsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -919,7 +919,7 @@ GS::Optional<GS::UniString> DeletePropertyGroupsCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> DeletePropertyGroupsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DeletePropertyGroupsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -996,7 +996,7 @@ GS::Optional<GS::UniString> CreatePropertyDefinitionsCommand::GetInputParameters
     })";
 }
 
-GS::Optional<GS::UniString> CreatePropertyDefinitionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreatePropertyDefinitionsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1344,7 +1344,7 @@ GS::Optional<GS::UniString> DeletePropertyDefinitionsCommand::GetInputParameters
     })";
 }
 
-GS::Optional<GS::UniString> DeletePropertyDefinitionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> DeletePropertyDefinitionsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -1438,7 +1438,7 @@ GS::Optional<GS::UniString> UpdatePropertyDefinitionsCommand::GetInputParameters
     })";
 }
 
-GS::Optional<GS::UniString> UpdatePropertyDefinitionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> UpdatePropertyDefinitionsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/PropertyCommands.hpp
+++ b/archicad-addon/Sources/PropertyCommands.hpp
@@ -7,7 +7,7 @@ class GetAllPropertiesCommand : public CommandBase
 public:
     GetAllPropertiesCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -17,7 +17,7 @@ public:
     GetPropertyValuesOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -27,7 +27,7 @@ public:
     SetPropertyValuesOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -37,7 +37,7 @@ public:
     GetPropertyValuesOfAttributesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -47,7 +47,7 @@ public:
     SetPropertyValuesOfAttributesCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;    
 };
 
@@ -57,7 +57,7 @@ public:
     CreatePropertyGroupsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -67,7 +67,7 @@ public:
     DeletePropertyGroupsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -77,7 +77,7 @@ public:
     CreatePropertyDefinitionsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -87,7 +87,7 @@ public:
     DeletePropertyDefinitionsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -97,6 +97,6 @@ public:
     UpdatePropertyDefinitionsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/RevisionCommands.cpp
+++ b/archicad-addon/Sources/RevisionCommands.cpp
@@ -11,7 +11,7 @@ GS::String GetRevisionIssuesCommand::GetName () const
     return "GetRevisionIssues";
 }
 
-GS::Optional<GS::UniString> GetRevisionIssuesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetRevisionIssuesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -89,7 +89,7 @@ GS::String GetRevisionChangesCommand::GetName () const
     return "GetRevisionChanges";
 }
 
-GS::Optional<GS::UniString> GetRevisionChangesCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetRevisionChangesCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -167,7 +167,7 @@ GS::String GetDocumentRevisionsCommand::GetName () const
     return "GetDocumentRevisions";
 }
 
-GS::Optional<GS::UniString> GetDocumentRevisionsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetDocumentRevisionsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -271,7 +271,7 @@ GS::Optional<GS::UniString> GetCurrentRevisionChangesOfLayoutsCommand::GetInputP
     })";
 }
 
-GS::Optional<GS::UniString> GetCurrentRevisionChangesOfLayoutsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetCurrentRevisionChangesOfLayoutsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -345,7 +345,7 @@ GS::Optional<GS::UniString> GetRevisionChangesOfElementsCommand::GetInputParamet
     })";
 }
 
-GS::Optional<GS::UniString> GetRevisionChangesOfElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetRevisionChangesOfElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/RevisionCommands.hpp
+++ b/archicad-addon/Sources/RevisionCommands.hpp
@@ -7,7 +7,7 @@ class GetRevisionIssuesCommand : public CommandBase
 public:
     GetRevisionIssuesCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -16,7 +16,7 @@ class GetRevisionChangesCommand : public CommandBase
 public:
     GetRevisionChangesCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -25,7 +25,7 @@ class GetDocumentRevisionsCommand : public CommandBase
 public:
     GetDocumentRevisionsCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -35,7 +35,7 @@ public:
     GetCurrentRevisionChangesOfLayoutsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -45,6 +45,6 @@ public:
     GetRevisionChangesOfElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/ScriptUICommands.cpp
+++ b/archicad-addon/Sources/ScriptUICommands.cpp
@@ -80,7 +80,7 @@ GS::Optional<GS::UniString> ShowScriptUICommand::GetInputParametersSchema () con
     })";
 }
 
-GS::Optional<GS::UniString> ShowScriptUICommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ShowScriptUICommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -129,7 +129,7 @@ GS::String GetScriptUIResultCommand::GetName () const
     return "GetScriptUIResult";
 }
 
-GS::Optional<GS::UniString> GetScriptUIResultCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetScriptUIResultCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/ScriptUICommands.hpp
+++ b/archicad-addon/Sources/ScriptUICommands.hpp
@@ -8,7 +8,7 @@ public:
     ShowScriptUICommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -17,6 +17,6 @@ class GetScriptUIResultCommand : public CommandBase
 public:
     GetScriptUIResultCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/SolidElementOperationCommands.cpp
+++ b/archicad-addon/Sources/SolidElementOperationCommands.cpp
@@ -97,7 +97,7 @@ GS::Optional<GS::UniString> CreateSolidElementLinksCommand::GetInputParametersSc
     })";
 }
 
-GS::Optional<GS::UniString> CreateSolidElementLinksCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> CreateSolidElementLinksCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -201,7 +201,7 @@ GS::Optional<GS::UniString> RemoveSolidElementLinksCommand::GetInputParametersSc
     })";
 }
 
-GS::Optional<GS::UniString> RemoveSolidElementLinksCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> RemoveSolidElementLinksCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -279,7 +279,7 @@ GS::Optional<GS::UniString> GetSolidElementLinksCommand::GetInputParametersSchem
     })";
 }
 
-GS::Optional<GS::UniString> GetSolidElementLinksCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> GetSolidElementLinksCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",

--- a/archicad-addon/Sources/SolidElementOperationCommands.hpp
+++ b/archicad-addon/Sources/SolidElementOperationCommands.hpp
@@ -8,7 +8,7 @@ public:
     CreateSolidElementLinksCommand ();
     virtual GS::String                          GetName () const override;
     virtual GS::Optional<GS::UniString>         GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString>         GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString>         GetResponseSchema () const override;
     virtual GS::ObjectState                     Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -18,7 +18,7 @@ public:
     RemoveSolidElementLinksCommand ();
     virtual GS::String                          GetName () const override;
     virtual GS::Optional<GS::UniString>         GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString>         GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString>         GetResponseSchema () const override;
     virtual GS::ObjectState                     Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -28,6 +28,6 @@ public:
     GetSolidElementLinksCommand ();
     virtual GS::String                          GetName () const override;
     virtual GS::Optional<GS::UniString>         GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString>         GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString>         GetResponseSchema () const override;
     virtual GS::ObjectState                     Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };

--- a/archicad-addon/Sources/TeamworkCommands.cpp
+++ b/archicad-addon/Sources/TeamworkCommands.cpp
@@ -13,7 +13,7 @@ GS::String TeamworkSendCommand::GetName () const
     return "TeamworkSend";
 }
 
-GS::Optional<GS::UniString> TeamworkSendCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> TeamworkSendCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -39,7 +39,7 @@ GS::String TeamworkReceiveCommand::GetName () const
     return "TeamworkReceive";
 }
 
-GS::Optional<GS::UniString> TeamworkReceiveCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> TeamworkReceiveCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"
@@ -81,7 +81,7 @@ GS::Optional<GS::UniString> ReserveElementsCommand::GetInputParametersSchema () 
     })";
 }
 
-GS::Optional<GS::UniString> ReserveElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ReserveElementsCommand::GetResponseSchema () const
 {
     return R"({
         "type": "object",
@@ -202,7 +202,7 @@ GS::Optional<GS::UniString> ReleaseElementsCommand::GetInputParametersSchema () 
     })";
 }
 
-GS::Optional<GS::UniString> ReleaseElementsCommand::GetRawResponseSchema () const
+GS::Optional<GS::UniString> ReleaseElementsCommand::GetResponseSchema () const
 {
     return R"({
         "$ref": "#/ExecutionResult"

--- a/archicad-addon/Sources/TeamworkCommands.hpp
+++ b/archicad-addon/Sources/TeamworkCommands.hpp
@@ -7,7 +7,7 @@ class TeamworkSendCommand : public CommandBase
 public:
     TeamworkSendCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -16,7 +16,7 @@ class TeamworkReceiveCommand : public CommandBase
 public:
     TeamworkReceiveCommand ();
     virtual GS::String GetName () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -26,7 +26,7 @@ public:
     ReserveElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
@@ -36,6 +36,6 @@ public:
     ReleaseElementsCommand ();
     virtual GS::String GetName () const override;
     virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
-    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::Optional<GS::UniString> GetResponseSchema () const override;
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };


### PR DESCRIPTION
Reverts #499. Reopens #483.

#499 made `CommandBase::GetResponseSchema` `final` and had it wrap every
command's declared schema in `{"anyOf": [<schema>, <error object>]}`, so a
failing command's `{"error": {code, message}}` response would survive
Archicad's schema validation.

@tlorantfy built this revert and tested it against a live Archicad: **the
regressions disappear**. A top-level `anyOf` is not something the response
schemas may use.

## What this restores

- `GetResponseSchema` is the plain, non-`final` virtual the commands override
  again — `GetRawResponseSchema` is gone.
- The schema a command declares reaches Archicad verbatim, with no wrapper.
- `RegisterCommand` reads it back through `GetResponseSchema ()`.

The rename is undone by hand rather than with `git revert -m 1 2d5acab`,
because roughly forty commands added since #499 override
`GetRawResponseSchema` and would not compile once the base declaration is
removed. The rename is 1:1 mechanical in both directions, so the result is
the same source state #499 changed, applied to today's tree. Zero occurrences
of `GetRawResponseSchema` remain.

No schema content changes: the generated docs already used the raw schema, so
`docs/archicad-addon/command_definitions.js` is unaffected.

## What comes back

#483: a failing command returns `{"error": {...}}` as the whole response,
which its own schema forbids (`additionalProperties: false`), so Archicad
discards it with schema validation error 4009 and the caller sees a generic
failure instead of the actual message.

That needs a different fix, and the codebase already contains the shape of
one. About fifteen commands never had this problem, because their response
schema is a `#/<Name>OrError` definition in `CommonSchemaDefinitions.json` —
`FavoritesOrError`, `AttributeHeadersOrError`, `ZoneBoundariesOrError` and so
on — each a `oneOf` of the success shape and `#/ErrorItem`. Those have always
worked in production, which suggests the problem is specifically a union
written at the root of the response schema string, not unions as such. I will
work that up separately against #483 rather than fold it into a revert that
fixes live breakage.

## Verification

- `cmake --build Build/AC29 --config RelWithDebInfo` → clean.
- Live: regressions gone, per @tlorantfy's test of this exact build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
