### PR TITLE
ModifyWindows / ModifyDoors: expose reveal and revealDepthOffset

### DIFF
--- a/archicad-addon/Sources/ExtendedElementCommands.cpp
+++ b/archicad-addon/Sources/ExtendedElementCommands.cpp
@@ -3081,6 +3081,18 @@ bool ApplyWindowOrDoorDetails (API_Element& element, API_Element& mask, const GS
         ACAPI_ELEMENT_MASK_SET (mask, API_WindowType, openingBase.oSide);
         changed = true;
     }
+    bool reveal = false;
+    if (details.Get ("reveal", reveal)) {
+        element.window.reveal = reveal;
+        ACAPI_ELEMENT_MASK_SET (mask, API_WindowType, reveal);
+        changed = true;
+    }
+    auto revealDepthOffset = GetOptionalDouble (details, "revealDepthOffset");
+    if (revealDepthOffset.HasValue ()) {
+        element.window.revealDepthOffset = revealDepthOffset.Get ();
+        ACAPI_ELEMENT_MASK_SET (mask, API_WindowType, revealDepthOffset);
+        changed = true;
+    }
     return changed;
 }
 
@@ -6074,7 +6086,9 @@ GS::Optional<GS::UniString> ModifyWindowsCommand::GetInputParametersSchema () co
                         "centerOffset": { "type": "number", "minimum": 0.0 },
                         "reflected": { "type": "boolean" },
                         "refSide": { "type": "boolean" },
-                        "oSide": { "type": "boolean" }
+                        "oSide": { "type": "boolean" },
+                        "reveal": { "type": "boolean", "description": "Turn the reveal on or off." },
+                        "revealDepthOffset": { "type": "number", "description": "Distance the frame plane is moved across the wall thickness, along the wall normal." }
                     },
                     "additionalProperties": false,
                     "required": ["elementId"]
@@ -6154,7 +6168,9 @@ GS::Optional<GS::UniString> ModifyDoorsCommand::GetInputParametersSchema () cons
                         "centerOffset": { "type": "number", "minimum": 0.0 },
                         "reflected": { "type": "boolean" },
                         "refSide": { "type": "boolean" },
-                        "oSide": { "type": "boolean" }
+                        "oSide": { "type": "boolean" },
+                        "reveal": { "type": "boolean", "description": "Turn the reveal on or off." },
+                        "revealDepthOffset": { "type": "number", "description": "Distance the frame plane is moved across the wall thickness, along the wall normal." }
                     },
                     "additionalProperties": false,
                     "required": ["elementId"]

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyDoorsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyDoorsComponent.cs
@@ -25,7 +25,9 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the door center from the beginning point of the owner wall."),
             new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the door on its vertical axis."),
             new Field("RefSide", "refSide", FieldKind.Boolean, "Place the door on the reference line side of the owner wall."),
-            new Field("OSide", "oSide", FieldKind.Boolean, "Place the door on the side opposite to the reference line of the owner wall.")
+            new Field("OSide", "oSide", FieldKind.Boolean, "Place the door on the side opposite to the reference line of the owner wall."),
+            new Field("Reveal", "reveal", FieldKind.Boolean, "Turn the reveal on or off."),
+            new Field("RevealDepthOffsets", "revealDepthOffset", FieldKind.Number, "Distance the frame plane is moved across the wall thickness, along the wall normal.")
         };
 
         protected override IReadOnlyList<Field> Fields => FieldDefinitions;

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWindowsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/ModifyWindowsComponent.cs
@@ -25,7 +25,9 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             new Field("CenterOffsets", "centerOffset", FieldKind.Number, "Distance of the window center from the beginning point of the owner wall."),
             new Field("Reflected", "reflected", FieldKind.Boolean, "Mirror the window on its vertical axis."),
             new Field("RefSide", "refSide", FieldKind.Boolean, "Place the window on the reference line side of the owner wall."),
-            new Field("OSide", "oSide", FieldKind.Boolean, "Place the window on the side opposite to the reference line of the owner wall.")
+            new Field("OSide", "oSide", FieldKind.Boolean, "Place the window on the side opposite to the reference line of the owner wall."),
+            new Field("Reveal", "reveal", FieldKind.Boolean, "Turn the reveal on or off."),
+            new Field("RevealDepthOffsets", "revealDepthOffset", FieldKind.Number, "Distance the frame plane is moved across the wall thickness, along the wall normal.")
         };
 
         protected override IReadOnlyList<Field> Fields => FieldDefinitions;


### PR DESCRIPTION
The frame plane position across the wall thickness (`API_WindowType.reveal` + `revealDepthOffset`) is not reachable through the JSON API at all: windows and doors created via `CreateWindows`/`CreateDoors` always sit at the wall reference plane, and none of the ~900 GDL parameters of the library part move it (`refSide`/`oSide` only mirror).

This exposes the two fields on `ModifyWindows` and `ModifyDoors` through the shared `ApplyWindowOrDoorDetails` helper, so they follow the same optional-field pattern as `refSide`/`oSide` next to them.

Behaviour is exactly linear — one metre of `revealDepthOffset` moves the frame one metre along the wall normal, sign depending on the wall's reference side — and width, height, sill height and elevation are untouched (verified by measuring floor-plan polygons).

The second commit adds the matching `Reveal` and `RevealDepthOffsets` inputs to the Modify Windows and Modify Doors Grasshopper components. Optional `Field` entries, so existing definitions keep working.

Verified on Archicad 28 / Windows (DevKit 28.3001, VS2022 BuildTools, toolset v142), across a Revit→Archicad conversion with 187 windows and 220 doors. The other DevKit versions are covered only by this PR's build checks.
