### PR TITLE
Take slab outlines and voids as curves (#582)

### DIFF
--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/CreateElementsComponentBase.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/CreateElementsComponentBase.cs
@@ -42,7 +42,14 @@ namespace TapirGrasshopperPlugin.Components
             ElementGuid,
             AttributeGuid,
             PointsTree2D,
-            PointsTree3D
+            PointsTree3D,
+            // A closed curve per element, written as polygonCoordinates plus the
+            // polygonArcs of its arc segments. Its JsonKey names the coordinate
+            // field; the arcs go next to it under polygonArcs.
+            OutlineCurve,
+            // One branch of closed curves per element, written as the element's
+            // holes - each hole an object of polygonCoordinates and polygonArcs.
+            HoleCurvesTree
         }
 
         protected sealed class Field
@@ -151,6 +158,20 @@ namespace TapirGrasshopperPlugin.Components
                             description,
                             GH_ParamAccess.tree);
                         break;
+                    case FieldKind.OutlineCurve:
+                        inManager.AddCurveParameter(
+                            field.InputName,
+                            field.InputName,
+                            description,
+                            GH_ParamAccess.list);
+                        break;
+                    case FieldKind.HoleCurvesTree:
+                        inManager.AddCurveParameter(
+                            field.InputName,
+                            field.InputName,
+                            description,
+                            GH_ParamAccess.tree);
+                        break;
                 }
 
                 if (!field.Required)
@@ -249,6 +270,159 @@ namespace TapirGrasshopperPlugin.Components
             return coordinates;
         }
 
+        // Turns a closed planar curve into the polygon Archicad expects: the node
+        // coordinates, plus one polygonArcs entry per arc segment.
+        //
+        // begIndex/endIndex are 0 based within this contour's polygonCoordinates,
+        // and the contour is closed implicitly - the add-on appends the first node
+        // again itself, so the closing segment runs from the last index back to 0.
+        //
+        // arcAngle is positive when the arc bulges to the right of the straight
+        // segment from beg to end. A Rhino arc whose plane normal points up (+Z) in
+        // the world XY plane turns counter clockwise, which bulges to the left, so
+        // its angle is negated.
+        private static bool TryConvertCurveToPolygon(
+            Curve curve,
+            out JArray coordinates,
+            out JArray arcs,
+            out string error)
+        {
+            coordinates = new JArray();
+            arcs = new JArray();
+            error = null;
+
+            if (curve == null)
+            {
+                error = "a curve is null";
+                return false;
+            }
+
+            if (!curve.IsClosed)
+            {
+                error = "every outline curve has to be closed";
+                return false;
+            }
+
+            var segments = curve is PolyCurve polyCurve
+                ? polyCurve.DuplicateSegments()
+                : new[] { curve };
+
+            if (segments == null || segments.Length == 0)
+            {
+                error = "a curve has no segments";
+                return false;
+            }
+
+            // A single closed segment has no corners to read - a circle, an ellipse,
+            // a nurbs loop, or a polyline curve that is one object - so it is
+            // approximated with a polyline. A closed arc in particular cannot be
+            // expressed as one polygon arc: that would need a begIndex and an
+            // endIndex that are the same node.
+            if (segments.Length == 1 && segments[0].IsClosed)
+            {
+                var polyline = TessellateToPolyline(segments[0]);
+                if (polyline == null)
+                {
+                    error = "a curve could not be approximated with a polyline";
+                    return false;
+                }
+                // The polyline of a closed curve repeats its first point at the end;
+                // the add-on closes the contour itself, so that repeat is dropped.
+                for (var i = 0; i < polyline.Count - 1; i++)
+                {
+                    coordinates.Add(new JObject
+                    {
+                        ["x"] = polyline[i].X,
+                        ["y"] = polyline[i].Y
+                    });
+                }
+                return coordinates.Count >= 3;
+            }
+
+            foreach (var segment in segments)
+            {
+                var start = segment.PointAtStart;
+                var nodeIndex = coordinates.Count;
+                coordinates.Add(new JObject
+                {
+                    ["x"] = start.X,
+                    ["y"] = start.Y
+                });
+
+                if (segment.IsLinear())
+                {
+                    continue;
+                }
+
+                if (segment.TryGetArc(out Rhino.Geometry.Arc arc))
+                {
+                    var angle = arc.Angle;
+                    if (arc.Plane.Normal.Z > 0.0)
+                    {
+                        angle = -angle;
+                    }
+                    arcs.Add(new JObject
+                    {
+                        ["begIndex"] = nodeIndex,
+                        // The last segment closes back onto the first node.
+                        ["endIndex"] = nodeIndex + 1,
+                        ["arcAngle"] = angle
+                    });
+                    continue;
+                }
+
+                var tessellated = TessellateToPolyline(segment);
+                if (tessellated == null)
+                {
+                    error = "a curve segment could not be approximated with a polyline";
+                    return false;
+                }
+                // The segment's own start is already in, and its end is the next
+                // segment's start, so only the points in between are added.
+                for (var i = 1; i < tessellated.Count - 1; i++)
+                {
+                    coordinates.Add(new JObject
+                    {
+                        ["x"] = tessellated[i].X,
+                        ["y"] = tessellated[i].Y
+                    });
+                }
+            }
+
+            if (coordinates.Count < 3)
+            {
+                error = "an outline needs at least three points";
+                return false;
+            }
+
+            // Fix up the closing arc: its end node is 0, not the count.
+            foreach (var arcToken in arcs)
+            {
+                if ((int)arcToken["endIndex"] >= coordinates.Count)
+                {
+                    arcToken["endIndex"] = 0;
+                }
+            }
+
+            return true;
+        }
+
+        private static Polyline TessellateToPolyline(
+            Curve curve)
+        {
+            var polylineCurve = curve.ToPolyline(
+                0,
+                0,
+                0.05,
+                0.0,
+                0.0,
+                0.01,
+                0.0,
+                0.0,
+                true);
+            return polylineCurve?.ToPolyline();
+        }
+
         private static JToken ConvertGuidWrapper<T>(
             GH_ObjectWrapper wrapper)
             where T : GuidObject<T>, new()
@@ -286,6 +460,63 @@ namespace TapirGrasshopperPlugin.Components
         {
             switch (field.Kind)
             {
+                case FieldKind.OutlineCurve:
+                    {
+                        var curves = new List<Curve>();
+                        da.GetDataList(inputIndex, curves);
+                        tokens = new List<JToken>();
+                        foreach (var curve in curves)
+                        {
+                            if (!TryConvertCurveToPolygon(curve, out JArray coordinates, out JArray arcs, out string error))
+                            {
+                                this.AddError($"The input {field.InputName} is invalid: {error}.");
+                                tokens = null;
+                                return false;
+                            }
+
+                            var outline = new JObject { [field.JsonKey] = coordinates };
+                            if (arcs.Count > 0)
+                            {
+                                outline["polygonArcs"] = arcs;
+                            }
+                            tokens.Add(outline);
+                        }
+                        break;
+                    }
+                case FieldKind.HoleCurvesTree:
+                    {
+                        tokens = new List<JToken>();
+                        if (!da.TryGetTree(inputIndex, out GH_Structure<GH_Curve> holeTree))
+                        {
+                            break;
+                        }
+                        foreach (var branch in holeTree.Branches)
+                        {
+                            var holes = new JArray();
+                            foreach (var ghCurve in branch)
+                            {
+                                if (ghCurve == null)
+                                {
+                                    continue;
+                                }
+                                if (!TryConvertCurveToPolygon(ghCurve.Value, out JArray coordinates, out JArray arcs, out string error))
+                                {
+                                    this.AddError($"The input {field.InputName} is invalid: {error}.");
+                                    tokens = null;
+                                    return false;
+                                }
+
+                                var hole = new JObject { ["polygonCoordinates"] = coordinates };
+                                if (arcs.Count > 0)
+                                {
+                                    hole["polygonArcs"] = arcs;
+                                }
+                                holes.Add(hole);
+                            }
+                            tokens.Add(holes);
+                        }
+                        break;
+                    }
                 case FieldKind.Number:
                     {
                         var values = new List<double>();
@@ -379,7 +610,7 @@ namespace TapirGrasshopperPlugin.Components
             Field field,
             JToken token)
         {
-            if (field.Kind == FieldKind.Line)
+            if (field.Kind == FieldKind.Line || field.Kind == FieldKind.OutlineCurve)
             {
                 foreach (var property in ((JObject)token).Properties())
                 {
@@ -399,6 +630,8 @@ namespace TapirGrasshopperPlugin.Components
             var firstField = fields[0];
             var isTreeFirst = firstField.Kind == FieldKind.PointsTree2D ||
                               firstField.Kind == FieldKind.PointsTree3D;
+            // OutlineCurve is read as a plain list, so it needs no special casing
+            // here - TryReadTokens turns each curve into the item's polygon.
 
             int itemCount;
             var items = new List<JObject>();

--- a/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateSlabsComponent.cs
+++ b/grasshopper-plugin/TapirGrasshopperPlugin/Components/ElementsComponents/CreateSlabsComponent.cs
@@ -11,7 +11,7 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
             : base(
                 "CreateSlabs",
                 "Create Slab elements based on the given parameters. " +
-                "Holes and arcs can be given through the AdditionalSettings input (polygonArcs, holes).",
+                "The outline of each slab is a closed curve; its arc segments are kept as arcs.",
                 GroupNames.ElementCreation)
         {
         }
@@ -20,7 +20,8 @@ namespace TapirGrasshopperPlugin.Components.ElementsComponents
 
         private static readonly List<Field> FieldDefinitions = new List<Field>
         {
-            new Field("Vertices", "polygonCoordinates", FieldKind.PointsTree2D, "Outline points of each slab (one branch per slab, at least 3 points; only X and Y are used).", required: true, minPointsPerBranch: 3),
+            new Field("Outlines", "polygonCoordinates", FieldKind.OutlineCurve, "The closed outline curve of each slab, one curve per slab. Line and arc segments are kept as they are; anything else is approximated with a polyline. Only X and Y are used.", required: true),
+            new Field("Holes", "holes", FieldKind.HoleCurvesTree, "The closed curves of the voids in each slab, one branch per slab. A slab with no voids gets an empty branch."),
             new Field("Levels", "level", FieldKind.Number, "The Z coordinate of the reference plane of the slab.", required: true),
             new Field("Thicknesses", "thickness", FieldKind.Number, "Thickness of the slab."),
             new Field("ReferencePlaneLocations", "referencePlaneLocation", FieldKind.Text, "Reference plane location: Top, CoreTop, CoreBottom or Bottom.", valueList: () => new ReferencePlaneLocationValueList ()),


### PR DESCRIPTION
Fixes #582. @JBENEITEZ was right on both counts: the input called Vertices was a
point list, so an outline could only ever be straight edges, and arcs and voids
existed only as JSON you had to hand-write into `AdditionalSettings`.

## What the component takes now

- **Outlines** — one closed curve per slab. Line and arc segments are carried
  across as they are, so an arc drawn in Rhino stays an arc in Archicad instead
  of being flattened into chords. Anything else is approximated with a polyline.
- **Holes** — a second curve input, one branch of closed curves per slab. A slab
  with no voids gets an empty branch.

Both are new field kinds on `CreateElementsComponentBase`, so any other creation
command with a polygon can use them without repeating the conversion.

## ⚠️ Breaking

The first input changes from a **point tree** to a **curve list**. An existing
definition feeding points into `Vertices` needs a `PolyLine` component between
the points and this one. Renaming it to `Outlines` makes that visible on the
canvas rather than silently mismatched.

## What needs checking in Rhino — I could not

Built for net48, net7.0 and net7.0-windows, but there is no Rhino or Grasshopper
on this machine, so **none of it has been run**. Three things are worth checking
first, and all three are isolated to one method:

1. **Arc direction.** `arcAngle` is documented as positive when the arc bulges
   to the right of the straight segment from `begIndex` to `endIndex`. A Rhino
   arc whose plane normal points up turns counter-clockwise, which bulges left,
   so its angle is negated. If arcs come out mirrored, that negation is the one
   line to flip.
2. **Node indices.** `begIndex`/`endIndex` are written 0-based within the
   contour, and the closing segment's `endIndex` is folded back to 0, because
   the add-on appends the first node itself (`AddPolyToMemo`). A slab whose last
   segment is an arc is the case that exercises it.
3. **Hole orientation.** Nothing reverses a hole curve, on the assumption
   Archicad does not care. If voids come out solid, that is where to look.

A slab with a straight-edged outline and no voids exercises none of the three,
so it is worth testing an outline with at least one arc, one with a circular
void, and one whose closing segment is an arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
