### PR TITLE
Start every batch item from the tool defaults

### DIFF
--- a/archicad-addon/Sources/ElementCreationCommands.cpp
+++ b/archicad-addon/Sources/ElementCreationCommands.cpp
@@ -111,18 +111,25 @@ GS::ObjectState	CreateElementsCommandBase::Execute (const GS::ObjectState& param
                     ACAPI_Element_ChangeDefaults (&defaultsSnapshot, &defaultsSnapshotMemo, &restoreMask);
                     favoriteApplied = false;
                 }
+            }
 
-                // Re-read the (favorite-applied or restored) tool defaults so they are
-                // the baseline this item's explicit fields are written on top of.
-                ACAPI_DisposeElemMemoHdls (&memo);
-                memo = {};
-                element = {};
+            // Every item starts from the (favorite-applied or restored) tool defaults.
+            // SetTypeSpecificParameters only writes the fields the item actually names,
+            // so without this the previous item's values survive into this one: confirmed
+            // live that CreateBeams with [{slantAngle: 0.3}, {}] slants BOTH beams, and
+            // CreateWalls with [{arcAngle: 0.5}, {}] curves both walls.
+            ACAPI_DisposeElemMemoHdls (&memo);
+            memo = {};
+            element = {};
 #ifdef ServerMainVers_2600
-                element.header.type   = elemTypeID;
+            element.header.type   = elemTypeID;
 #else
-                element.header.typeID = elemTypeID;
+            element.header.typeID = elemTypeID;
 #endif
-                ACAPI_Element_GetDefaults (&element, &memo);
+            err = ACAPI_Element_GetDefaults (&element, &memo);
+            if (err != NoError) {
+                elements (CreateErrorResponse (err, "Failed to read the " + elemTypeName + " defaults."));
+                continue;
             }
 
             auto os = SetTypeSpecificParameters (element, memo, stories, data);


### PR DESCRIPTION
Found while running the live verification that the recently merged PRs still owed.

## The bug

`CreateElementsCommandBase::Execute` read `ACAPI_Element_GetDefaults` **once**
before the item loop and then reused the same `API_Element` for every item,
while `SetTypeSpecificParameters` only writes the fields an item actually
names. So whatever one item set survived into the next item that stayed silent
about it.

Confirmed live on Archicad 29:

```
CreateBeams [{slantAngle: 0.3}, {}]   -> slant=0.3 isSlanted=True | slant=0.3 isSlanted=True
CreateWalls [{arcAngle: 0.5},   {}]   -> arcAngle=0.5             | arcAngle=0.5
```

A single item is clean both before and after those calls, so the tool defaults
themselves are not polluted — the leak lives entirely inside one command. It
reaches **every optional field of every batch creation command**: walls, slabs,
beams, columns, objects, lamps, roofs, meshes, morphs and the rest.

Passing the field explicitly still wins (`[{slantAngle: 0.3}, {slantAngle: 0}]`
behaves), so the symptom only shows when a caller relies on an omitted field
meaning "leave it at the default" — which is exactly what the schemas promise,
since every one of these fields is optional.

## The fix

Re-read the defaults for each item, so each starts from the tool defaults
rather than from its predecessor's leftovers.

The per-item `favoriteName` path added in #519 already did this re-read, which
is why the leak never showed there — the re-read is now unconditional, and its
error is reported per item instead of being dropped.

## Cost

One extra `ACAPI_Element_GetDefaults` per item. That is what the favourite path
has been doing per item since #519, so the shape is proven; the comment claiming
the common path was left "exactly as it was" was accurate, and that turned out
to be the problem.

## Verification

- `cmake --build Build/AC29 --config RelWithDebInfo` → clean.
- ~~- **Not verified live yet**: the running Archicad has an older `.apx` loaded, so~~
  confirming the fix needs the new build loaded (which means restarting
  Archicad). The two commands above are the check — both should come back with
  the second element unslanted / unbent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### ✅ Live verification — passed

Archicad 29, add-on built from `d00a2a1`, untitled project from the default template. `CreateBeams [{slantAngle: 0.3}, {}]` → `slant=0.3 | slant=0`, `CreateWalls [{arcAngle: 0.5}, {}]` → `arc=0.5 | arc=0`, and four beams `[0.3, -, 0.15, -]` → `0.3 | 0 | 0.15 | 0`. The leak is gone and an explicitly named field still wins.
