### PR TITLE
GetNavigatorItemTree: allow selecting a publisher set by name

### DIFF
--- a/archicad-addon/Sources/NavigatorCommands.cpp
+++ b/archicad-addon/Sources/NavigatorCommands.cpp
@@ -1533,6 +1533,11 @@ GS::Optional<GS::UniString> GetNavigatorItemTreeCommand::GetInputParametersSchem
                 "type": "string",
                 "enum": ["PublicViewMap", "ProjectMap", "LayoutBook", "PublisherSets"],
                 "description": "The navigator map to retrieve."
+            },
+            "publisherSetName": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The name of the publisher set to retrieve. Used only when navigatorMapId is PublisherSets. Without it the first publisher set is returned."
             }
         },
         "additionalProperties": false,
@@ -1550,16 +1555,32 @@ GS::ObjectState GetNavigatorItemTreeCommand::Execute (const GS::ObjectState& par
     else if (navigatorMapIdStr == "LayoutBook")    mapId = API_LayoutMap;
     else if (navigatorMapIdStr == "PublisherSets") mapId = API_PublisherSets;
 
-    API_NavigatorSet navSet = {};
-    navSet.mapId = mapId;
-    Int32 idx = 0;
-    GSErrCode err = ACAPI_Navigator_GetNavigatorSet (&navSet, &idx);
-    if (err != NoError) {
-        return CreateErrorResponse (err, "Failed to get navigator set.");
+    API_Guid rootGuid = APINULLGuid;
+    if (mapId == API_PublisherSets && parameters.Contains ("publisherSetName")) {
+        // A project can hold several publisher sets, and the index passed to
+        // ACAPI_Navigator_GetNavigatorSet selects between them. Looking the
+        // set up by name lets the caller reach any of them, not just the first.
+        GS::UniString publisherSetName;
+        parameters.Get ("publisherSetName", publisherSetName);
+
+        const auto publisherSetNameGuidTable = GetPublisherSetNameGuidTable ();
+        if (!publisherSetNameGuidTable.ContainsKey (publisherSetName)) {
+            return CreateErrorResponse (Error, "Not valid publisher set name.");
+        }
+        rootGuid = publisherSetNameGuidTable.Get (publisherSetName);
+    } else {
+        API_NavigatorSet navSet = {};
+        navSet.mapId = mapId;
+        Int32 idx = 0;
+        GSErrCode err = ACAPI_Navigator_GetNavigatorSet (&navSet, &idx);
+        if (err != NoError) {
+            return CreateErrorResponse (err, "Failed to get navigator set.");
+        }
+        rootGuid = navSet.rootGuid;
     }
 
     API_NavigatorItem rootItem = {};
-    err = ACAPI_Navigator_GetNavigatorItem (&navSet.rootGuid, &rootItem);
+    GSErrCode err = ACAPI_Navigator_GetNavigatorItem (&rootGuid, &rootItem);
     if (err != NoError) {
         return CreateErrorResponse (err, "Failed to get root navigator item.");
     }


### PR DESCRIPTION
## The problem

`GetNavigatorItemTreeCommand::Execute` passes a hardcoded index to
`ACAPI_Navigator_GetNavigatorSet`:

```cpp
API_NavigatorSet navSet = {};
navSet.mapId = mapId;
Int32 idx = 0;
GSErrCode err = ACAPI_Navigator_GetNavigatorSet (&navSet, &idx);
```

The DevKit documents that parameter as *"Index of the required set. Used only
for Publisher Sets"*. So in a project with more than one publisher set, every
caller gets the **first** set's tree regardless of which set they wanted -
silently, because the response looks perfectly valid.

This also makes `selectedNavigatorItemIds` on `PublishPublisherSet` unusable in
practice. The navigator item ids come from the first set, the publish call
targets the named set, that set does not recognise them, and the **whole set is
published** instead of the selection. From the outside it looks like the
parameter is ignored - it took us a source read to find the real cause.

## The change

Adds an optional `publisherSetName` to `GetNavigatorItemTree`, resolved through
the `GetPublisherSetNameGuidTable ()` helper that `PublishPublisherSet` already
uses a few lines above in the same file. Behaviour without the parameter is
unchanged, so this is backwards compatible.

## Verification

Archicad 29 (build 3100, Norwegian), a project with 8 publisher sets, built
from this branch:

| call | root children |
|---|---|
| no `publisherSetName` | `Skisse/forprosjekt, Byggesøknad, Detaljprosjekt, Illustrasjoner` |
| `"Utskrift"` (first set) | same as above - confirming the old behaviour was always set #1 |
| `"Lagre som PDF"` | `0000-Bygningsnavn ARK Skisse/forprosjekt, ... Byggesøknad, ...` |
| `"Lagre som DWG"` | `0000 ARK DWG-eksport` |

End to end: publishing `"Lagre som PDF"` with `selectedNavigatorItemIds` taken
from that set's own tree produced **7 PDFs** (the selected branch) instead of
all **23** - which is what the same call produced before the fix.

Build is clean with `/W4 /WX` (`Visual Studio 18 2026`, `-T v143`, AC29).

## Note, not part of this PR

The root item of a publisher set tree comes back with `"name": "???"`, which is
why a caller cannot tell which set they received. Happy to look at that
separately if you consider it worth changing.
