### PR TITLE
Drop an include nothing uses

### DIFF
--- a/archicad-addon/Sources/IFCCommands.cpp
+++ b/archicad-addon/Sources/IFCCommands.cpp
@@ -3,7 +3,6 @@
 #include "StringConversion.hpp"
 
 #ifdef ServerMainVers_2800
-#include "ACAPI/IFCAssignments.hpp"
 #include "ACAPI/IFCAttribute.hpp"
 #include "ACAPI/IFCObjectAccessor.hpp"
 #include "ACAPI/IFCObjectID.hpp"


### PR DESCRIPTION
A deliberately small cleanup, and I want to be straight about why it is small
rather than pad it.

## What is in it

`IFCCommands.cpp` included `ACAPI/IFCAssignments.hpp` but never named
`Assignments`. That file reads IFC objects and properties; it does not touch the
assignment tree. The stray include has already misled a reader once — the triage
on #590 cited it as a hint that an IFC write path might live there.

Built against **AC29 and AC25**, so both sides of the `ServerMainVers_2800`
guard.

## What I deliberately did not do

**The biggest cleanup in the add-on collides with every open PR.** Manual
`BMKillHandle` cleanup repeated on every early return:

| file | occurrences | touched by |
|---|---|---|
| `ProjectCommands.cpp` | 21 | #574 |
| `ExtendedElementCommands.cpp` | 13 | #463, #587 |

Both are the same pattern — a handle freed by hand at each of a dozen exits,
which is a leak waiting for the next `return` someone adds. `GS::OnExit` is
already used elsewhere in the codebase (`CalculateStairBounds`) and would remove
the whole class. But rewriting the exits of `SetStories` while #574 rewrites its
body would hand a conflict to a branch that is mid-review, and the same for
`ExtendedElementCommands.cpp` against #463 and #587.

That is worth doing **after those land**, not now.

**Things that look like cleanup and are not:**

- `ACAPI/IFCAttribute.hpp` in the same file looks equally unused by a token
  search. It is not: `GetAttributes` returns `std::vector<Attribute>` and
  iterating it needs the complete type.
- `CollectCutFillPolygons` in `ElementCommands.cpp` reads as dead — it is passed
  as a callback to `ACAPI_Element_ShapePrimsExt`, under a version guard.
- The `ACAPI/MEP*.hpp` includes in `MEPCommands.cpp` (13 of them) all resolve to
  types spelled differently from their header names.

Each of those would have compiled fine on AC29 and broken something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
