### PR TITLE
Read and extend a property's possibleEnumValues (#589)

### DIFF
--- a/archicad-addon/Examples/add_enum_values_to_property.py
+++ b/archicad-addon/Examples/add_enum_values_to_property.py
@@ -1,0 +1,59 @@
+import aclib
+
+# An enumeration property's option list can be extended after the fact: values already on
+# the property keep their identifier, so the values elements have stored stay assigned.
+# GetAllProperties reports the current option list back, which is what lets a caller notice
+# that a project has drifted from the definition it ships (#589).
+
+GROUP_NAME = 'Tapir Example'
+PROPERTY_NAME = 'Schedule'
+
+
+def FindProperty ():
+    for property in aclib.RunTapirCommand ('GetAllProperties', {}, debug = False)['properties']:
+        if property['propertyGroupName'] == GROUP_NAME and property['propertyName'] == PROPERTY_NAME:
+            return property
+    return None
+
+
+def PrintEnumValues (label, property):
+    values = property.get ('possibleEnumValues', [])
+    print ('{}: {}'.format (label, [v['enumValue']['displayValue'] for v in values]))
+    return values
+
+
+property = FindProperty ()
+if property is None:
+    print ('Create a "{}/{}" singleEnum property first - this example only extends an existing one.'.format (
+        GROUP_NAME, PROPERTY_NAME))
+    raise SystemExit (0)
+
+before = PrintEnumValues ('Before', property)
+
+aclib.RunTapirCommand ('UpdatePropertyDefinitions', {
+    'propertyDefinitions': [
+        {
+            'propertyId': property['propertyId'],
+            'possibleEnumValues': [
+                {
+                    'enumValue': {
+                        'displayValue': 'SKYLIGHT SCHEDULE',
+                        'nonLocalizedValue': 'SKYLIGHT'
+                    }
+                }
+            ]
+        }
+    ]
+})
+
+after = PrintEnumValues ('After ', FindProperty ())
+
+# The identifiers of the values which were already there must not change - an element which
+# stored one of them refers to it by that identifier.
+def IdsByDisplayValue (values):
+    return {v['enumValue']['displayValue']: v['enumValue']['enumValueId']['guid'] for v in values}
+
+idsBefore = IdsByDisplayValue (before)
+idsAfter = IdsByDisplayValue (after)
+kept = all (idsBefore[name] == idsAfter.get (name) for name in idsBefore)
+print ('Existing values kept their identifier: {}'.format (kept))

--- a/archicad-addon/Sources/PropertyCommands.cpp
+++ b/archicad-addon/Sources/PropertyCommands.cpp
@@ -98,6 +98,24 @@ static API_Guid GetRandomGuid ()
     return GSGuid2APIGuid (guid);
 }
 
+// The enumValue shape shared by CreatePropertyDefinitions, UpdatePropertyDefinitions and
+// GetAllProperties - see PossibleEnumValues in CommonSchemaDefinitions.json.
+static GS::ObjectState CreateEnumValueObjectState (const API_SingleEnumerationVariant& variant)
+{
+    GS::ObjectState enumValue;
+    enumValue.Add ("displayValue", variant.displayVariant.uniStringValue);
+    if (variant.nonLocalizedValue.HasValue ()) {
+        enumValue.Add ("nonLocalizedValue", *variant.nonLocalizedValue);
+    }
+
+    GS::ObjectState enumValueId;
+    enumValueId.Add ("type", GS::UniString ("guid"));
+    enumValueId.Add ("guid", APIGuidToString (variant.keyVariant.guidValue));
+    enumValue.Add ("enumValueId", enumValueId);
+
+    return GS::ObjectState ("enumValue", enumValue);
+}
+
 static API_Guid FindEnumValueGuid (const GS::Array<API_SingleEnumerationVariant>& possibleEnumValues,
                                    const GS::UniString& enumValueIdTypeStr,
                                    const GS::UniString& valueStr)
@@ -211,6 +229,13 @@ GS::ObjectState GetAllPropertiesCommand::Execute (const GS::ObjectState& /*param
             details.Add ("propertyMeasureType", GetPropertyTypeString (definition.measureType));
             details.Add ("propertyIsEditable", definition.canValueBeEditable);
             details.Add ("isExpressionBased", definition.defaultValue.hasExpression);
+
+            if (!definition.possibleEnumValues.IsEmpty ()) {
+                const auto& enumValueList = details.AddList<GS::ObjectState> ("possibleEnumValues");
+                for (const API_SingleEnumerationVariant& variant : definition.possibleEnumValues) {
+                    enumValueList (CreateEnumValueObjectState (variant));
+                }
+            }
             if (definition.defaultValue.hasExpression) {
                 const auto& expressionList = details.AddList<GS::UniString> ("expressions");
                 for (const GS::UniString& expr : definition.defaultValue.propertyExpressions) {
@@ -1407,7 +1432,7 @@ GS::Optional<GS::UniString> UpdatePropertyDefinitionsCommand::GetInputParameters
         "properties": {
             "propertyDefinitions": {
                 "type": "array",
-                "description": "The list of expression-based property definitions to update.",
+                "description": "The property definitions to update.",
                 "items": {
                     "type": "object",
                     "properties": {
@@ -1416,17 +1441,20 @@ GS::Optional<GS::UniString> UpdatePropertyDefinitionsCommand::GetInputParameters
                         },
                         "expressions": {
                             "type": "array",
-                            "description": "The new expression strings for the property.",
+                            "description": "The new expression strings for the property. Only for expression-based properties.",
                             "items": {
                                 "type": "string"
                             },
                             "minItems": 1
+                        },
+                        "possibleEnumValues": {
+                            "$ref": "#/PossibleEnumValues",
+                            "description": "The enum values to add to an enumeration property. Values already on the property keep their identifier, so element values assigned to them survive; values not listed here are kept as well."
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "propertyId",
-                        "expressions"
+                        "propertyId"
                     ]
                 }
             }
@@ -1477,14 +1505,77 @@ GS::ObjectState UpdatePropertyDefinitionsCommand::Execute (const GS::ObjectState
                 continue;
             }
 
-            if (!definition.defaultValue.hasExpression) {
-                executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "property is not expression-based"));
+            GS::Array<GS::ObjectState> possibleEnumValues;
+            const bool hasEnumValues = item.Get ("possibleEnumValues", possibleEnumValues);
+            GS::Array<GS::UniString> expressions;
+            const bool hasExpressions = item.Get ("expressions", expressions);
+
+            if (!hasEnumValues && !hasExpressions) {
+                executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "expressions or possibleEnumValues is missing"));
                 continue;
             }
 
-            GS::Array<GS::UniString> expressions;
-            item.Get ("expressions", expressions);
-            definition.defaultValue.propertyExpressions = expressions;
+            if (hasExpressions) {
+                if (!definition.defaultValue.hasExpression) {
+                    executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "property is not expression-based"));
+                    continue;
+                }
+
+                definition.defaultValue.propertyExpressions = expressions;
+            }
+
+            if (hasEnumValues) {
+                if (definition.collectionType != API_PropertySingleChoiceEnumerationCollectionType &&
+                    definition.collectionType != API_PropertyMultipleChoiceEnumerationCollectionType) {
+                    executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "property is not an enumeration"));
+                    continue;
+                }
+
+                // Existing values are left exactly as they are - element values reference an
+                // enum value by its keyVariant guid, so regenerating those would detach every
+                // stored value. Only values which are not on the property yet are appended.
+                bool badValue = false;
+                for (const GS::ObjectState& e : possibleEnumValues) {
+                    const GS::ObjectState* enumValue = e.Get ("enumValue");
+                    if (enumValue == nullptr) {
+                        badValue = true;
+                        break;
+                    }
+
+                    API_SingleEnumerationVariant variant;
+                    variant.displayVariant.type = definition.valueType;
+                    variant.keyVariant.type = API_PropertyGuidValueType;
+
+                    if (!enumValue->Get ("displayValue", variant.displayVariant.uniStringValue)) {
+                        badValue = true;
+                        break;
+                    }
+
+                    GS::UniString nonLocalizedValueStr;
+                    if (enumValue->Get ("nonLocalizedValue", nonLocalizedValueStr)) {
+                        variant.nonLocalizedValue = nonLocalizedValueStr;
+                    }
+
+                    const GS::UniString& matchOn = variant.nonLocalizedValue.HasValue ()
+                        ? *variant.nonLocalizedValue
+                        : variant.displayVariant.uniStringValue;
+                    const GS::UniString matchType = variant.nonLocalizedValue.HasValue ()
+                        ? "nonLocalizedValue"
+                        : "displayValue";
+
+                    if (FindEnumValueGuid (definition.possibleEnumValues, matchType, matchOn) != APINULLGuid) {
+                        continue;
+                    }
+
+                    variant.keyVariant.guidValue = GetRandomGuid ();
+                    definition.possibleEnumValues.Push (variant);
+                }
+
+                if (badValue) {
+                    executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "an enumValue is missing or has no displayValue"));
+                    continue;
+                }
+            }
 
             GSErrCode err = ACAPI_Property_ChangePropertyDefinition (definition);
             if (err != NoError) {

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -2511,6 +2511,9 @@
         "type": "object",
         "description": "The details of the property.",
         "properties": {
+            "possibleEnumValues": {
+                "$ref": "#/PossibleEnumValues"
+            },
             "propertyId": {
                 "$ref": "#/PropertyId"
             },
@@ -6889,25 +6892,7 @@
             "propertyGroup"
         ]
     },
-    "PropertyDefinition": {
-        "type": "object",
-        "properties": {
-            "name": {
-                "type": "string"
-            },
-            "description": {
-                "type": "string"
-            },
-            "type": {
-                "$ref": "#/PropertyDataType"
-            },
-            "isEditable": {
-                "type": "boolean"
-            },
-            "defaultValue": {
-                "$ref": "#/PropertyDefaultValue"
-            },
-            "possibleEnumValues": {
+    "PossibleEnumValues": {
                 "type": "array",
                 "description": "The possible enum values of the property when the property type is enumeration.",
                 "items": {
@@ -6940,6 +6925,27 @@
                         "enumValue"
                     ]
                 }
+            },
+    "PropertyDefinition": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "description": {
+                "type": "string"
+            },
+            "type": {
+                "$ref": "#/PropertyDataType"
+            },
+            "isEditable": {
+                "type": "boolean"
+            },
+            "defaultValue": {
+                "$ref": "#/PropertyDefaultValue"
+            },
+            "possibleEnumValues": {
+                "$ref": "#/PossibleEnumValues"
             },
             "availability": {
                 "type": "array",


### PR DESCRIPTION
Fixes #589. Both halves of it — @sprtic1 asked in the thread whether the read
side was in scope, and it is: without it you cannot tell which projects have
drifted, so the write alone would still mean opening Property Manager in each
one to find out where to write.

## Read

`GetAllProperties` now reports `possibleEnumValues` for enumeration properties,
in the same `enumValue` shape `CreatePropertyDefinitions` already accepts, plus
the value's `enumValueId` so a caller can tell two identically-named values
apart.

## Write

`UpdatePropertyDefinitions` accepts `possibleEnumValues` alongside (or instead
of) `expressions`. It is **additive**:

- a value already on the property is matched by `nonLocalizedValue`, or by
  `displayValue` when it has none, and left completely untouched;
- values on the property that the call does not mention are kept;
- only genuinely new values are appended, with a fresh identifier.

That matters for the reason the triage comment flagged: an element's stored
value refers to an enum value **by its `keyVariant` guid**. Regenerating the
existing values' guids would detach every stored value in the project, which is
the same damage as delete-and-recreate. So the existing entries are carried
across untouched rather than rebuilt.

`expressions` keeps its old behaviour and still requires an expression-based
property; `possibleEnumValues` requires an enumeration. Sending neither is now
an error that names both, rather than the old blanket
`property is not expression-based`.

The `enumValue` shape is now a single `PossibleEnumValues` definition in
`CommonSchemaDefinitions.json`, referenced from `PropertyDefinition`,
`PropertyDetails` and the update input, instead of a copy per command.

## Status: built, **not** live-verified

Compiles on AC29. I could not run it, and I want to be precise about why rather
than imply it is tested:

The scratch project has 1802 properties and **zero** enumeration properties, so
there was nothing to read or extend, and I could not create one to test
against: `CreatePropertyDefinitions` refuses a `singleEnum` in that project with
`failed to create the property` from `ACAPI_Property_CreatePropertyDefinition`
itself, after the schema validation passes. That is the existing create command,
untouched by this branch, but it blocked the fixture.

So the two things a maintainer with a real project should check are exactly the
two claims above:

1. after adding a value, an element that had one of the **old** values still
   reports it — this is the one that matters, and the one the triage comment
   said needed a seat;
2. `GetAllProperties` lists the full option list, and the identifiers of the
   pre-existing values are unchanged across the update.

`archicad-addon/Examples/add_enum_values_to_property.py` does both checks and
prints the verdict; it needs an existing `Tapir Example / Schedule` singleEnum
property to run against.

No new command, so no `AddOnMain.cpp` registration and no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
