### PR TITLE
CreateStairs z offset + finishVisible; reveal depth on window/door modify

### DIFF
--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -3710,6 +3710,7 @@ GS::Optional<GS::ObjectState> CreateStairsCommand::SetTypeSpecificParameters (AP
     parameters.Get ("zCoordinate", zCoordinate);
     const auto floorIndexAndOffset = ResolveFloorIndexAndOffset (parameters, "floorIndex", zCoordinate, stories);
     element.header.floorInd = floorIndexAndOffset.first;
+    element.stair.basePlane.basePoint.z = floorIndexAndOffset.second;
 
     auto totalHeight = GetOptionalDouble (parameters, "totalHeight");
     if (totalHeight.HasValue ()) {

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -3081,6 +3081,18 @@ bool ApplyWindowOrDoorDetails (API_Element& element, API_Element& mask, const GS
         ACAPI_ELEMENT_MASK_SET (mask, API_WindowType, openingBase.oSide);
         changed = true;
     }
+    bool reveal = false;
+    if (details.Get ("reveal", reveal)) {
+        element.window.reveal = reveal;
+        ACAPI_ELEMENT_MASK_SET (mask, API_WindowType, reveal);
+        changed = true;
+    }
+    auto revealDepthOffset = GetOptionalDouble (details, "revealDepthOffset");
+    if (revealDepthOffset.HasValue ()) {
+        element.window.revealDepthOffset = revealDepthOffset.Get ();
+        ACAPI_ELEMENT_MASK_SET (mask, API_WindowType, revealDepthOffset);
+        changed = true;
+    }
     return changed;
 }
 
@@ -6088,7 +6100,9 @@ GS::Optional<GS::UniString> ModifyWindowsCommand::GetInputParametersSchema () co
                         "centerOffset": { "type": "number", "minimum": 0.0 },
                         "reflected": { "type": "boolean" },
                         "refSide": { "type": "boolean" },
-                        "oSide": { "type": "boolean" }
+                        "oSide": { "type": "boolean" },
+                        "reveal": { "type": "boolean", "description": "Turn the reveal on or off." },
+                        "revealDepthOffset": { "type": "number", "description": "Distance the frame plane is moved across the wall thickness, along the wall normal." }
                     },
                     "additionalProperties": false,
                     "required": ["elementId"]
@@ -6168,7 +6182,9 @@ GS::Optional<GS::UniString> ModifyDoorsCommand::GetInputParametersSchema () cons
                         "centerOffset": { "type": "number", "minimum": 0.0 },
                         "reflected": { "type": "boolean" },
                         "refSide": { "type": "boolean" },
-                        "oSide": { "type": "boolean" }
+                        "oSide": { "type": "boolean" },
+                        "reveal": { "type": "boolean", "description": "Turn the reveal on or off." },
+                        "revealDepthOffset": { "type": "number", "description": "Distance the frame plane is moved across the wall thickness, along the wall normal." }
                     },
                     "additionalProperties": false,
                     "required": ["elementId"]

--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -3686,6 +3686,10 @@ GS::Optional<GS::UniString> CreateStairsCommand::GetInputParametersSchema () con
                             "type": "number",
                             "description": "Depth (going) of each tread.",
                             "exclusiveMinimum": 0.0
+                        },
+                        "finishVisible": {
+                            "type": "boolean",
+                            "description": "Optional. If false, the tread/riser finishes are hidden and only the stair structure (e.g. a monolith) is modeled."
                         }
                     },
                     "additionalProperties": false,
@@ -3711,6 +3715,15 @@ GS::Optional<GS::ObjectState> CreateStairsCommand::SetTypeSpecificParameters (AP
     const auto floorIndexAndOffset = ResolveFloorIndexAndOffset (parameters, "floorIndex", zCoordinate, stories);
     element.header.floorInd = floorIndexAndOffset.first;
     element.stair.basePlane.basePoint.z = floorIndexAndOffset.second;
+
+    bool finishVisible = true;
+    if (parameters.Get ("finishVisible", finishVisible)) {
+        element.stair.finishVisible = finishVisible;
+        for (int role = 0; role < API_StairPartRoleNum; ++role) {
+            element.stair.tread[role].visible = finishVisible;
+            element.stair.riser[role].visible = finishVisible;
+        }
+    }
 
     auto totalHeight = GetOptionalDouble (parameters, "totalHeight");
     if (totalHeight.HasValue ()) {

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateStairsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateStairsComponent.cs
@@ -29,7 +29,8 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             new Field("RiserHeights", "riserHeight", FieldKind.Number, "Height of the risers."),
             new Field("TreadDepths", "treadDepth", FieldKind.Number, "Depth of the treads."),
             new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the stair."),
-            new Field("FavoriteNames", "favoriteName", FieldKind.Text, "Name of a favorite to base the new element on. Its settings are applied first, then the other inputs override them.")
+            new Field("FavoriteNames", "favoriteName", FieldKind.Text, "Name of a favorite to base the new element on. Its settings are applied first, then the other inputs override them."),
+            new Field("FinishVisible", "finishVisible", FieldKind.Boolean, "If false, the tread/riser finishes are hidden and only the stair structure is modeled.")
         };
 
         protected override IReadOnlyList<Field> Fields => FieldDefinitions;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyDoorsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyDoorsComponent.cs
@@ -25,7 +25,9 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the door center from the beginning point of the owner wall."),
             new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the door on its vertical axis."),
             new Field("RefSide", "refSide", FieldKind.Boolean, "Place the door on the reference line side of the owner wall."),
-            new Field("OSide", "oSide", FieldKind.Boolean, "Place the door on the side opposite to the reference line of the owner wall.")
+            new Field("OSide", "oSide", FieldKind.Boolean, "Place the door on the side opposite to the reference line of the owner wall."),
+            new Field("Reveal", "reveal", FieldKind.Boolean, "Turn the reveal on or off."),
+            new Field("RevealDepthOffsets", "revealDepthOffset", FieldKind.Number, "Distance the frame plane is moved across the wall thickness, along the wall normal.")
         };
 
         protected override IReadOnlyList<Field> Fields => FieldDefinitions;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWindowsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWindowsComponent.cs
@@ -25,7 +25,9 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the window center from the beginning point of the owner wall."),
             new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the window on its vertical axis."),
             new Field("RefSide", "refSide", FieldKind.Boolean, "Place the window on the reference line side of the owner wall."),
-            new Field("OSide", "oSide", FieldKind.Boolean, "Place the window on the side opposite to the reference line of the owner wall.")
+            new Field("OSide", "oSide", FieldKind.Boolean, "Place the window on the side opposite to the reference line of the owner wall."),
+            new Field("Reveal", "reveal", FieldKind.Boolean, "Turn the reveal on or off."),
+            new Field("RevealDepthOffsets", "revealDepthOffset", FieldKind.Number, "Distance the frame plane is moved across the wall thickness, along the wall normal.")
         };
 
         protected override IReadOnlyList<Field> Fields => FieldDefinitions;


### PR DESCRIPTION
This PR fixes one bug and adds two small capabilities, in three commits, plus a fourth that keeps the Grasshopper components in step.

### 1. Bug fix: the z offset is resolved but never applied

`CreateStairsCommand::SetTypeSpecificParameters` calls `ResolveFloorIndexAndOffset (parameters, "floorIndex", zCoordinate, stories)` but only assigns `floorIndexAndOffset.first` (the floor index). The offset (`.second`) is dropped, so **every created stair sits exactly on its home story level**, regardless of `zCoordinate`. Any stair whose base is not exactly on a story plane (e.g. an exterior stair starting 1.9 m above the story, or an interior flight starting a few cm below the finished-floor level) is created at the wrong elevation.

The sibling commands apply their offset — `CreateSlabs` → `element.slab.level`, `CreateRoofs` → `element.roof.shellBase.level`, `CreateBeams` → `element.beam.level`. Stairs now do the same via `element.stair.basePlane.basePoint.z`.

Repro (Archicad 28, any project with a story at 0.00):

```json
{ "stairsData": [ {
  "baseLinePoints": [ {"x": 0, "y": 0}, {"x": 6, "y": 0} ],
  "zCoordinate": 1.0,
  "totalHeight": 3.0
} ] }
```

Before: the stair base is at 0.00. After: at 1.00. Verified on AC 28 / Windows with a collision probe against a slab placed at 0.2–0.5 m — a bbox check cannot show this, since stair bounding boxes come back z-degenerate (#563).

### 2. Feature: optional `finishVisible`

A created stair always carries the default tread/riser finishes; there is no way to request a bare (e.g. monolithic cast-in-place) stair through the JSON API. Changing the stair *tool default* beforehand does not help, because the element defaults fetched for the create do not carry the hierarchical sub-element settings.

This adds an optional boolean `finishVisible` to the `CreateStairs` input schema. When `false`, `element.stair.finishVisible` and the `tread[role].visible` / `riser[role].visible` flags are cleared, so only the stair structure is modeled. Omitted → unchanged behavior.

### 3. Feature: `reveal` + `revealDepthOffset` on ModifyWindows / ModifyDoors

The frame plane position across the wall thickness (`API_WindowType.reveal` + `revealDepthOffset`) is not reachable through the JSON API at all: windows and doors created via `CreateWindows`/`CreateDoors` always sit at the wall reference plane, and none of the ~900 GDL parameters of the library part move it (`refSide`/`oSide` only mirror). This exposes the two fields on `ModifyWindows` and `ModifyDoors`, through the shared `ApplyWindowOrDoorDetails` helper.

Behaviour is exactly linear — one metre of `revealDepthOffset` moves the frame one metre along the wall normal, sign depending on the wall's reference side — and width, height, sill height and elevation are untouched (verified by measuring floor-plan polygons).

### 4. Grasshopper components

`FinishVisible` on Create Stairs, `Reveal` + `RevealDepthOffsets` on Modify Windows and Modify Doors. Optional `Field` entries only, so existing definitions keep working.

---

The three add-on changes were verified on a complete Revit→Archicad conversion (8 stories, 503 walls, 187 windows, 220 doors, 12 stairs including U-shaped winder flights) on Archicad 28 / Windows, built with DevKit 28.3001 / VS2022 BuildTools / toolset v142. The other DevKit versions are covered only by this PR's build checks — happy to adjust if AC25/26 lack any of the fields used.
