### PR TITLE
Refuse polygonal walls and name the missing opening size

### DIFF
--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -237,6 +237,45 @@ bool DoesWallExist (const API_Guid& wallGuid)
     return DoesElementExist (wallGuid, API_WallID);
 }
 
+// Archicad cannot put an opening into a polygonal wall - the DevKit's own
+// Do_CreateWindow refuses the case outright ("No way to put openings into polygonal
+// walls") before it ever reaches ACAPI_Element_CreateExt. Creating one anyway does not
+// fail: the window or door is placed at a fixed spot inside the wall and every
+// centerOffset lands in the same place, which is what #453 reports. Refusing it here
+// turns a silently wrong result into an answerable error.
+bool IsPolygonalWall (const API_Guid& wallGuid)
+{
+    API_Element wall = {};
+#ifdef ServerMainVers_2600
+    wall.header.type = API_WallID;
+#else
+    wall.header.typeID = API_WallID;
+#endif
+    wall.header.guid = wallGuid;
+    if (ACAPI_Element_Get (&wall) != NoError) {
+        return false;
+    }
+    return wall.wall.type == APIWtyp_Poly;
+}
+
+// An opening's base polygon is built from width and height, so a missing one reaches
+// Archicad as an empty polygon and comes back as "Can't use empty polygon!", which says
+// nothing about the field that was left out (#453). Windows and doors are NOT checked
+// this way on purpose: there the size is optional and the tool defaults or the named
+// favorite supply it.
+GS::Optional<GS::UniString> CheckOpeningSize (const GS::ObjectState& data)
+{
+    const auto width = GetOptionalDouble (data, "width");
+    const auto height = GetOptionalDouble (data, "height");
+    if (!width.HasValue () || !height.HasValue ()) {
+        return GS::UniString ("Both 'width' and 'height' are required to create an opening.");
+    }
+    if (width.Get () <= 0.0 || height.Get () <= 0.0) {
+        return GS::UniString ("'width' and 'height' must be greater than zero.");
+    }
+    return {};
+}
+
 GSErrCode PrepareWindowOrDoorDefaults (API_ElemTypeID elemTypeId, API_Element& element, API_ElementMemo& memo, API_SubElement& marker)
 {
     element = {};
@@ -3750,6 +3789,11 @@ GS::ObjectState CreateWindowsCommand::Execute (const GS::ObjectState& parameters
                 elements.Push (CreateErrorResponse (APIERR_BADID, "Failed to load owner wall."));
                 continue;
             }
+            if (IsPolygonalWall (wallGuid)) {
+                elements.Push (CreateErrorResponse (APIERR_BADPARS,
+                    "The owner wall is polygonal, and Archicad cannot place a window in one."));
+                continue;
+            }
 
             API_Element element = {};
             API_ElementMemo memo = {};
@@ -3890,6 +3934,11 @@ GS::ObjectState CreateDoorsCommand::Execute (const GS::ObjectState& parameters, 
             const API_Guid wallGuid = GetGuidFromObjectState (*data.Get ("ownerWallId"));
             if (!DoesWallExist (wallGuid)) {
                 elements.Push (CreateErrorResponse (APIERR_BADID, "Failed to load owner wall."));
+                continue;
+            }
+            if (IsPolygonalWall (wallGuid)) {
+                elements.Push (CreateErrorResponse (APIERR_BADPARS,
+                    "The owner wall is polygonal, and Archicad cannot place a door in one."));
                 continue;
             }
 
@@ -4046,6 +4095,11 @@ GS::ObjectState CreateOpeningsCommand::Execute (const GS::ObjectState& parameter
         for (const auto& data : openingsData) {
             if (data.Get ("basePoint") == nullptr || data.Get ("ownerElementId") == nullptr) {
                 elements.Push (CreateErrorResponse (APIERR_BADPARS, "Missing required 'basePoint' or 'ownerElementId' field."));
+                continue;
+            }
+            const auto sizeError = CheckOpeningSize (data);
+            if (sizeError.HasValue ()) {
+                elements.Push (CreateErrorResponse (APIERR_BADPARS, sizeError.Get ()));
                 continue;
             }
             const API_Coord3D basePoint = Get3DCoordinateFromObjectState (*data.Get ("basePoint"));


### PR DESCRIPTION
Addresses issues 2 and 3 of #453.

## Issue 2 — polygonal walls

**Archicad cannot place an opening in a polygonal wall.** The DevKit's own
`Do_CreateWindow` refuses the case outright before it ever reaches
`ACAPI_Element_CreateExt`:

```cpp
if (element.wall.type == APIWtyp_Poly) {
    WriteReport_Alert ("No way to put openings into polygonal walls");
    return;
}
```

Going ahead anyway does not fail — the window or door is placed at a fixed spot
inside the wall and every `centerOffset` lands in the same place, which is
exactly what @mozzi86 measured with three doors at 0.6 / 1.7 / 2.8. That is the
worst kind of failure: a success response and silently wrong geometry.

`CreateWindows` and `CreateDoors` now check the owner wall's type and answer

> The owner wall is polygonal, and Archicad cannot place a window in one.

## Issue 3 — the missing size

`CreateOpenings` builds its base polygon from `width` and `height`, so omitting
one reached Archicad as an empty polygon and came back as *"Can't use empty
polygon!"*, which names nothing. It now says:

> Both 'width' and 'height' are required to create an opening.

**Windows and doors are deliberately not size-checked.** There the size is
optional — the tool defaults or the named favourite supply it — and adding the
same check would have broken working callers. Verified live that both still
create with no `width` or `height` at all.

## Issues 1 and 4

Not addressed here.

- **Issue 1** (some door favourites fail with `-2130313110`) is the same family
  as #413, #532, #399 and #481. It needs a seat where it reproduces; mine does
  not. Notably it fits the pattern: the reporter's failing favourites are all
  based on one library part (`Tür 29`) while a favourite on another
  (`Eingang 01 1-Fl 27`) works with identical parameters.
- **Issue 4** is a version-drift note against 1.5.3 — `thickness` and
  `compositeId` are already returned by current `main`.

## Verification

Live on AC29:

```
  window, no width/height     : OK          <- unchanged
  door, no width/height       : OK          <- unchanged
  window, sized               : OK
  opening, no height          : ERR: Both 'width' and 'height' are required to create an opening.
  opening, no width           : ERR: Both 'width' and 'height' are required to create an opening.
  opening, neither            : ERR: Both 'width' and 'height' are required to create an opening.
  opening, both               : OK
```

The polygonal-wall guard is **not** exercised live: Tapir's `CreateWalls`
cannot make an `APIWtyp_Poly` wall (the schema has no polygon input), so I
could not build one to test against. The check is a direct read of
`wall.type`, and the DevKit statement above is the authority for the rule
itself. @mozzi86 — you have such walls; the expected result is now a clear
error instead of three doors landing on top of each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
