### PR TITLE
Let an empty value clear a project info field

### DIFF
--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -165,8 +165,7 @@ GS::Optional<GS::UniString> SetProjectInfoFieldCommand::GetInputParametersSchema
             },
             "projectInfoValue": {
                 "type": "string",
-                "description": "The new value of the project info field.",
-                "minLength": 1
+                "description": "The new value of the project info field. An empty string clears the field."
             }
         },
         "additionalProperties": false,
@@ -185,9 +184,17 @@ GS::ObjectState SetProjectInfoFieldCommand::Execute (const GS::ObjectState& para
         return CreateErrorResponse (Error, "Invalid input parameters.");
     }
 
-    GSErrCode err = ACAPI_AutoText_SetAnAutoText (&projectInfoId, &projectInfoValue);
+    // Clearing a field is a nullptr value, not an empty string - the DevKit is explicit:
+    // "You can set the autotext value empty by passing nullptr in the autotextValue
+    // parameter." Passing an empty UniString instead does not clear it.
+    const bool clearTheField = projectInfoValue.IsEmpty ();
+
+    GSErrCode err = ACAPI_AutoText_SetAnAutoText (&projectInfoId,
+                                                  clearTheField ? nullptr : &projectInfoValue);
     if (err != NoError) {
-        return CreateErrorResponse (err, "Failed to set project information field.");
+        return CreateErrorResponse (err, clearTheField
+            ? "Failed to clear project information field."
+            : "Failed to set project information field.");
     }
 
     return {};


### PR DESCRIPTION
Answers the question directly: **no, it was not intentional — empty is a perfectly valid state for a project info field in Archicad, and the restriction was ours.**

The DevKit says so outright, on `ACAPI_AutoText_SetAnAutoText`:

> *"You can set the autotext value empty by passing **nullptr** in the autotextValue parameter."*

What blocked it was Tapir's own input schema:

```json
"projectInfoValue": { "type": "string", "minLength": 1 }
```

That `minLength: 1` arrived with the commit that first added the command, with no
rationale recorded — it reads as a copy of the constraint on `projectInfoId`,
where requiring a non-empty key is genuinely right. No code stood behind it:
`Execute` passed `&projectInfoValue` unconditionally, so the documented nullptr
case was never reachable.

## The change

- `minLength: 1` dropped from `projectInfoValue` (kept on `projectInfoId`)
- an empty string is passed to Archicad as `nullptr`, i.e. the documented clear
- the failure message distinguishes clearing from setting

No new command: `SetProjectInfoField` with `""` now means "clear", which matches
the API's own model. `DeleteProjectInfoFields` is not the answer to this — it
removes a *custom* field entirely and will not touch the built-in ones.

## Verification

Live on AC29:

```
field   : PROJECTNAME
set to 'Tapir test value'   -> now: 'Tapir test value'
clear with ""               -> now: ''            PASS
set again to 'Back again'   -> now: 'Back again'
```

The third step matters: clearing does not leave the field in a state that
refuses later writes. The original value is restored afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
