### PR TITLE
CreateStairs: optional finishVisible for bare (structure-only) stairs

### DIFF
--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -3686,6 +3686,10 @@ GS::Optional<GS::UniString> CreateStairsCommand::GetInputParametersSchema () con
                             "type": "number",
                             "description": "Depth (going) of each tread.",
                             "exclusiveMinimum": 0.0
+                        },
+                        "finishVisible": {
+                            "type": "boolean",
+                            "description": "Optional. If false, the tread/riser finishes are hidden and only the stair structure (e.g. a monolith) is modeled."
                         }
                     },
                     "additionalProperties": false,
@@ -3710,6 +3714,15 @@ GS::Optional<GS::ObjectState> CreateStairsCommand::SetTypeSpecificParameters (AP
     parameters.Get ("zCoordinate", zCoordinate);
     const auto floorIndexAndOffset = ResolveFloorIndexAndOffset (parameters, "floorIndex", zCoordinate, stories);
     element.header.floorInd = floorIndexAndOffset.first;
+
+    bool finishVisible = true;
+    if (parameters.Get ("finishVisible", finishVisible)) {
+        element.stair.finishVisible = finishVisible;
+        for (int role = 0; role < API_StairPartRoleNum; ++role) {
+            element.stair.tread[role].visible = finishVisible;
+            element.stair.riser[role].visible = finishVisible;
+        }
+    }
 
     auto totalHeight = GetOptionalDouble (parameters, "totalHeight");
     if (totalHeight.HasValue ()) {

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateStairsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateStairsComponent.cs
@@ -29,7 +29,8 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             new Field("RiserHeights", "riserHeight", FieldKind.Number, "Height of the risers."),
             new Field("TreadDepths", "treadDepth", FieldKind.Number, "Depth of the treads."),
             new Field("FloorIndices", "floorIndex", FieldKind.Integer, "Home story index of the stair."),
-            new Field("FavoriteNames", "favoriteName", FieldKind.Text, "Name of a favorite to base the new element on. Its settings are applied first, then the other inputs override them.")
+            new Field("FavoriteNames", "favoriteName", FieldKind.Text, "Name of a favorite to base the new element on. Its settings are applied first, then the other inputs override them."),
+            new Field("FinishVisible", "finishVisible", FieldKind.Boolean, "If false, the tread/riser finishes are hidden and only the stair structure is modeled.")
         };
 
         protected override IReadOnlyList<Field> Fields => FieldDefinitions;


### PR DESCRIPTION
A created stair always carries the default tread/riser finishes; there is no way to request a bare (e.g. monolithic cast-in-place) stair through the JSON API.

Changing the stair *tool default* beforehand does not help either, because the element defaults fetched for the create do not carry the hierarchical sub-element settings — the same reason `ApplyFavoritesToElementDefaults` with a stair favorite has no effect on subsequently created stairs (#576).

This adds an optional boolean `finishVisible` to the `CreateStairs` input schema. When `false`, `element.stair.finishVisible` and the `tread[role].visible` / `riser[role].visible` flags are cleared for both part roles, so only the stair structure is modeled. Omitted → unchanged behavior.

The second commit adds the matching `FinishVisible` input to the Create Stairs Grasshopper component. It is an optional `Field` entry, so existing definitions keep working.

Verified on Archicad 28 / Windows (DevKit 28.3001, VS2022 BuildTools, toolset v142), across a Revit→Archicad conversion with 12 stairs including U-shaped winder flights. The other DevKit versions are covered only by this PR's build checks — happy to guard the code if AC25/26 lack `API_StairPartRoleNum` or the `finishVisible` field.


---

Note for whoever merges: #579 (the `CreateStairs` z-offset bug fix) touches the same function a few lines above this change. They are independent, but whichever lands second needs a trivial rebase — happy to do it.
