### PR TITLE
Fix what the review found on #596

### DIFF
--- a/archicad-addon/Examples/add_enum_values_to_property.py
+++ b/archicad-addon/Examples/add_enum_values_to_property.py
@@ -24,8 +24,12 @@ def PrintEnumValues (label, property):
 
 property = FindProperty ()
 if property is None:
-    print ('Create a "{}/{}" singleEnum property first - this example only extends an existing one.'.format (
+    # test_examples.py runs every example against TestProject.pla and pins whatever it
+    # prints, so say plainly that nothing was tested rather than printing a hint that
+    # reads like a passing run.
+    print ('SKIPPED: no "{}/{}" singleEnum property in this project, so nothing was extended.'.format (
         GROUP_NAME, PROPERTY_NAME))
+    print ('Create one in Property Manager to exercise this example.')
     raise SystemExit (0)
 
 before = PrintEnumValues ('Before', property)

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -654,7 +654,7 @@ GSErrCode Initialize (void)
         );
         err |= RegisterCommand<UpdatePropertyDefinitionsCommand> (
             propertyCommands, "1.5.4",
-            "Updates the expression(s) of existing expression-based Custom Property Definitions."
+            "Updates existing Custom Property Definitions: the expression(s) of an expression-based property, or the possible enum values of an enumeration property."
         );
         AddCommandGroup (propertyCommands);
     }

--- a/archicad-addon/Sources/PropertyCommands.cpp
+++ b/archicad-addon/Sources/PropertyCommands.cpp
@@ -108,10 +108,9 @@ static GS::ObjectState CreateEnumValueObjectState (const API_SingleEnumerationVa
         enumValue.Add ("nonLocalizedValue", *variant.nonLocalizedValue);
     }
 
-    GS::ObjectState enumValueId;
-    enumValueId.Add ("type", GS::UniString ("guid"));
-    enumValueId.Add ("guid", APIGuidToString (variant.keyVariant.guidValue));
-    enumValue.Add ("enumValueId", enumValueId);
+    // Not enumValueId: that is a oneOf over displayValue / nonLocalizedValue, so a guid
+    // does not validate as one and a value read here could not be sent back.
+    enumValue.Add ("guid", APIGuidToString (variant.keyVariant.guidValue));
 
     return GS::ObjectState ("enumValue", enumValue);
 }
@@ -1448,7 +1447,7 @@ GS::Optional<GS::UniString> UpdatePropertyDefinitionsCommand::GetInputParameters
                             "minItems": 1
                         },
                         "possibleEnumValues": {
-                            "$ref": "#/PossibleEnumValues",
+                            "$ref": "#/EnumValuesToAdd",
                             "description": "The enum values to add to an enumeration property. Values already on the property keep their identifier, so element values assigned to them survive; values not listed here are kept as well."
                         }
                     },
@@ -1556,14 +1555,17 @@ GS::ObjectState UpdatePropertyDefinitionsCommand::Execute (const GS::ObjectState
                         variant.nonLocalizedValue = nonLocalizedValueStr;
                     }
 
-                    const GS::UniString& matchOn = variant.nonLocalizedValue.HasValue ()
-                        ? *variant.nonLocalizedValue
-                        : variant.displayVariant.uniStringValue;
-                    const GS::UniString matchType = variant.nonLocalizedValue.HasValue ()
-                        ? "nonLocalizedValue"
-                        : "displayValue";
+                    // Matched on both keys, not just the one the incoming value happens to
+                    // carry: a value already on the property as {displayValue: "Door"} which
+                    // is sent again with a nonLocalizedValue added has to match the existing
+                    // entry, or it is appended a second time and the property ends up with
+                    // two options reading "Door".
+                    const bool alreadyThere =
+                        (variant.nonLocalizedValue.HasValue () &&
+                         FindEnumValueGuid (definition.possibleEnumValues, "nonLocalizedValue", *variant.nonLocalizedValue) != APINULLGuid) ||
+                        FindEnumValueGuid (definition.possibleEnumValues, "displayValue", variant.displayVariant.uniStringValue) != APINULLGuid;
 
-                    if (FindEnumValueGuid (definition.possibleEnumValues, matchType, matchOn) != APINULLGuid) {
+                    if (alreadyThere) {
                         continue;
                     }
 

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -6893,80 +6893,84 @@
         ]
     },
     "PossibleEnumValues": {
-                "type": "array",
-                "description": "The possible enum values of the property when the property type is enumeration.",
-                "items": {
+        "type": "array",
+        "description": "The possible enum values of the property when the property type is enumeration.",
+        "items": {
+            "type": "object",
+            "properties": {
+                "enumValue": {
                     "type": "object",
+                    "description": "The description of an enumeration value.",
                     "properties": {
-                        "enumValue": {
-                            "type": "object",
-                            "description": "The description of an enumeration value.",
-                            "properties": {
-                                "enumValueId": {
-                                    "$ref": "#/EnumValueId"
-                                },
-                                "displayValue": {
-                                    "type": "string",
-                                    "description": "Displayed value of the enumeration."
-                                },
-                                "nonLocalizedValue": {
-                                    "type": "string",
-                                    "description": "Nonlocalized value of the enumeration if there is one."
-                                }
-                            },
-                            "additionalProperties": false,
-                            "required": [
-                                "displayValue"
-                            ]
+                        "enumValueId": {
+                            "$ref": "#/EnumValueId"
+                        },
+                "guid": {
+                    "$ref": "#/Guid",
+                    "description": "The identifier of the enumeration value, as reported by GetAllProperties. An element's stored value refers to the value by this."
+                },
+                        "displayValue": {
+                            "type": "string",
+                            "description": "Displayed value of the enumeration."
+                        },
+                        "nonLocalizedValue": {
+                            "type": "string",
+                            "description": "Nonlocalized value of the enumeration if there is one."
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "enumValue"
+                        "displayValue"
                     ]
                 }
+            },
+            "additionalProperties": false,
+            "required": [
+                "enumValue"
+            ]
+        }
             },
     "PropertyDefinition": {
         "type": "object",
         "properties": {
             "name": {
-                "type": "string"
+        "type": "string"
             },
             "description": {
-                "type": "string"
+        "type": "string"
             },
             "type": {
-                "$ref": "#/PropertyDataType"
+        "$ref": "#/PropertyDataType"
             },
             "isEditable": {
-                "type": "boolean"
+        "type": "boolean"
             },
             "defaultValue": {
-                "$ref": "#/PropertyDefaultValue"
+        "$ref": "#/PropertyDefaultValue"
             },
             "possibleEnumValues": {
-                "$ref": "#/PossibleEnumValues"
+        "$ref": "#/PossibleEnumValues"
             },
             "availability": {
-                "type": "array",
-                "description": "The identifiers of classification items the new property is available for.",
-                "items": {
-                    "$ref": "#/ClassificationItemIdArrayItem"
-                }
+        "type": "array",
+        "description": "The identifiers of classification items the new property is available for.",
+        "items": {
+            "$ref": "#/ClassificationItemIdArrayItem"
+        }
             },
             "group": {
-                "type": "object",
-                "description": "The property group defined by name or id. If both fields exists the id will be used.",
-                "properties": {
-                    "propertyGroupId": {
-                        "$ref": "#/PropertyGroupId"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "required": []
+        "type": "object",
+        "description": "The property group defined by name or id. If both fields exists the id will be used.",
+        "properties": {
+            "propertyGroupId": {
+                "$ref": "#/PropertyGroupId"
+            },
+            "name": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": []
             }
         },
         "additionalProperties": false,
@@ -6979,6 +6983,37 @@
             "group"
         ]
 
+    },
+    "EnumValuesToAdd": {
+        "type": "array",
+        "description": "Enumeration values to add to a property.",
+        "items": {
+            "type": "object",
+            "properties": {
+                "enumValue": {
+                    "type": "object",
+                    "description": "The description of an enumeration value.",
+                    "properties": {
+                        "displayValue": {
+                            "type": "string",
+                            "description": "Displayed value of the enumeration."
+                        },
+                        "nonLocalizedValue": {
+                            "type": "string",
+                            "description": "Nonlocalized value of the enumeration if there is one."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "displayValue"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "enumValue"
+            ]
+        }
     },
     "PropertyDefinitionArrayItem": {
         "description": "A wrapper containing a property definition",


### PR DESCRIPTION
The review on #596 was right on every count, and #596 was auto-merged seven
minutes after it said "Not ready to merge" — so this fixes the findings on
`main`.

## The one that mattered

**Matching was one-sided**, which defeated the point of the change. A value
already on the property as `{displayValue: "Door"}` with no
`nonLocalizedValue`, sent again with one added, was looked up by
`nonLocalizedValue` only, missed, and appended — leaving two options both
reading "Door" in the UI. Both keys are checked now, so *values already there
are left untouched* holds in both directions.

## The rest

- **`enumValueId` shape** — it is a `oneOf` over `displayValue` /
  `nonLocalizedValue`, and the read side emitted `{"type":"guid","guid":...}`,
  which validates as neither. A value read from `GetAllProperties` could not be
  fed back into a write command. The identifier is now its own `guid` field.
- **Input accepted an identifier it ignored** — the update took
  `PossibleEnumValues`, which carries `enumValueId`, and always assigned a fresh
  guid. It now takes a new `EnumValuesToAdd` with no identifier fields, so there
  is nothing to silently drop.
- **Registered description** in `AddOnMain.cpp` still described the old
  expressions-only command; the generated docs come from it.
- **Indentation** of the moved `PossibleEnumValues` block.
- **The example** printed a hint that `test_examples.py` would have pinned as a
  golden looking like a passing run. It says `SKIPPED:` now.

## Not done, deliberately

`GetAllPropertiesComponent` gains no enum-values output. It exposes ids and
names only, and already omits seven other `PropertyDetails` fields
(`propertyType`, `propertyValueType`, `isExpressionBased`, …), so surfacing
exactly one of them is arbitrary. Exposing that response properly in Grasshopper
is its own change.

## Still unverified, and now I know why

The behaviour claims — existing values keep their guid, elements keep their
stored value — are still untested. `CreatePropertyDefinitions` **cannot create
any property** in the scratch project: a `singleEnum` fails with
`-2130313112` and a plain `string` property with `-2130313104`, both from
`ACAPI_Property_CreatePropertyDefinition` after schema validation passes, with
the property group created successfully first. That is unrelated to this branch
and looks like its own bug, but it is what blocks the fixture.

Built on AC29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
