### PR TITLE
CreateStairs: apply the resolved z offset instead of dropping it

### DIFF
--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -3710,6 +3710,7 @@ GS::Optional<GS::ObjectState> CreateStairsCommand::SetTypeSpecificParameters (AP
     parameters.Get ("zCoordinate", zCoordinate);
     const auto floorIndexAndOffset = ResolveFloorIndexAndOffset (parameters, "floorIndex", zCoordinate, stories);
     element.header.floorInd = floorIndexAndOffset.first;
+    element.stair.basePlane.basePoint.z = floorIndexAndOffset.second;
 
     auto totalHeight = GetOptionalDouble (parameters, "totalHeight");
     if (totalHeight.HasValue ()) {


### PR DESCRIPTION
`CreateStairsCommand::SetTypeSpecificParameters` calls `ResolveFloorIndexAndOffset (parameters, "floorIndex", zCoordinate, stories)` but only assigns `floorIndexAndOffset.first` (the floor index). The offset (`.second`) is dropped, so **every created stair sits exactly on its home story level**, regardless of `zCoordinate`.

Any stair whose base is not exactly on a story plane is affected — an exterior stair starting 1.9 m above the story, or an interior flight starting a few cm below the finished-floor level.

The sibling commands all apply their offset — `CreateSlabs` → `element.slab.level`, `CreateRoofs` → `element.roof.shellBase.level`, `CreateBeams` → `element.beam.level`, `CreateColumns` → `element.column.bottomOffset`. Stairs now do the same via `element.stair.basePlane.basePoint.z`.

### Repro (Archicad 28, any project with a story at 0.00)

```json
{ "stairsData": [ {
  "baseLinePoints": [ {"x": 0, "y": 0}, {"x": 6, "y": 0} ],
  "zCoordinate": 1.0,
  "totalHeight": 3.0
} ] }
```

Before: the stair base is at 0.00. After: at 1.00.

Verified on AC 28 / Windows (DevKit 28.3001, VS2022 BuildTools, toolset v142) with a collision probe against a slab placed at 0.2–0.5 m — a bounding-box check cannot show this, since stair bounding boxes come back z-degenerate (#563). Also exercised across a Revit→Archicad conversion with 12 stairs on 8 stories.


---

Note for whoever merges: #580 (`finishVisible`) touches the same function a few lines below this one-line change. They are independent, but whichever lands second needs a trivial rebase — happy to do it.
