### PR TITLE
Hotlink nodes and instances: create, place, change, read

### DIFF
--- a/archicad-addon/Examples/hotlink_instances.py
+++ b/archicad-addon/Examples/hotlink_instances.py
@@ -1,0 +1,52 @@
+import os
+import math
+import aclib
+
+# Hotlink nodes and instances.
+#
+# A hotlink module is a NODE (the reference to the source file) plus any
+# number of placed INSTANCES. This example lists the nodes, places an instance
+# of the first one, reads its placement back, moves and mirrors it with
+# ChangeHotlinkInstances, then deletes the instance again.
+#
+# Set TAPIR_HOTLINK_SOURCE to the absolute path of a .mod or .pln to have the
+# example create a node first; without it the example works with whatever
+# nodes the open project already has, and does nothing if there are none.
+
+sourcePath = os.environ.get ('TAPIR_HOTLINK_SOURCE')
+if sourcePath:
+    aclib.RunTapirCommand ('CreateHotlinkNodes', {
+        'hotlinkNodes': [{'sourceLocation': sourcePath}]
+    })
+
+hotlinks = aclib.RunTapirCommand ('GetHotlinks')['hotlinks']
+
+if len (hotlinks) == 0:
+    print ('No hotlink nodes in this project - set TAPIR_HOTLINK_SOURCE to create one.')
+else:
+    nodeId = hotlinks[0]['hotlinkNodeId']
+
+    created = aclib.RunTapirCommand ('CreateHotlinkInstances', {
+        'hotlinkInstances': [{
+            'hotlinkNodeId': nodeId,
+            'origin': {'x': 10.0, 'y': 4.0},
+            'rotationAngle': math.pi / 6.0
+        }]
+    })['elements']
+
+    instances = [e for e in created if 'elementId' in e]
+
+    aclib.RunTapirCommand ('GetDetailsOfElements', {'elements': instances})
+
+    aclib.RunTapirCommand ('ChangeHotlinkInstances', {
+        'hotlinkInstances': [{
+            'elementId': instances[0]['elementId'],
+            'origin': {'x': 20.0, 'y': 8.0},
+            'rotationAngle': math.pi / 3.0,
+            'mirrored': True
+        }]
+    })
+
+    aclib.RunTapirCommand ('GetDetailsOfElements', {'elements': instances})
+
+    aclib.RunTapirCommand ('DeleteElements', {'elements': instances})

--- a/archicad-addon/Examples/hotlink_instances.py
+++ b/archicad-addon/Examples/hotlink_instances.py
@@ -14,18 +14,25 @@ import aclib
 # example create a node first; without it the example works with whatever
 # nodes the open project already has, and does nothing if there are none.
 
+# GetHotlinks walks the tree of PLACED nodes, so a node that has just been
+# created and not placed yet is not in it; the id CreateHotlinkNodes returns is
+# what the first placement needs.
+nodeId = None
 sourcePath = os.environ.get ('TAPIR_HOTLINK_SOURCE')
 if sourcePath:
-    aclib.RunTapirCommand ('CreateHotlinkNodes', {
+    nodes = aclib.RunTapirCommand ('CreateHotlinkNodes', {
         'hotlinkNodes': [{'sourceLocation': sourcePath}]
-    })
+    })['hotlinkNodes']
+    nodeId = next ((n['hotlinkNodeId'] for n in nodes if 'hotlinkNodeId' in n), None)
 
-hotlinks = aclib.RunTapirCommand ('GetHotlinks')['hotlinks']
+if nodeId is None:
+    hotlinks = aclib.RunTapirCommand ('GetHotlinks')['hotlinks']
+    if len (hotlinks) > 0:
+        nodeId = hotlinks[0]['hotlinkNodeId']
 
-if len (hotlinks) == 0:
+if nodeId is None:
     print ('No hotlink nodes in this project - set TAPIR_HOTLINK_SOURCE to create one.')
 else:
-    nodeId = hotlinks[0]['hotlinkNodeId']
 
     created = aclib.RunTapirCommand ('CreateHotlinkInstances', {
         'hotlinkInstances': [{

--- a/archicad-addon/Examples/hotlink_instances.py
+++ b/archicad-addon/Examples/hotlink_instances.py
@@ -1,5 +1,6 @@
 import os
 import math
+import sys
 import aclib
 
 # Hotlink nodes and instances.
@@ -35,6 +36,9 @@ else:
     })['elements']
 
     instances = [e for e in created if 'elementId' in e]
+    if not instances:
+        print ('Placement failed: {}'.format (created))
+        sys.exit (1)
 
     aclib.RunTapirCommand ('GetDetailsOfElements', {'elements': instances})
 

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -243,7 +243,7 @@ GSErrCode Initialize (void)
         );
         err |= RegisterCommand<CreateHotlinkNodesCommand> (
             projectCommands, "1.5.9",
-            "Creates hotlink module nodes from source files. A node that already points at the same file is returned instead of duplicated."
+            "Creates hotlink module nodes from source files. A node that already points at the same file is returned instead of duplicated (Archicad 27 and later; 25 and 26 cannot see an unplaced node)."
         );
         err |= RegisterCommand<CreateHotlinkInstancesCommand> (
             projectCommands, "1.5.9",

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -241,6 +241,18 @@ GSErrCode Initialize (void)
             projectCommands, "0.1.0",
             "Gets the file system locations (path) of the hotlink modules. The hotlinks can have tree hierarchy in the project."
         );
+        err |= RegisterCommand<CreateHotlinkNodesCommand> (
+            projectCommands, "1.5.9",
+            "Creates hotlink module nodes from source files. A node that already points at the same file is returned instead of duplicated."
+        );
+        err |= RegisterCommand<CreateHotlinkInstancesCommand> (
+            projectCommands, "1.5.9",
+            "Places instances of hotlink module nodes at an origin, rotation and mirroring."
+        );
+        err |= RegisterCommand<ChangeHotlinkInstancesCommand> (
+            projectCommands, "1.5.9",
+            "Moves, rotates or mirrors placed hotlink instances by changing their transformation. MoveElements and RotateElements do not work on hotlink instances."
+        );
         err |= RegisterCommand<OpenProjectCommand> (
             projectCommands, "1.0.7",
             "Opens the given project."

--- a/archicad-addon/Sources/AddOnMain.cpp
+++ b/archicad-addon/Sources/AddOnMain.cpp
@@ -243,7 +243,7 @@ GSErrCode Initialize (void)
         );
         err |= RegisterCommand<CreateHotlinkNodesCommand> (
             projectCommands, "1.5.9",
-            "Creates hotlink module nodes from source files. A node that already points at the same file is returned instead of duplicated (Archicad 27 and later; 25 and 26 cannot see an unplaced node)."
+            "Creates hotlink module nodes from source files. A node that already points at the same file is returned instead of duplicated (Archicad 26 and later; 25 cannot see an unplaced node)."
         );
         err |= RegisterCommand<CreateHotlinkInstancesCommand> (
             projectCommands, "1.5.9",

--- a/archicad-addon/Sources/CommandBase.cpp
+++ b/archicad-addon/Sources/CommandBase.cpp
@@ -3,6 +3,8 @@
 #include "SchemaDefinitions.hpp"
 #include "MigrationHelper.hpp"
 
+#include <cmath>
+
 constexpr double EPS = 0.001;
 constexpr const char* CommandNamespace = "TapirCommand";
 
@@ -1058,4 +1060,41 @@ bool DoesElementExist (const API_Guid& elementGuid, API_ElemTypeID expectedTypeI
         return false;
     }
     return GetElemTypeId (header) == expectedTypeId;
+}
+
+
+API_Tranmat CreateHotlinkTransformation (const API_Coord3D& origin, double rotationAngle, bool mirrored)
+{
+    API_Tranmat transformation = {};
+    const double co = std::cos (rotationAngle);
+    const double si = std::sin (rotationAngle);
+    const double mx = mirrored ? -1.0 : 1.0;
+
+    transformation.tmx[0]  = co * mx;
+    transformation.tmx[1]  = -si;
+    transformation.tmx[2]  = 0.0;
+    transformation.tmx[3]  = origin.x;
+
+    transformation.tmx[4]  = si * mx;
+    transformation.tmx[5]  = co;
+    transformation.tmx[6]  = 0.0;
+    transformation.tmx[7]  = origin.y;
+
+    transformation.tmx[8]  = 0.0;
+    transformation.tmx[9]  = 0.0;
+    transformation.tmx[10] = 1.0;
+    transformation.tmx[11] = origin.z;
+
+    return transformation;
+}
+
+void DecomposeHotlinkTransformation (const API_Tranmat& transformation, API_Coord3D& origin, double& rotationAngle, bool& mirrored)
+{
+    origin = { transformation.tmx[3], transformation.tmx[7], transformation.tmx[11] };
+    // The image of the local Y axis is the second column, (-sin, cos), and a
+    // mirror of the local X axis leaves it alone - so the angle reads off it
+    // regardless of mirroring, and the mirror reads off the determinant.
+    rotationAngle = std::atan2 (-transformation.tmx[1], transformation.tmx[5]);
+    const double det = transformation.tmx[0] * transformation.tmx[5] - transformation.tmx[1] * transformation.tmx[4];
+    mirrored = det < 0.0;
 }

--- a/archicad-addon/Sources/CommandBase.hpp
+++ b/archicad-addon/Sources/CommandBase.hpp
@@ -73,6 +73,15 @@ inline GS::ObjectState CreateAttributeIdObjectState (const API_Guid& guid) { ret
 inline GS::ObjectState CreateIssueIdObjectState (const API_Guid& guid)     { return CreateIdObjectState ("issueId", guid); }
 inline GS::ObjectState CreateDatabaseIdObjectState (const API_Guid& guid)  { return CreateIdObjectState ("databaseId", guid); }
 
+// A hotlink instance is placed by an API_Tranmat. Every caller of this add-on
+// thinks in an origin, a rotation and a mirror flag, so the two directions of
+// that conversion live here, shared by the hotlink commands and by
+// GetDetailsOfElements. Mirroring reflects the module's local X axis before
+// the rotation is applied; a reflection is an orthogonal matrix, which is what
+// Archicad expects.
+API_Tranmat CreateHotlinkTransformation (const API_Coord3D& origin, double rotationAngle, bool mirrored);
+void        DecomposeHotlinkTransformation (const API_Tranmat& transformation, API_Coord3D& origin, double& rotationAngle, bool& mirrored);
+
 struct PolygonData {
     std::vector<API_Coord>   coords;
     std::vector<API_PolyArc> arcs;

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -520,6 +520,10 @@ GS::Optional<GS::UniString> GetDetailsOfElementsCommand::GetRawResponseSchema ()
                         "drawIndex": {
                             "type": "number"
                         },
+                        "hotlinkId": {
+                            "$ref": "#/ElementId",
+                            "description": "The hotlink instance this element belongs to. Present only for elements that came in through a placed hotlink; such elements are read-only."
+                        },
                         "details": {
                             "$ref": "#/TypeSpecificDetails"
                         },
@@ -886,6 +890,9 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
         }
         if (isFieldRequested ("drawIndex")) {
             detailsOfElement.Add ("drawIndex", static_cast<short> (elem.header.drwIndex));
+        }
+        if (isFieldRequested ("hotlinkId") && elem.header.hotlinkGuid != APINULLGuid) {
+            detailsOfElement.Add ("hotlinkId", CreateElementIdObjectState (elem.header.hotlinkGuid));
         }
 
         if (isFieldRequested ("id")) {
@@ -1419,6 +1426,23 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
             case API_MorphID:
                 AddMorphBodyFromMemo (elem, typeSpecificDetails);
                 break;
+
+            case API_HotlinkID: {
+                API_Coord3D origin;
+                double rotationAngle;
+                bool mirrored;
+                DecomposeHotlinkTransformation (elem.hotlink.transformation, origin, rotationAngle, mirrored);
+                typeSpecificDetails.Add ("hotlinkType", elem.hotlink.type == APIHotlink_XRef ? "XRef" : "Module");
+                typeSpecificDetails.Add ("hotlinkNodeId", CreateGuidObjectState (elem.hotlink.hotlinkNodeGuid));
+                typeSpecificDetails.Add ("origin", Create3DCoordinateObjectState (origin));
+                typeSpecificDetails.Add ("rotationAngle", rotationAngle);
+                typeSpecificDetails.Add ("mirrored", mirrored);
+                typeSpecificDetails.Add ("floorDifference", elem.hotlink.floorDifference);
+                typeSpecificDetails.Add ("skipNested", elem.hotlink.skipNested);
+                typeSpecificDetails.Add ("suspendFixAngle", elem.hotlink.suspendFixAngle);
+                typeSpecificDetails.Add ("ignoreTopFloorLinks", elem.hotlink.ignoreTopFloorLinks);
+                break;
+            }
 
             default:
                 typeSpecificDetails.Add ("error", "Not yet supported element type");

--- a/archicad-addon/Sources/ElementCommands.cpp
+++ b/archicad-addon/Sources/ElementCommands.cpp
@@ -1441,6 +1441,8 @@ GS::ObjectState GetDetailsOfElementsCommand::Execute (const GS::ObjectState& par
                 typeSpecificDetails.Add ("skipNested", elem.hotlink.skipNested);
                 typeSpecificDetails.Add ("suspendFixAngle", elem.hotlink.suspendFixAngle);
                 typeSpecificDetails.Add ("ignoreTopFloorLinks", elem.hotlink.ignoreTopFloorLinks);
+                typeSpecificDetails.Add ("relinkWallOpenings", elem.hotlink.relinkWallOpenings);
+                typeSpecificDetails.Add ("adjustLevelDiffs", elem.hotlink.adjustLevelDiffs);
                 break;
             }
 

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -212,11 +212,6 @@ inline GSErrCode ACAPI_Hotlink_GetHotlinkNodes (const API_HotlinkTypeID* type, G
     return ACAPI_Database (APIDb_GetHotlinkNodesID, (void*) type, (void*) nodeRefList);
 }
 
-inline GSErrCode ACAPI_Hotlink_GetHotlinkInstances (const API_Guid* hotlinkNodeGuid, GS::Array<API_Guid>* elementRefList)
-{
-    return ACAPI_Database (APIDb_GetHotlinkInstancesID, (void*) hotlinkNodeGuid, (void*) elementRefList);
-}
-
 inline GSErrCode ACAPI_Navigator_GetNavigatorSetNum (Int32* setNum)
 {
     return ACAPI_Navigator (APINavigator_GetNavigatorSetNumID, setNum);

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -187,9 +187,12 @@ inline GSErrCode ACAPI_AutoText_DeleteAnAutoText (const char* dbKey)
     return ACAPI_Goodies (APIAny_DeleteAnAutoTextID, (void*) dbKey);
 }
 
-inline GSErrCode ACAPI_Hotlink_GetHotlinkNode (API_HotlinkNode* hotlinkNode, bool* enableUnplaced = nullptr)
+// AC25/26: APIDb_GetHotlinkNodeID takes no second parameter and APIDb_GetHotlinkNodesID's
+// second is the node list (APIdefs_Database.h), so there is no way to ask for unplaced
+// nodes on these versions; the flag is accepted for the callers' sake and dropped.
+inline GSErrCode ACAPI_Hotlink_GetHotlinkNode (API_HotlinkNode* hotlinkNode, bool* /*enableUnplaced*/ = nullptr)
 {
-    return ACAPI_Database (APIDb_GetHotlinkNodeID, hotlinkNode, enableUnplaced);
+    return ACAPI_Database (APIDb_GetHotlinkNodeID, hotlinkNode);
 }
 
 inline GSErrCode ACAPI_Hotlink_GetHotlinkRootNodeGuid (const API_HotlinkTypeID* type, API_Guid* rootNodeGuid)

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -187,12 +187,18 @@ inline GSErrCode ACAPI_AutoText_DeleteAnAutoText (const char* dbKey)
     return ACAPI_Goodies (APIAny_DeleteAnAutoTextID, (void*) dbKey);
 }
 
-// AC25/26: APIDb_GetHotlinkNodeID takes no second parameter and APIDb_GetHotlinkNodesID's
-// second is the node list (APIdefs_Database.h), so there is no way to ask for unplaced
-// nodes on these versions; the flag is accepted for the callers' sake and dropped.
-inline GSErrCode ACAPI_Hotlink_GetHotlinkNode (API_HotlinkNode* hotlinkNode, bool* /*enableUnplaced*/ = nullptr)
+// The unplaced-node flag (APIdefs_Database.h): AC26 takes it as par2 of
+// APIDb_GetHotlinkNodeID and par3 of APIDb_GetHotlinkNodesID; AC25 has neither
+// (par2 is "---" and the node list respectively), so on 25 the flag is accepted
+// for the callers' sake and dropped, and an unplaced node cannot be read.
+inline GSErrCode ACAPI_Hotlink_GetHotlinkNode (API_HotlinkNode* hotlinkNode, bool* enableUnplaced = nullptr)
 {
+#ifdef ServerMainVers_2600
+    return ACAPI_Database (APIDb_GetHotlinkNodeID, hotlinkNode, enableUnplaced);
+#else
+    (void) enableUnplaced;
     return ACAPI_Database (APIDb_GetHotlinkNodeID, hotlinkNode);
+#endif
 }
 
 inline GSErrCode ACAPI_Hotlink_GetHotlinkRootNodeGuid (const API_HotlinkTypeID* type, API_Guid* rootNodeGuid)
@@ -210,9 +216,14 @@ inline GSErrCode ACAPI_Hotlink_CreateHotlinkNode (API_HotlinkNode* hotlinkNode)
     return ACAPI_Database (APIDb_CreateHotlinkNodeID, hotlinkNode);
 }
 
-inline GSErrCode ACAPI_Hotlink_GetHotlinkNodes (const API_HotlinkTypeID* type, GS::Array<API_Guid>* nodeRefList, bool* /*enableUnplaced*/ = nullptr)
+inline GSErrCode ACAPI_Hotlink_GetHotlinkNodes (const API_HotlinkTypeID* type, GS::Array<API_Guid>* nodeRefList, bool* enableUnplaced = nullptr)
 {
+#ifdef ServerMainVers_2600
+    return ACAPI_Database (APIDb_GetHotlinkNodesID, (void*) type, (void*) nodeRefList, (void*) enableUnplaced);
+#else
+    (void) enableUnplaced;
     return ACAPI_Database (APIDb_GetHotlinkNodesID, (void*) type, (void*) nodeRefList);
+#endif
 }
 
 inline GSErrCode ACAPI_Navigator_GetNavigatorSetNum (Int32* setNum)

--- a/archicad-addon/Sources/MigrationHelper.hpp
+++ b/archicad-addon/Sources/MigrationHelper.hpp
@@ -202,6 +202,21 @@ inline GSErrCode ACAPI_Hotlink_GetHotlinkNodeTree (const API_Guid* hotlinkNodeGu
     return ACAPI_Database (APIDb_GetHotlinkNodeTreeID, (void*) hotlinkNodeGuid, (void*) hotlinkNodeTree);
 }
 
+inline GSErrCode ACAPI_Hotlink_CreateHotlinkNode (API_HotlinkNode* hotlinkNode)
+{
+    return ACAPI_Database (APIDb_CreateHotlinkNodeID, hotlinkNode);
+}
+
+inline GSErrCode ACAPI_Hotlink_GetHotlinkNodes (const API_HotlinkTypeID* type, GS::Array<API_Guid>* nodeRefList, bool* /*enableUnplaced*/ = nullptr)
+{
+    return ACAPI_Database (APIDb_GetHotlinkNodesID, (void*) type, (void*) nodeRefList);
+}
+
+inline GSErrCode ACAPI_Hotlink_GetHotlinkInstances (const API_Guid* hotlinkNodeGuid, GS::Array<API_Guid>* elementRefList)
+{
+    return ACAPI_Database (APIDb_GetHotlinkInstancesID, (void*) hotlinkNodeGuid, (void*) elementRefList);
+}
+
 inline GSErrCode ACAPI_Navigator_GetNavigatorSetNum (Int32* setNum)
 {
     return ACAPI_Navigator (APINavigator_GetNavigatorSetNumID, setNum);

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -2020,8 +2020,10 @@ GS::ObjectState CreateHotlinkNodesCommand::Execute (const GS::ObjectState& param
         }
         GS::ucsncpy (hotlinkNode.name, name.ToUStr (), API_UniLongNameLen - 1);
         // The example add-on allocates the location and never frees it; the
-        // node keeps a reference to it, so this add-on does the same.
-        hotlinkNode.sourceLocation = new IO::Location (sourceLocation);
+        // node keeps a reference to it, so this add-on does the same when the
+        // node is created, and frees it when creation fails.
+        IO::Location* ownedLocation = new IO::Location (sourceLocation);
+        hotlinkNode.sourceLocation = ownedLocation;
 
 #ifdef ServerMainVers_2800
         // Fills the story info from the source so the node is created with
@@ -2030,8 +2032,12 @@ GS::ObjectState CreateHotlinkNodesCommand::Execute (const GS::ObjectState& param
         ACAPI_Hotlink_GetHotlinkStoryInfo (&hotlinkNode);
 #endif
 
-        const GSErrCode err = ACAPI_Hotlink_CreateHotlinkNode (&hotlinkNode);
+        const GSErrCode err = ACAPI_CallUndoableCommand ("Create Hotlink Node", [&] () -> GSErrCode {
+            return ACAPI_Hotlink_CreateHotlinkNode (&hotlinkNode);
+        });
         if (err != NoError) {
+            delete ownedLocation;
+            hotlinkNode.sourceLocation = nullptr;
             results (CreateErrorResponse (err, "Failed to create the hotlink node from " + sourcePath));
             continue;
         }
@@ -2099,7 +2105,7 @@ GS::Optional<GS::UniString> CreateHotlinkInstancesCommand::GetInputParametersSch
                         },
                         "layerIndex": {
                             "type": "integer",
-                            "description": "Optional layer of the instance. Defaults to the Archicad layer."
+                            "description": "Optional layer of the instance. Defaults to the hotlink tool's current default layer."
                         },
                         "skipNested": {
                             "type": "boolean",
@@ -2182,7 +2188,11 @@ GS::ObjectState CreateHotlinkInstancesCommand::Execute (const GS::ObjectState& p
 #else
             element.header.typeID = API_HotlinkID;
 #endif
-            element.header.layer = ACAPI_CreateAttributeIndex (1);   // the Archicad Layer, which every project has
+            const GSErrCode defaultsErr = ACAPI_Element_GetDefaults (&element, nullptr);
+            if (defaultsErr != NoError) {
+                elements (CreateErrorResponse (defaultsErr, "Failed to get the hotlink instance defaults"));
+                continue;
+            }
             Int32 layerIndex;
             if (instanceData.Get ("layerIndex", layerIndex)) {
                 element.header.layer = ACAPI_CreateAttributeIndex (layerIndex);
@@ -2203,18 +2213,15 @@ GS::ObjectState CreateHotlinkInstancesCommand::Execute (const GS::ObjectState& p
             instanceData.Get ("mirrored", mirrored);
             element.hotlink.transformation = CreateHotlinkTransformation (GetOriginFromObjectState (*origin), rotationAngle, mirrored);
 
-            Int32 floorDifference = 0;
-            instanceData.Get ("floorDifference", floorDifference);
-            element.hotlink.floorDifference = static_cast<short> (floorDifference);
-            element.hotlink.skipNested = false;
+            // The placement options keep the tool defaults unless the caller sets them.
+            Int32 floorDifference;
+            if (instanceData.Get ("floorDifference", floorDifference)) {
+                element.hotlink.floorDifference = static_cast<short> (floorDifference);
+            }
             instanceData.Get ("skipNested", element.hotlink.skipNested);
-            element.hotlink.suspendFixAngle = false;
             instanceData.Get ("suspendFixAngle", element.hotlink.suspendFixAngle);
-            element.hotlink.ignoreTopFloorLinks = true;
             instanceData.Get ("ignoreTopFloorLinks", element.hotlink.ignoreTopFloorLinks);
-            element.hotlink.relinkWallOpenings = false;
             instanceData.Get ("relinkWallOpenings", element.hotlink.relinkWallOpenings);
-            element.hotlink.adjustLevelDiffs = false;
             instanceData.Get ("adjustLevelDiffs", element.hotlink.adjustLevelDiffs);
 
             const GSErrCode err = ACAPI_Element_Create (&element, nullptr);
@@ -2333,27 +2340,43 @@ GS::ObjectState ChangeHotlinkInstancesCommand::Execute (const GS::ObjectState& p
                 continue;
             }
 
-            API_Coord3D origin;
-            double rotationAngle;
-            bool mirrored;
-            DecomposeHotlinkTransformation (element.hotlink.transformation, origin, rotationAngle, mirrored);
-
-            const GS::ObjectState* newOrigin = instanceData.Get ("origin");
-            if (newOrigin != nullptr) {
-                const API_Coord3D given = GetOriginFromObjectState (*newOrigin);
-                origin.x = given.x;
-                origin.y = given.y;
-                if (newOrigin->Contains ("z")) {
-                    origin.z = given.z;
-                }
-            }
-            instanceData.Get ("rotationAngle", rotationAngle);
-            instanceData.Get ("mirrored", mirrored);
-
             API_Element mask;
             ACAPI_ELEMENT_MASK_CLEAR (mask);
-            element.hotlink.transformation = CreateHotlinkTransformation (origin, rotationAngle, mirrored);
-            ACAPI_ELEMENT_MASK_SET (mask, API_HotlinkType, transformation);
+
+            const GS::ObjectState* newOrigin = instanceData.Get ("origin");
+            const bool hasRotation = instanceData.Contains ("rotationAngle");
+            const bool hasMirrored = instanceData.Contains ("mirrored");
+            if (newOrigin != nullptr && !hasRotation && !hasMirrored) {
+                // A move keeps the matrix as it is - scale, skew and all - and
+                // replaces only the translation.
+                const API_Coord3D given = GetOriginFromObjectState (*newOrigin);
+                element.hotlink.transformation.tmx[3] = given.x;
+                element.hotlink.transformation.tmx[7] = given.y;
+                if (newOrigin->Contains ("z")) {
+                    element.hotlink.transformation.tmx[11] = given.z;
+                }
+                ACAPI_ELEMENT_MASK_SET (mask, API_HotlinkType, transformation);
+            } else if (newOrigin != nullptr || hasRotation || hasMirrored) {
+                // A rotation or a mirror rebuilds the planar matrix from its
+                // decomposition; a scaled or non-planar placement loses that
+                // part, which is what asking for a new angle means.
+                API_Coord3D origin;
+                double rotationAngle;
+                bool mirrored;
+                DecomposeHotlinkTransformation (element.hotlink.transformation, origin, rotationAngle, mirrored);
+                if (newOrigin != nullptr) {
+                    const API_Coord3D given = GetOriginFromObjectState (*newOrigin);
+                    origin.x = given.x;
+                    origin.y = given.y;
+                    if (newOrigin->Contains ("z")) {
+                        origin.z = given.z;
+                    }
+                }
+                instanceData.Get ("rotationAngle", rotationAngle);
+                instanceData.Get ("mirrored", mirrored);
+                element.hotlink.transformation = CreateHotlinkTransformation (origin, rotationAngle, mirrored);
+                ACAPI_ELEMENT_MASK_SET (mask, API_HotlinkType, transformation);
+            }
 
             Int32 floorDifference;
             if (instanceData.Get ("floorDifference", floorDifference)) {

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -1912,7 +1912,7 @@ GS::Optional<GS::UniString> CreateHotlinkNodesCommand::GetInputParametersSchema 
         "properties": {
             "hotlinkNodes": {
                 "type": "array",
-                "description": "The hotlink module nodes to create. A node that already points at the same source file (compared case-insensitively) is returned as it is, with existing: true, and the name and story settings asked for are ignored.",
+                "description": "The hotlink module nodes to create. A node that already points at the same source file (compared case-insensitively) is returned as it is, with existing: true, and the name and story settings asked for are ignored. On Archicad 25 and 26 a node that has not been placed yet cannot be found, so a repeated request there creates a second node.",
                 "items": {
                     "type": "object",
                     "properties": {
@@ -1955,22 +1955,9 @@ GS::Optional<GS::UniString> CreateHotlinkNodesCommand::GetRawResponseSchema () c
         "properties": {
             "hotlinkNodes": {
                 "type": "array",
-                "description": "One item per requested node, in order: the node guid, or an error.",
+                "description": "One item per requested node, in order: the node guid with its existing flag, or an error.",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "hotlinkNodeId": {
-                            "$ref": "#/HotlinkNodeId"
-                        },
-                        "existing": {
-                            "type": "boolean",
-                            "description": "True when a node for the same source file already existed and was returned instead of created."
-                        },
-                        "error": {
-                            "$ref": "#/Error"
-                        }
-                    },
-                    "additionalProperties": false
+                    "$ref": "#/HotlinkNodeCreatedOrError"
                 }
             }
         },
@@ -2084,7 +2071,8 @@ GS::Optional<GS::UniString> CreateHotlinkInstancesCommand::GetInputParametersSch
                     "type": "object",
                     "properties": {
                         "hotlinkNodeId": {
-                            "$ref": "#/HotlinkNodeId"
+                            "$ref": "#/HotlinkNodeId",
+                            "description": "The node to place, from GetHotlinks or CreateHotlinkNodes. On Archicad 25 and 26 a node that has never been placed cannot be read, so a node created through the API can only be placed from Archicad 27 on."
                         },
                         "origin": {
                             "$ref": "#/HotlinkOrigin"

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -2184,8 +2184,8 @@ GS::ObjectState CreateHotlinkInstancesCommand::Execute (const GS::ObjectState& p
                 elements (CreateErrorResponse (defaultsErr, "Failed to get the hotlink instance defaults"));
                 continue;
             }
-            Int32 layerIndex;
-            if (instanceData.Get ("layerIndex", layerIndex)) {
+            Int32 layerIndex = 0;
+            if (instanceData.Get ("layerIndex", layerIndex) && layerIndex > 0) {
                 element.header.layer = ACAPI_CreateAttributeIndex (layerIndex);
             }
             Int32 floorIndex;
@@ -2412,8 +2412,8 @@ GS::ObjectState ChangeHotlinkInstancesCommand::Execute (const GS::ObjectState& p
             if (instanceData.Get ("adjustLevelDiffs", element.hotlink.adjustLevelDiffs)) {
                 ACAPI_ELEMENT_MASK_SET (mask, API_HotlinkType, adjustLevelDiffs);
             }
-            Int32 layerIndex;
-            if (instanceData.Get ("layerIndex", layerIndex)) {
+            Int32 layerIndex = 0;
+            if (instanceData.Get ("layerIndex", layerIndex) && layerIndex > 0) {
                 element.header.layer = ACAPI_CreateAttributeIndex (layerIndex);
                 ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, layer);
             }

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -2015,6 +2015,7 @@ GS::ObjectState CreateHotlinkNodesCommand::Execute (const GS::ObjectState& param
                 name = lastLocalName.ToString ();
             }
             GS::ucsncpy (hotlinkNode.name, name.ToUStr (), API_UniLongNameLen - 1);
+            hotlinkNode.name[API_UniLongNameLen - 1] = 0;
             // API_HotlinkNode's destructor frees sourceLocation itself ("make sure
             // those point to memory on heap" - APIdefs_Database.h, AC25 to AC29),
             // which is also why the node reads elsewhere in this file do not leak.

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -1906,7 +1906,7 @@ GS::Optional<GS::UniString> CreateHotlinkNodesCommand::GetInputParametersSchema 
         "properties": {
             "hotlinkNodes": {
                 "type": "array",
-                "description": "The hotlink module nodes to create. A node that already points at the same source file is returned instead of creating a duplicate.",
+                "description": "The hotlink module nodes to create. A node that already points at the same source file (compared case-insensitively) is returned as it is, with existing: true, and the name and story settings asked for are ignored.",
                 "items": {
                     "type": "object",
                     "properties": {
@@ -1916,16 +1916,16 @@ GS::Optional<GS::UniString> CreateHotlinkNodesCommand::GetInputParametersSchema 
                         },
                         "name": {
                             "type": "string",
-                            "description": "Optional display name of the node. Defaults to the file name."
+                            "description": "Optional display name of the node. Defaults to the file name. Ignored when a node for the same file already exists."
                         },
                         "storyRangeType": {
                             "type": "string",
-                            "description": "Optional. Which stories of the source are placed: all of them, or the single reference story.",
+                            "description": "Optional. Which stories of the source are placed: all of them, or the single reference story. Ignored when a node for the same file already exists.",
                             "enum": ["AllStories", "SingleStory"]
                         },
                         "refFloorIndex": {
                             "type": "integer",
-                            "description": "Optional index of the reference story in the source file. Defaults to 0."
+                            "description": "Optional index of the reference story in the source file. Defaults to 0. Ignored when a node for the same file already exists."
                         }
                     },
                     "additionalProperties": false,
@@ -2022,9 +2022,11 @@ GS::ObjectState CreateHotlinkNodesCommand::Execute (const GS::ObjectState& param
                 name = lastLocalName.ToString ();
             }
             GS::ucsncpy (hotlinkNode.name, name.ToUStr (), API_UniLongNameLen - 1);
-            // The example add-on allocates the location and never frees it; the
-            // node keeps a reference to it, so this add-on does the same when the
-            // node is created, and frees it when creation fails.
+            // API_HotlinkNode's destructor frees sourceLocation itself ("make sure
+            // those point to memory on heap" - APIdefs_Database.h, AC25 to AC28),
+            // which is also why the node reads elsewhere in this file do not leak.
+            // On failure the location is freed here and nulled so the destructor
+            // does not free it twice.
             IO::Location* ownedLocation = new IO::Location (sourceLocation);
             hotlinkNode.sourceLocation = ownedLocation;
 
@@ -2283,6 +2285,19 @@ GS::Optional<GS::UniString> ChangeHotlinkInstancesCommand::GetInputParametersSch
                         },
                         "suspendFixAngle": {
                             "type": "boolean"
+                        },
+                        "ignoreTopFloorLinks": {
+                            "type": "boolean"
+                        },
+                        "relinkWallOpenings": {
+                            "type": "boolean"
+                        },
+                        "adjustLevelDiffs": {
+                            "type": "boolean"
+                        },
+                        "layerIndex": {
+                            "type": "integer",
+                            "description": "Move the instance to this layer."
                         }
                     },
                     "additionalProperties": false,
@@ -2391,6 +2406,20 @@ GS::ObjectState ChangeHotlinkInstancesCommand::Execute (const GS::ObjectState& p
             }
             if (instanceData.Get ("suspendFixAngle", element.hotlink.suspendFixAngle)) {
                 ACAPI_ELEMENT_MASK_SET (mask, API_HotlinkType, suspendFixAngle);
+            }
+            if (instanceData.Get ("ignoreTopFloorLinks", element.hotlink.ignoreTopFloorLinks)) {
+                ACAPI_ELEMENT_MASK_SET (mask, API_HotlinkType, ignoreTopFloorLinks);
+            }
+            if (instanceData.Get ("relinkWallOpenings", element.hotlink.relinkWallOpenings)) {
+                ACAPI_ELEMENT_MASK_SET (mask, API_HotlinkType, relinkWallOpenings);
+            }
+            if (instanceData.Get ("adjustLevelDiffs", element.hotlink.adjustLevelDiffs)) {
+                ACAPI_ELEMENT_MASK_SET (mask, API_HotlinkType, adjustLevelDiffs);
+            }
+            Int32 layerIndex;
+            if (instanceData.Get ("layerIndex", layerIndex)) {
+                element.header.layer = ACAPI_CreateAttributeIndex (layerIndex);
+                ACAPI_ELEMENT_MASK_SET (mask, API_Elem_Head, layer);
             }
 
             err = ACAPI_Element_Change (&element, &mask, nullptr, 0, true);

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -1871,15 +1871,21 @@ GS::ObjectState RebuildViewCommand::Execute (const GS::ObjectState& parameters, 
 
 static GS::Optional<API_Guid> FindHotlinkNodeBySource (const IO::Location& sourceLocation)
 {
+    // A node that has been created and not placed yet is "unplaced": the node
+    // reads skip it unless asked (AC27+; the AC25/26 database calls have no such
+    // flag). Without this a second CreateHotlinkNodes for the same file could not
+    // see the first, and CreateHotlinkInstances could not read the node it was
+    // given (measured on AC28).
+    bool enableUnplaced = true;
     API_HotlinkTypeID type = APIHotlink_Module;
     GS::Array<API_Guid> nodes;
-    if (ACAPI_Hotlink_GetHotlinkNodes (&type, &nodes) != NoError) {
+    if (ACAPI_Hotlink_GetHotlinkNodes (&type, &nodes, &enableUnplaced) != NoError) {
         return GS::NoValue;
     }
     for (const API_Guid& nodeGuid : nodes) {
         API_HotlinkNode node = {};
         node.guid = nodeGuid;
-        if (ACAPI_Hotlink_GetHotlinkNode (&node) == NoError && node.sourceLocation != nullptr) {
+        if (ACAPI_Hotlink_GetHotlinkNode (&node, &enableUnplaced) == NoError && node.sourceLocation != nullptr) {
             // Case-insensitive: on Windows a differently cased path is the same file.
             if (node.sourceLocation->ToDisplayText ().Compare (sourceLocation.ToDisplayText (), CaseInsensitive) == GS::UniString::Equal) {
                 return nodeGuid;
@@ -2205,7 +2211,8 @@ GS::ObjectState CreateHotlinkInstancesCommand::Execute (const GS::ObjectState& p
             // node is a mismatch.
             API_HotlinkNode node = {};
             node.guid = GetGuidFromObjectState (*hotlinkNodeId);
-            if (ACAPI_Hotlink_GetHotlinkNode (&node) != NoError) {
+            bool enableUnplaced = true;     // the node may have been created and not placed yet
+            if (ACAPI_Hotlink_GetHotlinkNode (&node, &enableUnplaced) != NoError) {
                 elements (CreateErrorResponse (APIERR_BADID, "hotlinkNodeId is not a hotlink node"));
                 continue;
             }

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -1,6 +1,8 @@
 #include "ProjectCommands.hpp"
 #include "MigrationHelper.hpp"
 
+#include <cmath>
+
 GetProjectInfoCommand::GetProjectInfoCommand () :
     CommandBase (CommonSchema::NotUsed)
 {
@@ -447,6 +449,16 @@ static GS::ObjectState DumpHotlinkWithChildren (const API_Guid& hotlinkGuid,
     const auto& location = GetLocationOfHotlink (hotlinkGuid);
     if (location.HasValue ()) {
         hotlinkNodeOS.Add ("location", location.Get ());
+    }
+
+    // The node guid is what CreateHotlinkInstances needs; the name and type
+    // are what a caller shows. All three are additions to the original shape.
+    hotlinkNodeOS.Add ("hotlinkNodeId", CreateGuidObjectState (hotlinkGuid));
+    API_HotlinkNode hotlinkNode = {};
+    hotlinkNode.guid = hotlinkGuid;
+    if (ACAPI_Hotlink_GetHotlinkNode (&hotlinkNode) == NoError) {
+        hotlinkNodeOS.Add ("name", GS::UniString (hotlinkNode.name));
+        hotlinkNodeOS.Add ("type", hotlinkNode.type == APIHotlink_XRef ? "XRef" : "Module");
     }
 
     const auto& children = hotlinkTree.Retrieve (hotlinkGuid);
@@ -1838,4 +1850,532 @@ GS::ObjectState RebuildViewCommand::Execute (const GS::ObjectState& parameters, 
     }
 
     return CreateSuccessfulExecutionResult ();
+}
+
+
+// ---------------------------------------------------------------------------
+// Hotlink nodes and instances.
+//
+// A hotlink module is two things in Archicad: a NODE (the reference to the
+// source file, with its cache) and any number of INSTANCES (elements of type
+// API_HotlinkID, each placed by a transformation). GetHotlinks lists the
+// nodes; these three commands create nodes, place instances and move them.
+// Instances are ordinary elements otherwise: DeleteElements removes one,
+// GetDetailsOfElements reads its placement, and the elements inside a
+// placed instance report it as their hotlinkId.
+//
+// MoveElements and RotateElements do NOT work on an instance - the drag edit
+// returns NoError and moves nothing - which is why ChangeHotlinkInstances
+// exists: an instance moves by changing its transformation.
+// ---------------------------------------------------------------------------
+
+static GS::Optional<API_Guid> FindHotlinkNodeBySource (const IO::Location& sourceLocation)
+{
+    API_HotlinkTypeID type = APIHotlink_Module;
+    GS::Array<API_Guid> nodes;
+    if (ACAPI_Hotlink_GetHotlinkNodes (&type, &nodes) != NoError) {
+        return GS::NoValue;
+    }
+    for (const API_Guid& nodeGuid : nodes) {
+        API_HotlinkNode node = {};
+        node.guid = nodeGuid;
+        if (ACAPI_Hotlink_GetHotlinkNode (&node) == NoError && node.sourceLocation != nullptr) {
+            if (node.sourceLocation->ToDisplayText () == sourceLocation.ToDisplayText ()) {
+                return nodeGuid;
+            }
+        }
+    }
+    return GS::NoValue;
+}
+
+CreateHotlinkNodesCommand::CreateHotlinkNodesCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String CreateHotlinkNodesCommand::GetName () const
+{
+    return "CreateHotlinkNodes";
+}
+
+GS::Optional<GS::UniString> CreateHotlinkNodesCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "hotlinkNodes": {
+                "type": "array",
+                "description": "The hotlink module nodes to create. A node that already points at the same source file is returned instead of creating a duplicate.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "sourceLocation": {
+                            "type": "string",
+                            "description": "Absolute path of the module source file (.mod or .pln)."
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Optional display name of the node. Defaults to the file name."
+                        },
+                        "storyRangeType": {
+                            "type": "string",
+                            "description": "Optional. Which stories of the source are placed: all of them, or the single reference story.",
+                            "enum": ["AllStories", "SingleStory"]
+                        },
+                        "refFloorIndex": {
+                            "type": "integer",
+                            "description": "Optional index of the reference story in the source file. Defaults to 0."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "sourceLocation"
+                    ]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "hotlinkNodes"
+        ]
+    })";
+}
+
+GS::Optional<GS::UniString> CreateHotlinkNodesCommand::GetRawResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "hotlinkNodes": {
+                "type": "array",
+                "description": "One item per requested node, in order: the node guid, or an error.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "hotlinkNodeId": {
+                            "$ref": "#/HotlinkNodeId"
+                        },
+                        "existing": {
+                            "type": "boolean",
+                            "description": "True when a node for the same source file already existed and was returned instead of created."
+                        },
+                        "error": {
+                            "$ref": "#/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "hotlinkNodes"
+        ]
+    })";
+}
+
+GS::ObjectState CreateHotlinkNodesCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::ObjectState> hotlinkNodes;
+    parameters.Get ("hotlinkNodes", hotlinkNodes);
+
+    GS::ObjectState response;
+    const auto& results = response.AddList<GS::ObjectState> ("hotlinkNodes");
+
+    for (const GS::ObjectState& nodeData : hotlinkNodes) {
+        GS::UniString sourcePath;
+        if (!nodeData.Get ("sourceLocation", sourcePath) || sourcePath.IsEmpty ()) {
+            results (CreateErrorResponse (APIERR_BADPARS, "sourceLocation is missing"));
+            continue;
+        }
+        IO::Location sourceLocation (sourcePath);
+        IO::Name lastLocalName;
+        if (sourceLocation.GetLastLocalName (&lastLocalName) != NoError) {
+            results (CreateErrorResponse (APIERR_BADPARS, "sourceLocation is not a valid path"));
+            continue;
+        }
+
+        const GS::Optional<API_Guid> existing = FindHotlinkNodeBySource (sourceLocation);
+        if (existing.HasValue ()) {
+            GS::ObjectState item;
+            item.Add ("hotlinkNodeId", CreateGuidObjectState (existing.Get ()));
+            item.Add ("existing", true);
+            results (item);
+            continue;
+        }
+
+        API_HotlinkNode hotlinkNode = {};
+        hotlinkNode.type = APIHotlink_Module;
+        hotlinkNode.storyRangeType = APIHotlink_AllStories;
+        GS::UniString storyRangeType;
+        if (nodeData.Get ("storyRangeType", storyRangeType) && storyRangeType == "SingleStory") {
+            hotlinkNode.storyRangeType = APIHotlink_SingleStory;
+        }
+        Int32 refFloorIndex = 0;
+        nodeData.Get ("refFloorIndex", refFloorIndex);
+        hotlinkNode.refFloorInd = static_cast<short> (refFloorIndex);
+        GS::UniString name;
+        if (!nodeData.Get ("name", name) || name.IsEmpty ()) {
+            name = lastLocalName.ToString ();
+        }
+        GS::ucsncpy (hotlinkNode.name, name.ToUStr (), API_UniLongNameLen - 1);
+        // The example add-on allocates the location and never frees it; the
+        // node keeps a reference to it, so this add-on does the same.
+        hotlinkNode.sourceLocation = new IO::Location (sourceLocation);
+
+#ifdef ServerMainVers_2700
+        // Fills the story info from the source so the node is created with
+        // the right story settings. Not available before 27; creation works
+        // without it.
+        ACAPI_Hotlink_GetHotlinkStoryInfo (&hotlinkNode);
+#endif
+
+        const GSErrCode err = ACAPI_Hotlink_CreateHotlinkNode (&hotlinkNode);
+        if (err != NoError) {
+            results (CreateErrorResponse (err, "Failed to create the hotlink node from " + sourcePath));
+            continue;
+        }
+
+        GS::ObjectState item;
+        item.Add ("hotlinkNodeId", CreateGuidObjectState (hotlinkNode.guid));
+        item.Add ("existing", false);
+        results (item);
+    }
+
+    return response;
+}
+
+static API_Coord3D GetOriginFromObjectState (const GS::ObjectState& os)
+{
+    API_Coord3D origin = { 0.0, 0.0, 0.0 };
+    os.Get ("x", origin.x);
+    os.Get ("y", origin.y);
+    os.Get ("z", origin.z);
+    return origin;
+}
+
+CreateHotlinkInstancesCommand::CreateHotlinkInstancesCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String CreateHotlinkInstancesCommand::GetName () const
+{
+    return "CreateHotlinkInstances";
+}
+
+GS::Optional<GS::UniString> CreateHotlinkInstancesCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "hotlinkInstances": {
+                "type": "array",
+                "description": "The hotlink instances to place.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "hotlinkNodeId": {
+                            "$ref": "#/HotlinkNodeId"
+                        },
+                        "origin": {
+                            "$ref": "#/HotlinkOrigin"
+                        },
+                        "rotationAngle": {
+                            "type": "number",
+                            "description": "Optional rotation about the origin, counter-clockwise, in radians. Defaults to 0."
+                        },
+                        "mirrored": {
+                            "type": "boolean",
+                            "description": "Optional. Reflects the module's local X axis before the rotation. Defaults to false."
+                        },
+                        "floorIndex": {
+                            "type": "integer",
+                            "description": "Optional story the instance is placed on. Defaults to the current story."
+                        },
+                        "floorDifference": {
+                            "type": "integer",
+                            "description": "Optional story offset applied to the module's stories. Defaults to 0."
+                        },
+                        "layerIndex": {
+                            "type": "integer",
+                            "description": "Optional layer of the instance. Defaults to the Archicad layer."
+                        },
+                        "skipNested": {
+                            "type": "boolean",
+                            "description": "Optional. Do not place hotlinks nested inside the module. Defaults to false."
+                        },
+                        "suspendFixAngle": {
+                            "type": "boolean",
+                            "description": "Optional. Rotate fixed-angle elements with the module. Defaults to false."
+                        },
+                        "ignoreTopFloorLinks": {
+                            "type": "boolean",
+                            "description": "Optional. Top-linked elements keep their height rather than their top story link. Defaults to true."
+                        },
+                        "relinkWallOpenings": {
+                            "type": "boolean",
+                            "description": "Optional. Defaults to false."
+                        },
+                        "adjustLevelDiffs": {
+                            "type": "boolean",
+                            "description": "Optional. Defaults to false."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "hotlinkNodeId",
+                        "origin"
+                    ]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "hotlinkInstances"
+        ]
+    })";
+}
+
+GS::Optional<GS::UniString> CreateHotlinkInstancesCommand::GetRawResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/ElementIdsOrErrors"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "elements"
+        ]
+    })";
+}
+
+GS::ObjectState CreateHotlinkInstancesCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::ObjectState> hotlinkInstances;
+    parameters.Get ("hotlinkInstances", hotlinkInstances);
+
+    GS::ObjectState response;
+    const auto& elements = response.AddList<GS::ObjectState> ("elements");
+
+    API_StoryInfo storyInfo = {};
+    const bool haveStoryInfo = ACAPI_ProjectSetting_GetStorySettings (&storyInfo) == NoError;
+    if (haveStoryInfo) {
+        BMKillHandle ((GSHandle*) &storyInfo.data);
+    }
+
+    ACAPI_CallUndoableCommand ("Create Hotlink Instances", [&] () -> GSErrCode {
+        for (const GS::ObjectState& instanceData : hotlinkInstances) {
+            const GS::ObjectState* hotlinkNodeId = instanceData.Get ("hotlinkNodeId");
+            const GS::ObjectState* origin = instanceData.Get ("origin");
+            if (hotlinkNodeId == nullptr || origin == nullptr) {
+                elements (CreateErrorResponse (APIERR_BADPARS, "hotlinkNodeId or origin is missing"));
+                continue;
+            }
+
+            API_Element element = {};
+#ifdef ServerMainVers_2600
+            element.header.type   = API_HotlinkID;
+#else
+            element.header.typeID = API_HotlinkID;
+#endif
+            element.header.layer = ACAPI_CreateAttributeIndex (1);   // the Archicad Layer, which every project has
+            Int32 layerIndex;
+            if (instanceData.Get ("layerIndex", layerIndex)) {
+                element.header.layer = ACAPI_CreateAttributeIndex (layerIndex);
+            }
+            Int32 floorIndex;
+            if (instanceData.Get ("floorIndex", floorIndex)) {
+                element.header.floorInd = static_cast<short> (floorIndex);
+            } else if (haveStoryInfo) {
+                element.header.floorInd = storyInfo.actStory;
+            }
+
+            element.hotlink.type = APIHotlink_Module;
+            element.hotlink.hotlinkNodeGuid = GetGuidFromObjectState (*hotlinkNodeId);
+
+            double rotationAngle = 0.0;
+            instanceData.Get ("rotationAngle", rotationAngle);
+            bool mirrored = false;
+            instanceData.Get ("mirrored", mirrored);
+            element.hotlink.transformation = CreateHotlinkTransformation (GetOriginFromObjectState (*origin), rotationAngle, mirrored);
+
+            Int32 floorDifference = 0;
+            instanceData.Get ("floorDifference", floorDifference);
+            element.hotlink.floorDifference = static_cast<short> (floorDifference);
+            element.hotlink.skipNested = false;
+            instanceData.Get ("skipNested", element.hotlink.skipNested);
+            element.hotlink.suspendFixAngle = false;
+            instanceData.Get ("suspendFixAngle", element.hotlink.suspendFixAngle);
+            element.hotlink.ignoreTopFloorLinks = true;
+            instanceData.Get ("ignoreTopFloorLinks", element.hotlink.ignoreTopFloorLinks);
+            element.hotlink.relinkWallOpenings = false;
+            instanceData.Get ("relinkWallOpenings", element.hotlink.relinkWallOpenings);
+            element.hotlink.adjustLevelDiffs = false;
+            instanceData.Get ("adjustLevelDiffs", element.hotlink.adjustLevelDiffs);
+
+            const GSErrCode err = ACAPI_Element_Create (&element, nullptr);
+            if (err != NoError) {
+                elements (CreateErrorResponse (err, "Failed to place the hotlink instance"));
+                continue;
+            }
+            elements (CreateElementIdObjectState (element.header.guid));
+        }
+        return NoError;
+    });
+
+    return response;
+}
+
+ChangeHotlinkInstancesCommand::ChangeHotlinkInstancesCommand () :
+    CommandBase (CommonSchema::Used)
+{
+}
+
+GS::String ChangeHotlinkInstancesCommand::GetName () const
+{
+    return "ChangeHotlinkInstances";
+}
+
+GS::Optional<GS::UniString> ChangeHotlinkInstancesCommand::GetInputParametersSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "hotlinkInstances": {
+                "type": "array",
+                "description": "The placed hotlink instances to change. Every field but elementId is optional; a field that is omitted keeps its current value.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": {
+                            "$ref": "#/ElementId"
+                        },
+                        "origin": {
+                            "$ref": "#/HotlinkOrigin"
+                        },
+                        "rotationAngle": {
+                            "type": "number",
+                            "description": "Rotation about the origin, counter-clockwise, in radians."
+                        },
+                        "mirrored": {
+                            "type": "boolean",
+                            "description": "Reflect the module's local X axis before the rotation."
+                        },
+                        "floorDifference": {
+                            "type": "integer"
+                        },
+                        "skipNested": {
+                            "type": "boolean"
+                        },
+                        "suspendFixAngle": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "elementId"
+                    ]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "hotlinkInstances"
+        ]
+    })";
+}
+
+GS::Optional<GS::UniString> ChangeHotlinkInstancesCommand::GetRawResponseSchema () const
+{
+    return R"({
+        "type": "object",
+        "properties": {
+            "executionResults": {
+                "$ref": "#/ExecutionResults"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executionResults"
+        ]
+    })";
+}
+
+GS::ObjectState ChangeHotlinkInstancesCommand::Execute (const GS::ObjectState& parameters, GS::ProcessControl& /*processControl*/) const
+{
+    GS::Array<GS::ObjectState> hotlinkInstances;
+    parameters.Get ("hotlinkInstances", hotlinkInstances);
+
+    GS::ObjectState response;
+    const auto& executionResults = response.AddList<GS::ObjectState> ("executionResults");
+
+    ACAPI_CallUndoableCommand ("Change Hotlink Instances", [&] () -> GSErrCode {
+        for (const GS::ObjectState& instanceData : hotlinkInstances) {
+            const GS::ObjectState* elementId = instanceData.Get ("elementId");
+            if (elementId == nullptr) {
+                executionResults (CreateFailedExecutionResult (APIERR_BADPARS, "elementId is missing"));
+                continue;
+            }
+
+            API_Element element = {};
+            element.header.guid = GetGuidFromObjectState (*elementId);
+            GSErrCode err = ACAPI_Element_Get (&element);
+            if (err != NoError) {
+                executionResults (CreateFailedExecutionResult (err, "Failed to get the element"));
+                continue;
+            }
+            if (GetElemTypeId (element.header) != API_HotlinkID) {
+                executionResults (CreateFailedExecutionResult (APIERR_BADELEMENTTYPE, "The element is not a hotlink instance"));
+                continue;
+            }
+
+            API_Coord3D origin;
+            double rotationAngle;
+            bool mirrored;
+            DecomposeHotlinkTransformation (element.hotlink.transformation, origin, rotationAngle, mirrored);
+
+            const GS::ObjectState* newOrigin = instanceData.Get ("origin");
+            if (newOrigin != nullptr) {
+                const API_Coord3D given = GetOriginFromObjectState (*newOrigin);
+                origin.x = given.x;
+                origin.y = given.y;
+                if (newOrigin->Contains ("z")) {
+                    origin.z = given.z;
+                }
+            }
+            instanceData.Get ("rotationAngle", rotationAngle);
+            instanceData.Get ("mirrored", mirrored);
+
+            API_Element mask;
+            ACAPI_ELEMENT_MASK_CLEAR (mask);
+            element.hotlink.transformation = CreateHotlinkTransformation (origin, rotationAngle, mirrored);
+            ACAPI_ELEMENT_MASK_SET (mask, API_HotlinkType, transformation);
+
+            Int32 floorDifference;
+            if (instanceData.Get ("floorDifference", floorDifference)) {
+                element.hotlink.floorDifference = static_cast<short> (floorDifference);
+                ACAPI_ELEMENT_MASK_SET (mask, API_HotlinkType, floorDifference);
+            }
+            if (instanceData.Get ("skipNested", element.hotlink.skipNested)) {
+                ACAPI_ELEMENT_MASK_SET (mask, API_HotlinkType, skipNested);
+            }
+            if (instanceData.Get ("suspendFixAngle", element.hotlink.suspendFixAngle)) {
+                ACAPI_ELEMENT_MASK_SET (mask, API_HotlinkType, suspendFixAngle);
+            }
+
+            err = ACAPI_Element_Change (&element, &mask, nullptr, 0, true);
+            if (err != NoError) {
+                executionResults (CreateFailedExecutionResult (err, "Failed to change the hotlink instance"));
+                continue;
+            }
+            executionResults (CreateSuccessfulExecutionResult ());
+        }
+        return NoError;
+    });
+
+    return response;
 }

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -2023,9 +2023,9 @@ GS::ObjectState CreateHotlinkNodesCommand::Execute (const GS::ObjectState& param
         // node keeps a reference to it, so this add-on does the same.
         hotlinkNode.sourceLocation = new IO::Location (sourceLocation);
 
-#ifdef ServerMainVers_2700
+#ifdef ServerMainVers_2800
         // Fills the story info from the source so the node is created with
-        // the right story settings. Not available before 27; creation works
+        // the right story settings. Not available before 28; creation works
         // without it.
         ACAPI_Hotlink_GetHotlinkStoryInfo (&hotlinkNode);
 #endif

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -1872,9 +1872,9 @@ GS::ObjectState RebuildViewCommand::Execute (const GS::ObjectState& parameters, 
 static GS::Optional<API_Guid> FindHotlinkNodeBySource (const IO::Location& sourceLocation)
 {
     // A node that has been created and not placed yet is "unplaced": the node
-    // reads skip it unless asked (AC27+; the AC25/26 database calls have no such
-    // flag). Without this a second CreateHotlinkNodes for the same file could not
-    // see the first, and CreateHotlinkInstances could not read the node it was
+    // reads skip it unless asked (AC26 and later; AC25's database calls have no
+    // such flag). Without this a second CreateHotlinkNodes for the same file could
+    // not see the first, and CreateHotlinkInstances could not read the node it was
     // given (measured on AC28).
     bool enableUnplaced = true;
     API_HotlinkTypeID type = APIHotlink_Module;
@@ -1912,7 +1912,7 @@ GS::Optional<GS::UniString> CreateHotlinkNodesCommand::GetInputParametersSchema 
         "properties": {
             "hotlinkNodes": {
                 "type": "array",
-                "description": "The hotlink module nodes to create. A node that already points at the same source file (compared case-insensitively) is returned as it is, with existing: true, and the name and story settings asked for are ignored. On Archicad 25 and 26 a node that has not been placed yet cannot be found, so a repeated request there creates a second node.",
+                "description": "The hotlink module nodes to create. A node that already points at the same source file (compared case-insensitively) is returned as it is, with existing: true, and the name and story settings asked for are ignored. On Archicad 25 a node that has not been placed yet cannot be found, so a repeated request there creates a second node.",
                 "items": {
                     "type": "object",
                     "properties": {
@@ -2016,7 +2016,7 @@ GS::ObjectState CreateHotlinkNodesCommand::Execute (const GS::ObjectState& param
             }
             GS::ucsncpy (hotlinkNode.name, name.ToUStr (), API_UniLongNameLen - 1);
             // API_HotlinkNode's destructor frees sourceLocation itself ("make sure
-            // those point to memory on heap" - APIdefs_Database.h, AC25 to AC28),
+            // those point to memory on heap" - APIdefs_Database.h, AC25 to AC29),
             // which is also why the node reads elsewhere in this file do not leak.
             // On failure the location is freed here and nulled so the destructor
             // does not free it twice.
@@ -2072,7 +2072,7 @@ GS::Optional<GS::UniString> CreateHotlinkInstancesCommand::GetInputParametersSch
                     "properties": {
                         "hotlinkNodeId": {
                             "$ref": "#/HotlinkNodeId",
-                            "description": "The node to place, from GetHotlinks or CreateHotlinkNodes. On Archicad 25 and 26 a node that has never been placed cannot be read, so a node created through the API can only be placed from Archicad 27 on."
+                            "description": "The node to place, from GetHotlinks or CreateHotlinkNodes. On Archicad 25 a node that has never been placed cannot be read, so a node created through the API can only be placed from Archicad 26 on."
                         },
                         "origin": {
                             "$ref": "#/HotlinkOrigin"

--- a/archicad-addon/Sources/ProjectCommands.cpp
+++ b/archicad-addon/Sources/ProjectCommands.cpp
@@ -1880,7 +1880,8 @@ static GS::Optional<API_Guid> FindHotlinkNodeBySource (const IO::Location& sourc
         API_HotlinkNode node = {};
         node.guid = nodeGuid;
         if (ACAPI_Hotlink_GetHotlinkNode (&node) == NoError && node.sourceLocation != nullptr) {
-            if (node.sourceLocation->ToDisplayText () == sourceLocation.ToDisplayText ()) {
+            // Case-insensitive: on Windows a differently cased path is the same file.
+            if (node.sourceLocation->ToDisplayText ().Compare (sourceLocation.ToDisplayText (), CaseInsensitive) == GS::UniString::Equal) {
                 return nodeGuid;
             }
         }
@@ -1982,82 +1983,75 @@ GS::ObjectState CreateHotlinkNodesCommand::Execute (const GS::ObjectState& param
     GS::ObjectState response;
     const auto& results = response.AddList<GS::ObjectState> ("hotlinkNodes");
 
-    for (const GS::ObjectState& nodeData : hotlinkNodes) {
-        GS::UniString sourcePath;
-        if (!nodeData.Get ("sourceLocation", sourcePath) || sourcePath.IsEmpty ()) {
-            results (CreateErrorResponse (APIERR_BADPARS, "sourceLocation is missing"));
-            continue;
-        }
-        IO::Location sourceLocation (sourcePath);
-        IO::Name lastLocalName;
-        if (sourceLocation.GetLastLocalName (&lastLocalName) != NoError) {
-            results (CreateErrorResponse (APIERR_BADPARS, "sourceLocation is not a valid path"));
-            continue;
-        }
+    // One undo step for the whole call, as the repo's other creating commands do.
+    ACAPI_CallUndoableCommand ("Create Hotlink Nodes", [&] () -> GSErrCode {
+        for (const GS::ObjectState& nodeData : hotlinkNodes) {
+            GS::UniString sourcePath;
+            if (!nodeData.Get ("sourceLocation", sourcePath) || sourcePath.IsEmpty ()) {
+                results (CreateErrorResponse (APIERR_BADPARS, "sourceLocation is missing"));
+                continue;
+            }
+            IO::Location sourceLocation (sourcePath);
+            IO::Name lastLocalName;
+            if (sourceLocation.GetLastLocalName (&lastLocalName) != NoError) {
+                results (CreateErrorResponse (APIERR_BADPARS, "sourceLocation is not a valid path"));
+                continue;
+            }
 
-        const GS::Optional<API_Guid> existing = FindHotlinkNodeBySource (sourceLocation);
-        if (existing.HasValue ()) {
+            const GS::Optional<API_Guid> existing = FindHotlinkNodeBySource (sourceLocation);
+            if (existing.HasValue ()) {
+                GS::ObjectState item;
+                item.Add ("hotlinkNodeId", CreateGuidObjectState (existing.Get ()));
+                item.Add ("existing", true);
+                results (item);
+                continue;
+            }
+
+            API_HotlinkNode hotlinkNode = {};
+            hotlinkNode.type = APIHotlink_Module;
+            hotlinkNode.storyRangeType = APIHotlink_AllStories;
+            GS::UniString storyRangeType;
+            if (nodeData.Get ("storyRangeType", storyRangeType) && storyRangeType == "SingleStory") {
+                hotlinkNode.storyRangeType = APIHotlink_SingleStory;
+            }
+            Int32 refFloorIndex = 0;
+            nodeData.Get ("refFloorIndex", refFloorIndex);
+            hotlinkNode.refFloorInd = static_cast<short> (refFloorIndex);
+            GS::UniString name;
+            if (!nodeData.Get ("name", name) || name.IsEmpty ()) {
+                name = lastLocalName.ToString ();
+            }
+            GS::ucsncpy (hotlinkNode.name, name.ToUStr (), API_UniLongNameLen - 1);
+            // The example add-on allocates the location and never frees it; the
+            // node keeps a reference to it, so this add-on does the same when the
+            // node is created, and frees it when creation fails.
+            IO::Location* ownedLocation = new IO::Location (sourceLocation);
+            hotlinkNode.sourceLocation = ownedLocation;
+
+    #ifdef ServerMainVers_2800
+            // Fills the story info from the source so the node is created with
+            // the right story settings. Not available before 28; creation works
+            // without it.
+            ACAPI_Hotlink_GetHotlinkStoryInfo (&hotlinkNode);
+    #endif
+
+            const GSErrCode err = ACAPI_Hotlink_CreateHotlinkNode (&hotlinkNode);
+            if (err != NoError) {
+                delete ownedLocation;
+                hotlinkNode.sourceLocation = nullptr;
+                results (CreateErrorResponse (err, "Failed to create the hotlink node from " + sourcePath));
+                continue;
+            }
+
             GS::ObjectState item;
-            item.Add ("hotlinkNodeId", CreateGuidObjectState (existing.Get ()));
-            item.Add ("existing", true);
+            item.Add ("hotlinkNodeId", CreateGuidObjectState (hotlinkNode.guid));
+            item.Add ("existing", false);
             results (item);
-            continue;
         }
-
-        API_HotlinkNode hotlinkNode = {};
-        hotlinkNode.type = APIHotlink_Module;
-        hotlinkNode.storyRangeType = APIHotlink_AllStories;
-        GS::UniString storyRangeType;
-        if (nodeData.Get ("storyRangeType", storyRangeType) && storyRangeType == "SingleStory") {
-            hotlinkNode.storyRangeType = APIHotlink_SingleStory;
-        }
-        Int32 refFloorIndex = 0;
-        nodeData.Get ("refFloorIndex", refFloorIndex);
-        hotlinkNode.refFloorInd = static_cast<short> (refFloorIndex);
-        GS::UniString name;
-        if (!nodeData.Get ("name", name) || name.IsEmpty ()) {
-            name = lastLocalName.ToString ();
-        }
-        GS::ucsncpy (hotlinkNode.name, name.ToUStr (), API_UniLongNameLen - 1);
-        // The example add-on allocates the location and never frees it; the
-        // node keeps a reference to it, so this add-on does the same when the
-        // node is created, and frees it when creation fails.
-        IO::Location* ownedLocation = new IO::Location (sourceLocation);
-        hotlinkNode.sourceLocation = ownedLocation;
-
-#ifdef ServerMainVers_2800
-        // Fills the story info from the source so the node is created with
-        // the right story settings. Not available before 28; creation works
-        // without it.
-        ACAPI_Hotlink_GetHotlinkStoryInfo (&hotlinkNode);
-#endif
-
-        const GSErrCode err = ACAPI_CallUndoableCommand ("Create Hotlink Node", [&] () -> GSErrCode {
-            return ACAPI_Hotlink_CreateHotlinkNode (&hotlinkNode);
-        });
-        if (err != NoError) {
-            delete ownedLocation;
-            hotlinkNode.sourceLocation = nullptr;
-            results (CreateErrorResponse (err, "Failed to create the hotlink node from " + sourcePath));
-            continue;
-        }
-
-        GS::ObjectState item;
-        item.Add ("hotlinkNodeId", CreateGuidObjectState (hotlinkNode.guid));
-        item.Add ("existing", false);
-        results (item);
-    }
+        return NoError;
+    });
 
     return response;
-}
-
-static API_Coord3D GetOriginFromObjectState (const GS::ObjectState& os)
-{
-    API_Coord3D origin = { 0.0, 0.0, 0.0 };
-    os.Get ("x", origin.x);
-    os.Get ("y", origin.y);
-    os.Get ("z", origin.z);
-    return origin;
 }
 
 CreateHotlinkInstancesCommand::CreateHotlinkInstancesCommand () :
@@ -2101,7 +2095,7 @@ GS::Optional<GS::UniString> CreateHotlinkInstancesCommand::GetInputParametersSch
                         },
                         "floorDifference": {
                             "type": "integer",
-                            "description": "Optional story offset applied to the module's stories. Defaults to 0."
+                            "description": "Optional story offset applied to the module's stories. Defaults to the hotlink tool's current default."
                         },
                         "layerIndex": {
                             "type": "integer",
@@ -2109,23 +2103,23 @@ GS::Optional<GS::UniString> CreateHotlinkInstancesCommand::GetInputParametersSch
                         },
                         "skipNested": {
                             "type": "boolean",
-                            "description": "Optional. Do not place hotlinks nested inside the module. Defaults to false."
+                            "description": "Optional. Do not place hotlinks nested inside the module. Defaults to the hotlink tool's current default."
                         },
                         "suspendFixAngle": {
                             "type": "boolean",
-                            "description": "Optional. Rotate fixed-angle elements with the module. Defaults to false."
+                            "description": "Optional. Rotate fixed-angle elements with the module. Defaults to the hotlink tool's current default."
                         },
                         "ignoreTopFloorLinks": {
                             "type": "boolean",
-                            "description": "Optional. Top-linked elements keep their height rather than their top story link. Defaults to true."
+                            "description": "Optional. Top-linked elements keep their height rather than their top story link. Defaults to the hotlink tool's current default."
                         },
                         "relinkWallOpenings": {
                             "type": "boolean",
-                            "description": "Optional. Defaults to false."
+                            "description": "Optional. Defaults to the hotlink tool's current default."
                         },
                         "adjustLevelDiffs": {
                             "type": "boolean",
-                            "description": "Optional. Defaults to false."
+                            "description": "Optional. Defaults to the hotlink tool's current default."
                         }
                     },
                     "additionalProperties": false,
@@ -2204,14 +2198,23 @@ GS::ObjectState CreateHotlinkInstancesCommand::Execute (const GS::ObjectState& p
                 element.header.floorInd = storyInfo.actStory;
             }
 
-            element.hotlink.type = APIHotlink_Module;
-            element.hotlink.hotlinkNodeGuid = GetGuidFromObjectState (*hotlinkNodeId);
+            // The instance takes the node's own type: GetHotlinks hands out XRef
+            // node ids as well as module ones, and a module instance of an XRef
+            // node is a mismatch.
+            API_HotlinkNode node = {};
+            node.guid = GetGuidFromObjectState (*hotlinkNodeId);
+            if (ACAPI_Hotlink_GetHotlinkNode (&node) != NoError) {
+                elements (CreateErrorResponse (APIERR_BADID, "hotlinkNodeId is not a hotlink node"));
+                continue;
+            }
+            element.hotlink.type = node.type;
+            element.hotlink.hotlinkNodeGuid = node.guid;
 
             double rotationAngle = 0.0;
             instanceData.Get ("rotationAngle", rotationAngle);
             bool mirrored = false;
             instanceData.Get ("mirrored", mirrored);
-            element.hotlink.transformation = CreateHotlinkTransformation (GetOriginFromObjectState (*origin), rotationAngle, mirrored);
+            element.hotlink.transformation = CreateHotlinkTransformation (Get3DCoordinateFromObjectState (*origin), rotationAngle, mirrored);
 
             // The placement options keep the tool defaults unless the caller sets them.
             Int32 floorDifference;
@@ -2349,7 +2352,7 @@ GS::ObjectState ChangeHotlinkInstancesCommand::Execute (const GS::ObjectState& p
             if (newOrigin != nullptr && !hasRotation && !hasMirrored) {
                 // A move keeps the matrix as it is - scale, skew and all - and
                 // replaces only the translation.
-                const API_Coord3D given = GetOriginFromObjectState (*newOrigin);
+                const API_Coord3D given = Get3DCoordinateFromObjectState (*newOrigin);
                 element.hotlink.transformation.tmx[3] = given.x;
                 element.hotlink.transformation.tmx[7] = given.y;
                 if (newOrigin->Contains ("z")) {
@@ -2365,7 +2368,7 @@ GS::ObjectState ChangeHotlinkInstancesCommand::Execute (const GS::ObjectState& p
                 bool mirrored;
                 DecomposeHotlinkTransformation (element.hotlink.transformation, origin, rotationAngle, mirrored);
                 if (newOrigin != nullptr) {
-                    const API_Coord3D given = GetOriginFromObjectState (*newOrigin);
+                    const API_Coord3D given = Get3DCoordinateFromObjectState (*newOrigin);
                     origin.x = given.x;
                     origin.y = given.y;
                     if (newOrigin->Contains ("z")) {

--- a/archicad-addon/Sources/ProjectCommands.hpp
+++ b/archicad-addon/Sources/ProjectCommands.hpp
@@ -58,6 +58,36 @@ public:
     virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
 };
 
+class CreateHotlinkNodesCommand : public CommandBase
+{
+public:
+    CreateHotlinkNodesCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class CreateHotlinkInstancesCommand : public CommandBase
+{
+public:
+    CreateHotlinkInstancesCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
+class ChangeHotlinkInstancesCommand : public CommandBase
+{
+public:
+    ChangeHotlinkInstancesCommand ();
+    virtual GS::String GetName () const override;
+    virtual GS::Optional<GS::UniString> GetInputParametersSchema () const override;
+    virtual GS::Optional<GS::UniString> GetRawResponseSchema () const override;
+    virtual GS::ObjectState Execute (const GS::ObjectState& parameters, GS::ProcessControl& processControl) const override;
+};
+
 class GetStoriesCommand : public CommandBase
 {
 public:

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -1731,7 +1731,7 @@
     },
     "HotlinkOrigin": {
         "type": "object",
-        "description": "Where a hotlink instance's origin lands, in the project's coordinates. z is optional and defaults to 0.",
+        "description": "Where a hotlink instance's origin lands, in the project's coordinates. z is optional: CreateHotlinkInstances places at 0 when it is omitted, ChangeHotlinkInstances keeps the instance's current z.",
         "properties": {
             "x": {
                 "type": "number"
@@ -1782,6 +1782,12 @@
             },
             "ignoreTopFloorLinks": {
                 "type": "boolean"
+            },
+            "relinkWallOpenings": {
+                "type": "boolean"
+            },
+            "adjustLevelDiffs": {
+                "type": "boolean"
             }
         },
         "additionalProperties": false,
@@ -1791,6 +1797,32 @@
             "origin",
             "rotationAngle",
             "mirrored"
+        ]
+    },
+    "HotlinkNodeCreated": {
+        "type": "object",
+        "properties": {
+            "hotlinkNodeId": {
+                "$ref": "#/HotlinkNodeId"
+            },
+            "existing": {
+                "type": "boolean",
+                "description": "True when a node for the same source file already existed and was returned instead of created."
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "hotlinkNodeId", "existing" ]
+    },
+    "HotlinkNodeCreatedOrError": {
+        "type": "object",
+        "description": "The created (or already existing) node's guid, or an error.",
+        "oneOf": [
+            {
+                "$ref": "#/HotlinkNodeCreated"
+            },
+            {
+                "$ref": "#/ErrorItem"
+            }
         ]
     },
     "SetGDLParameterArray": {

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -6395,7 +6395,8 @@
             "layerIndex",
             "drawIndex",
             "details",
-            "floorPlanPolygons"
+            "floorPlanPolygons",
+            "hotlinkId"
         ]
     },
     "RevisionIssueId": {

--- a/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
+++ b/archicad-addon/Sources/RFIX/Images/CommonSchemaDefinitions.json
@@ -1694,6 +1694,18 @@
                 "type": "string",
                 "description": "The path of the hotlink file."
             },
+            "hotlinkNodeId": {
+                "$ref": "#/HotlinkNodeId"
+            },
+            "name": {
+                "type": "string",
+                "description": "The display name of the hotlink node."
+            },
+            "type": {
+                "type": "string",
+                "description": "Module or XRef.",
+                "enum": ["Module", "XRef"]
+            },
             "children": {
                 "$ref": "#/Hotlinks",
                 "description": "The children of the hotlink node if it has any."
@@ -1702,6 +1714,83 @@
         "additionalProperties": false,
         "required": [
             "location"
+        ]
+    },
+    "HotlinkNodeId": {
+        "type": "object",
+        "description": "The identifier of a hotlink node - the reference to a module source file, which instances are placed from.",
+        "properties": {
+            "guid": {
+                "$ref": "#/Guid"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "guid"
+        ]
+    },
+    "HotlinkOrigin": {
+        "type": "object",
+        "description": "Where a hotlink instance's origin lands, in the project's coordinates. z is optional and defaults to 0.",
+        "properties": {
+            "x": {
+                "type": "number"
+            },
+            "y": {
+                "type": "number"
+            },
+            "z": {
+                "type": "number"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "x",
+            "y"
+        ]
+    },
+    "HotlinkDetails": {
+        "type": "object",
+        "description": "Details of a placed hotlink instance: which node it comes from and where it sits.",
+        "properties": {
+            "hotlinkType": {
+                "type": "string",
+                "enum": ["Module", "XRef"]
+            },
+            "hotlinkNodeId": {
+                "$ref": "#/HotlinkNodeId"
+            },
+            "origin": {
+                "$ref": "#/Coordinate3D"
+            },
+            "rotationAngle": {
+                "type": "number",
+                "description": "Counter-clockwise rotation about the origin, in radians."
+            },
+            "mirrored": {
+                "type": "boolean",
+                "description": "True when the module's local X axis is reflected."
+            },
+            "floorDifference": {
+                "type": "integer"
+            },
+            "skipNested": {
+                "type": "boolean"
+            },
+            "suspendFixAngle": {
+                "type": "boolean"
+            },
+            "ignoreTopFloorLinks": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "hotlinkType",
+            "hotlinkNodeId",
+            "origin",
+            "rotationAngle",
+            "mirrored"
         ]
     },
     "SetGDLParameterArray": {
@@ -6231,6 +6320,9 @@
         "description": "Represents the complete type-specific details of an element. Used as output from GET requests",
         "type": "object",
         "oneOf": [
+            {
+                "$ref": "#/HotlinkDetails"
+            },
             {
                 "$ref": "#/WallDetails"
             },

--- a/archicad-addon/Test/ExpectedOutputs/hotlink_instances.py.output
+++ b/archicad-addon/Test/ExpectedOutputs/hotlink_instances.py.output
@@ -1,0 +1,8 @@
+Command: GetHotlinks
+Parameters:
+{}
+Response:
+{
+    "hotlinks": []
+}
+No hotlink nodes in this project - set TAPIR_HOTLINK_SOURCE to create one.

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -418,13 +418,13 @@ var gCommands = [{
             },{
                 "name": "CreateHotlinkNodes",
                 "version": "1.5.9",
-                "description": "Creates hotlink module nodes from source files. A node that already points at the same file is returned instead of duplicated.",
+                "description": "Creates hotlink module nodes from source files. A node that already points at the same file is returned instead of duplicated (Archicad 27 and later; 25 and 26 cannot see an unplaced node).",
                 "inputScheme": {
         "type": "object",
         "properties": {
             "hotlinkNodes": {
                 "type": "array",
-                "description": "The hotlink module nodes to create. A node that already points at the same source file (compared case-insensitively) is returned as it is, with existing: true, and the name and story settings asked for are ignored.",
+                "description": "The hotlink module nodes to create. A node that already points at the same source file (compared case-insensitively) is returned as it is, with existing: true, and the name and story settings asked for are ignored. On Archicad 25 and 26 a node that has not been placed yet cannot be found, so a repeated request there creates a second node.",
                 "items": {
                     "type": "object",
                     "properties": {
@@ -463,22 +463,9 @@ var gCommands = [{
         "properties": {
             "hotlinkNodes": {
                 "type": "array",
-                "description": "One item per requested node, in order: the node guid, or an error.",
+                "description": "One item per requested node, in order: the node guid with its existing flag, or an error.",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "hotlinkNodeId": {
-                            "$ref": "#/HotlinkNodeId"
-                        },
-                        "existing": {
-                            "type": "boolean",
-                            "description": "True when a node for the same source file already existed and was returned instead of created."
-                        },
-                        "error": {
-                            "$ref": "#/Error"
-                        }
-                    },
-                    "additionalProperties": false
+                    "$ref": "#/HotlinkNodeCreatedOrError"
                 }
             }
         },
@@ -501,7 +488,8 @@ var gCommands = [{
                     "type": "object",
                     "properties": {
                         "hotlinkNodeId": {
-                            "$ref": "#/HotlinkNodeId"
+                            "$ref": "#/HotlinkNodeId",
+                            "description": "The node to place, from GetHotlinks or CreateHotlinkNodes. On Archicad 25 and 26 a node that has never been placed cannot be read, so a node created through the API can only be placed from Archicad 27 on."
                         },
                         "origin": {
                             "$ref": "#/HotlinkOrigin"

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -418,13 +418,13 @@ var gCommands = [{
             },{
                 "name": "CreateHotlinkNodes",
                 "version": "1.5.9",
-                "description": "Creates hotlink module nodes from source files. A node that already points at the same file is returned instead of duplicated (Archicad 27 and later; 25 and 26 cannot see an unplaced node).",
+                "description": "Creates hotlink module nodes from source files. A node that already points at the same file is returned instead of duplicated (Archicad 26 and later; 25 cannot see an unplaced node).",
                 "inputScheme": {
         "type": "object",
         "properties": {
             "hotlinkNodes": {
                 "type": "array",
-                "description": "The hotlink module nodes to create. A node that already points at the same source file (compared case-insensitively) is returned as it is, with existing: true, and the name and story settings asked for are ignored. On Archicad 25 and 26 a node that has not been placed yet cannot be found, so a repeated request there creates a second node.",
+                "description": "The hotlink module nodes to create. A node that already points at the same source file (compared case-insensitively) is returned as it is, with existing: true, and the name and story settings asked for are ignored. On Archicad 25 a node that has not been placed yet cannot be found, so a repeated request there creates a second node.",
                 "items": {
                     "type": "object",
                     "properties": {
@@ -489,7 +489,7 @@ var gCommands = [{
                     "properties": {
                         "hotlinkNodeId": {
                             "$ref": "#/HotlinkNodeId",
-                            "description": "The node to place, from GetHotlinks or CreateHotlinkNodes. On Archicad 25 and 26 a node that has never been placed cannot be read, so a node created through the API can only be placed from Archicad 27 on."
+                            "description": "The node to place, from GetHotlinks or CreateHotlinkNodes. On Archicad 25 a node that has never been placed cannot be read, so a node created through the API can only be placed from Archicad 26 on."
                         },
                         "origin": {
                             "$ref": "#/HotlinkOrigin"

--- a/docs/archicad-addon/command_definitions.js
+++ b/docs/archicad-addon/command_definitions.js
@@ -416,6 +416,237 @@ var gCommands = [{
         ]
     }
             },{
+                "name": "CreateHotlinkNodes",
+                "version": "1.5.9",
+                "description": "Creates hotlink module nodes from source files. A node that already points at the same file is returned instead of duplicated.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "hotlinkNodes": {
+                "type": "array",
+                "description": "The hotlink module nodes to create. A node that already points at the same source file (compared case-insensitively) is returned as it is, with existing: true, and the name and story settings asked for are ignored.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "sourceLocation": {
+                            "type": "string",
+                            "description": "Absolute path of the module source file (.mod or .pln)."
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Optional display name of the node. Defaults to the file name. Ignored when a node for the same file already exists."
+                        },
+                        "storyRangeType": {
+                            "type": "string",
+                            "description": "Optional. Which stories of the source are placed: all of them, or the single reference story. Ignored when a node for the same file already exists.",
+                            "enum": ["AllStories", "SingleStory"]
+                        },
+                        "refFloorIndex": {
+                            "type": "integer",
+                            "description": "Optional index of the reference story in the source file. Defaults to 0. Ignored when a node for the same file already exists."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "sourceLocation"
+                    ]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "hotlinkNodes"
+        ]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "hotlinkNodes": {
+                "type": "array",
+                "description": "One item per requested node, in order: the node guid, or an error.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "hotlinkNodeId": {
+                            "$ref": "#/HotlinkNodeId"
+                        },
+                        "existing": {
+                            "type": "boolean",
+                            "description": "True when a node for the same source file already existed and was returned instead of created."
+                        },
+                        "error": {
+                            "$ref": "#/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "hotlinkNodes"
+        ]
+    }
+            },{
+                "name": "CreateHotlinkInstances",
+                "version": "1.5.9",
+                "description": "Places instances of hotlink module nodes at an origin, rotation and mirroring.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "hotlinkInstances": {
+                "type": "array",
+                "description": "The hotlink instances to place.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "hotlinkNodeId": {
+                            "$ref": "#/HotlinkNodeId"
+                        },
+                        "origin": {
+                            "$ref": "#/HotlinkOrigin"
+                        },
+                        "rotationAngle": {
+                            "type": "number",
+                            "description": "Optional rotation about the origin, counter-clockwise, in radians. Defaults to 0."
+                        },
+                        "mirrored": {
+                            "type": "boolean",
+                            "description": "Optional. Reflects the module's local X axis before the rotation. Defaults to false."
+                        },
+                        "floorIndex": {
+                            "type": "integer",
+                            "description": "Optional story the instance is placed on. Defaults to the current story."
+                        },
+                        "floorDifference": {
+                            "type": "integer",
+                            "description": "Optional story offset applied to the module's stories. Defaults to the hotlink tool's current default."
+                        },
+                        "layerIndex": {
+                            "type": "integer",
+                            "description": "Optional layer of the instance. Defaults to the hotlink tool's current default layer."
+                        },
+                        "skipNested": {
+                            "type": "boolean",
+                            "description": "Optional. Do not place hotlinks nested inside the module. Defaults to the hotlink tool's current default."
+                        },
+                        "suspendFixAngle": {
+                            "type": "boolean",
+                            "description": "Optional. Rotate fixed-angle elements with the module. Defaults to the hotlink tool's current default."
+                        },
+                        "ignoreTopFloorLinks": {
+                            "type": "boolean",
+                            "description": "Optional. Top-linked elements keep their height rather than their top story link. Defaults to the hotlink tool's current default."
+                        },
+                        "relinkWallOpenings": {
+                            "type": "boolean",
+                            "description": "Optional. Defaults to the hotlink tool's current default."
+                        },
+                        "adjustLevelDiffs": {
+                            "type": "boolean",
+                            "description": "Optional. Defaults to the hotlink tool's current default."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "hotlinkNodeId",
+                        "origin"
+                    ]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "hotlinkInstances"
+        ]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "elements": {
+                "$ref": "#/ElementIdsOrErrors"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "elements"
+        ]
+    }
+            },{
+                "name": "ChangeHotlinkInstances",
+                "version": "1.5.9",
+                "description": "Moves, rotates or mirrors placed hotlink instances by changing their transformation. MoveElements and RotateElements do not work on hotlink instances.",
+                "inputScheme": {
+        "type": "object",
+        "properties": {
+            "hotlinkInstances": {
+                "type": "array",
+                "description": "The placed hotlink instances to change. Every field but elementId is optional; a field that is omitted keeps its current value.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "elementId": {
+                            "$ref": "#/ElementId"
+                        },
+                        "origin": {
+                            "$ref": "#/HotlinkOrigin"
+                        },
+                        "rotationAngle": {
+                            "type": "number",
+                            "description": "Rotation about the origin, counter-clockwise, in radians."
+                        },
+                        "mirrored": {
+                            "type": "boolean",
+                            "description": "Reflect the module's local X axis before the rotation."
+                        },
+                        "floorDifference": {
+                            "type": "integer"
+                        },
+                        "skipNested": {
+                            "type": "boolean"
+                        },
+                        "suspendFixAngle": {
+                            "type": "boolean"
+                        },
+                        "ignoreTopFloorLinks": {
+                            "type": "boolean"
+                        },
+                        "relinkWallOpenings": {
+                            "type": "boolean"
+                        },
+                        "adjustLevelDiffs": {
+                            "type": "boolean"
+                        },
+                        "layerIndex": {
+                            "type": "integer",
+                            "description": "Move the instance to this layer."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "elementId"
+                    ]
+                }
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "hotlinkInstances"
+        ]
+    },
+                "outputScheme": {
+        "type": "object",
+        "properties": {
+            "executionResults": {
+                "$ref": "#/ExecutionResults"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "executionResults"
+        ]
+    }
+            },{
                 "name": "OpenProject",
                 "version": "1.0.7",
                 "description": "Opens the given project.",
@@ -966,7 +1197,7 @@ var gCommands = [{
             },{
                 "name": "GetDetailsOfElements",
                 "version": "1.5.7",
-                "description": "Gets the details of the given elements (geometry parameters etc).",
+                "description": "Gets the details of the given elements (geometry parameters etc). Use the optional fields parameter to return only the fields you need and skip the computation of the others (for example floorPlanPolygons).",
                 "inputScheme": {
         "type": "object",
         "properties": {
@@ -1010,6 +1241,10 @@ var gCommands = [{
                         },
                         "drawIndex": {
                             "type": "number"
+                        },
+                        "hotlinkId": {
+                            "$ref": "#/ElementId",
+                            "description": "The hotlink instance this element belongs to. Present only for elements that came in through a placed hotlink; such elements are read-only."
                         },
                         "details": {
                             "$ref": "#/TypeSpecificDetails"
@@ -2140,6 +2375,10 @@ var gCommands = [{
                             "type": "number",
                             "description": "Depth (going) of each tread.",
                             "exclusiveMinimum": 0.0
+                        },
+                        "finishVisible": {
+                            "type": "boolean",
+                            "description": "Optional. If false, the tread/riser finishes are hidden and only the stair structure (e.g. a monolith) is modeled."
                         }
                     },
                     "additionalProperties": false,
@@ -3928,7 +4167,8 @@ var gCommands = [{
                         "polygonOutline": {
                             "type": "array",
                             "items": { "$ref": "#/Coordinate2D" },
-                            "minItems": 3
+                            "minItems": 3,
+                            "description": "Replaces the slab's entire polygon, including its holes - resend the holes field too to keep them, otherwise they are removed."
                         },
                         "polygonArcs": {
                             "type": "array",
@@ -4018,7 +4258,9 @@ var gCommands = [{
                         "centerOffset": { "type": "number", "minimum": 0.0 },
                         "reflected": { "type": "boolean" },
                         "refSide": { "type": "boolean" },
-                        "oSide": { "type": "boolean" }
+                        "oSide": { "type": "boolean" },
+                        "reveal": { "type": "boolean", "description": "Turn the reveal on or off." },
+                        "revealDepthOffset": { "type": "number", "description": "Distance the frame plane is moved across the wall thickness, along the wall normal." }
                     },
                     "additionalProperties": false,
                     "required": ["elementId"]
@@ -4048,7 +4290,9 @@ var gCommands = [{
                         "centerOffset": { "type": "number", "minimum": 0.0 },
                         "reflected": { "type": "boolean" },
                         "refSide": { "type": "boolean" },
-                        "oSide": { "type": "boolean" }
+                        "oSide": { "type": "boolean" },
+                        "reveal": { "type": "boolean", "description": "Turn the reveal on or off." },
+                        "revealDepthOffset": { "type": "number", "description": "Distance the frame plane is moved across the wall thickness, along the wall normal." }
                     },
                     "additionalProperties": false,
                     "required": ["elementId"]
@@ -5470,13 +5714,13 @@ var gCommands = [{
             },{
                 "name": "UpdatePropertyDefinitions",
                 "version": "1.5.4",
-                "description": "Updates the expression(s) of existing expression-based Custom Property Definitions.",
+                "description": "Updates existing Custom Property Definitions: the expression(s) of an expression-based property, or the possible enum values of an enumeration property.",
                 "inputScheme": {
         "type": "object",
         "properties": {
             "propertyDefinitions": {
                 "type": "array",
-                "description": "The list of expression-based property definitions to update.",
+                "description": "The property definitions to update.",
                 "items": {
                     "type": "object",
                     "properties": {
@@ -5485,17 +5729,20 @@ var gCommands = [{
                         },
                         "expressions": {
                             "type": "array",
-                            "description": "The new expression strings for the property.",
+                            "description": "The new expression strings for the property. Only for expression-based properties.",
                             "items": {
                                 "type": "string"
                             },
                             "minItems": 1
+                        },
+                        "possibleEnumValues": {
+                            "$ref": "#/EnumValuesToAdd",
+                            "description": "The enum values to add to an enumeration property. Values already on the property keep their identifier, so element values assigned to them survive; values not listed here are kept as well."
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "propertyId",
-                        "expressions"
+                        "propertyId"
                     ]
                 }
             }

--- a/docs/archicad-addon/common_schema_definitions.js
+++ b/docs/archicad-addon/common_schema_definitions.js
@@ -1694,6 +1694,18 @@ var gSchemaDefinitions = {
                 "type": "string",
                 "description": "The path of the hotlink file."
             },
+            "hotlinkNodeId": {
+                "$ref": "#/HotlinkNodeId"
+            },
+            "name": {
+                "type": "string",
+                "description": "The display name of the hotlink node."
+            },
+            "type": {
+                "type": "string",
+                "description": "Module or XRef.",
+                "enum": ["Module", "XRef"]
+            },
             "children": {
                 "$ref": "#/Hotlinks",
                 "description": "The children of the hotlink node if it has any."
@@ -1702,6 +1714,83 @@ var gSchemaDefinitions = {
         "additionalProperties": false,
         "required": [
             "location"
+        ]
+    },
+    "HotlinkNodeId": {
+        "type": "object",
+        "description": "The identifier of a hotlink node - the reference to a module source file, which instances are placed from.",
+        "properties": {
+            "guid": {
+                "$ref": "#/Guid"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "guid"
+        ]
+    },
+    "HotlinkOrigin": {
+        "type": "object",
+        "description": "Where a hotlink instance's origin lands, in the project's coordinates. z is optional and defaults to 0.",
+        "properties": {
+            "x": {
+                "type": "number"
+            },
+            "y": {
+                "type": "number"
+            },
+            "z": {
+                "type": "number"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "x",
+            "y"
+        ]
+    },
+    "HotlinkDetails": {
+        "type": "object",
+        "description": "Details of a placed hotlink instance: which node it comes from and where it sits.",
+        "properties": {
+            "hotlinkType": {
+                "type": "string",
+                "enum": ["Module", "XRef"]
+            },
+            "hotlinkNodeId": {
+                "$ref": "#/HotlinkNodeId"
+            },
+            "origin": {
+                "$ref": "#/Coordinate3D"
+            },
+            "rotationAngle": {
+                "type": "number",
+                "description": "Counter-clockwise rotation about the origin, in radians."
+            },
+            "mirrored": {
+                "type": "boolean",
+                "description": "True when the module's local X axis is reflected."
+            },
+            "floorDifference": {
+                "type": "integer"
+            },
+            "skipNested": {
+                "type": "boolean"
+            },
+            "suspendFixAngle": {
+                "type": "boolean"
+            },
+            "ignoreTopFloorLinks": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "hotlinkType",
+            "hotlinkNodeId",
+            "origin",
+            "rotationAngle",
+            "mirrored"
         ]
     },
     "SetGDLParameterArray": {
@@ -2511,6 +2600,9 @@ var gSchemaDefinitions = {
         "type": "object",
         "description": "The details of the property.",
         "properties": {
+            "possibleEnumValues": {
+                "$ref": "#/PossibleEnumValues"
+            },
             "propertyId": {
                 "$ref": "#/PropertyId"
             },
@@ -6156,6 +6248,10 @@ var gSchemaDefinitions = {
           },
           "hasLeaderLine": {
             "type": "boolean"
+          },
+          "text": {
+            "type": "string",
+            "description": "The text content of the label. Present only for text-type labels (symbol labels have no text content)."
           }
         },
         "additionalProperties": false,
@@ -6165,7 +6261,49 @@ var gSchemaDefinitions = {
               "endCoordinate",
               "hasLeaderLine"
           ]
-    },    
+    },
+    "TextDetails": {
+        "type": "object",
+        "properties": {
+            "text": {
+                "type": "string",
+                "description": "The text content. Newlines separate the lines."
+            },
+            "position": {
+                "$ref": "#/Coordinate2D",
+                "description": "The placement position of the text."
+            },
+            "angle": {
+                "type": "number",
+                "description": "The rotation angle in radians."
+            },
+            "height": {
+                "type": "number",
+                "description": "The character height in millimeters."
+            },
+            "pen": {
+                "type": "integer",
+                "description": "The pen attribute index."
+            },
+            "justification": {
+                "type": "string",
+                "enum": ["Left", "Center", "Right", "Full"]
+            },
+            "zCoordinate": {
+                "type": "number"
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "text",
+            "position",
+            "angle",
+            "height",
+            "pen",
+            "justification",
+            "zCoordinate"
+        ]
+    },
     "NotYetSupportedElementTypeDetails": {
         "type": "object",
         "properties": {
@@ -6182,6 +6320,9 @@ var gSchemaDefinitions = {
         "description": "Represents the complete type-specific details of an element. Used as output from GET requests",
         "type": "object",
         "oneOf": [
+            {
+                "$ref": "#/HotlinkDetails"
+            },
             {
                 "$ref": "#/WallDetails"
             },
@@ -6237,6 +6378,9 @@ var gSchemaDefinitions = {
                 "$ref": "#/LabelDetails"
             },
             {
+                "$ref": "#/TextDetails"
+            },
+            {
                 "$ref": "#/NotYetSupportedElementTypeDetails"
             }
         ]
@@ -6251,7 +6395,8 @@ var gSchemaDefinitions = {
             "layerIndex",
             "drawIndex",
             "details",
-            "floorPlanPolygons"
+            "floorPlanPolygons",
+            "hotlinkId"
         ]
     },
     "RevisionIssueId": {
@@ -6953,6 +7098,35 @@ var gSchemaDefinitions = {
         },
         "additionalProperties": false
     },
+    "TextSettings": {
+        "type": "object",
+        "description": "Settings for modifying a Text element or a text-type Label. For Labels only the text field is applied. Setting text replaces the whole content (any per-run formatting of the old content is dropped) and switches the element to automatic width, matching the behavior of CreateTexts/CreateLabels.",
+        "properties": {
+            "text": {
+                "type": "string",
+                "description": "The new text content. Newlines create multiple lines."
+            },
+            "position": {
+                "$ref": "#/Coordinate2D",
+                "description": "The placement position of the text. Only applied to Text elements."
+            },
+            "angle": {
+                "type": "number",
+                "description": "The rotation angle in radians. Only applied to Text elements."
+            },
+            "height": {
+                "type": "number",
+                "description": "The character height in millimeters. Only applied to Text elements."
+            },
+            "justification": {
+                "type": "string",
+                "enum": ["Left", "Center", "Right", "Full"],
+                "description": "The text justification. Only applied to Text elements."
+            }
+        },
+        "additionalProperties": false,
+        "required": []
+    },
     "TypeSpecificSettings": {
         "description": "Defines the modifiable type-specific settings for an element. Used as input for SET requests.",
         "type": "object",
@@ -6983,6 +7157,9 @@ var gSchemaDefinitions = {
             },
             {
                 "$ref": "#/DrawingSettings"
+            },
+            {
+                "$ref": "#/TextSettings"
             }
         ]
     },
@@ -7015,78 +7192,85 @@ var gSchemaDefinitions = {
             "propertyGroup"
         ]
     },
-    "PropertyDefinition": {
-        "type": "object",
-        "properties": {
-            "name": {
-                "type": "string"
-            },
-            "description": {
-                "type": "string"
-            },
-            "type": {
-                "$ref": "#/PropertyDataType"
-            },
-            "isEditable": {
-                "type": "boolean"
-            },
-            "defaultValue": {
-                "$ref": "#/PropertyDefaultValue"
-            },
-            "possibleEnumValues": {
-                "type": "array",
-                "description": "The possible enum values of the property when the property type is enumeration.",
-                "items": {
+    "PossibleEnumValues": {
+        "type": "array",
+        "description": "The possible enum values of the property when the property type is enumeration.",
+        "items": {
+            "type": "object",
+            "properties": {
+                "enumValue": {
                     "type": "object",
+                    "description": "The description of an enumeration value.",
                     "properties": {
-                        "enumValue": {
-                            "type": "object",
-                            "description": "The description of an enumeration value.",
-                            "properties": {
-                                "enumValueId": {
-                                    "$ref": "#/EnumValueId"
-                                },
-                                "displayValue": {
-                                    "type": "string",
-                                    "description": "Displayed value of the enumeration."
-                                },
-                                "nonLocalizedValue": {
-                                    "type": "string",
-                                    "description": "Nonlocalized value of the enumeration if there is one."
-                                }
-                            },
-                            "additionalProperties": false,
-                            "required": [
-                                "displayValue"
-                            ]
+                        "enumValueId": {
+                            "$ref": "#/EnumValueId"
+                        },
+                "guid": {
+                    "$ref": "#/Guid",
+                    "description": "The identifier of the enumeration value, as reported by GetAllProperties. An element's stored value refers to the value by this."
+                },
+                        "displayValue": {
+                            "type": "string",
+                            "description": "Displayed value of the enumeration."
+                        },
+                        "nonLocalizedValue": {
+                            "type": "string",
+                            "description": "Nonlocalized value of the enumeration if there is one."
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "enumValue"
+                        "displayValue"
                     ]
                 }
             },
+            "additionalProperties": false,
+            "required": [
+                "enumValue"
+            ]
+        }
+            },
+    "PropertyDefinition": {
+        "type": "object",
+        "properties": {
+            "name": {
+        "type": "string"
+            },
+            "description": {
+        "type": "string"
+            },
+            "type": {
+        "$ref": "#/PropertyDataType"
+            },
+            "isEditable": {
+        "type": "boolean"
+            },
+            "defaultValue": {
+        "$ref": "#/PropertyDefaultValue"
+            },
+            "possibleEnumValues": {
+        "$ref": "#/PossibleEnumValues"
+            },
             "availability": {
-                "type": "array",
-                "description": "The identifiers of classification items the new property is available for.",
-                "items": {
-                    "$ref": "#/ClassificationItemIdArrayItem"
-                }
+        "type": "array",
+        "description": "The identifiers of classification items the new property is available for.",
+        "items": {
+            "$ref": "#/ClassificationItemIdArrayItem"
+        }
             },
             "group": {
-                "type": "object",
-                "description": "The property group defined by name or id. If both fields exists the id will be used.",
-                "properties": {
-                    "propertyGroupId": {
-                        "$ref": "#/PropertyGroupId"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "required": []
+        "type": "object",
+        "description": "The property group defined by name or id. If both fields exists the id will be used.",
+        "properties": {
+            "propertyGroupId": {
+                "$ref": "#/PropertyGroupId"
+            },
+            "name": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": []
             }
         },
         "additionalProperties": false,
@@ -7099,6 +7283,37 @@ var gSchemaDefinitions = {
             "group"
         ]
 
+    },
+    "EnumValuesToAdd": {
+        "type": "array",
+        "description": "Enumeration values to add to a property.",
+        "items": {
+            "type": "object",
+            "properties": {
+                "enumValue": {
+                    "type": "object",
+                    "description": "The description of an enumeration value.",
+                    "properties": {
+                        "displayValue": {
+                            "type": "string",
+                            "description": "Displayed value of the enumeration."
+                        },
+                        "nonLocalizedValue": {
+                            "type": "string",
+                            "description": "Nonlocalized value of the enumeration if there is one."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "displayValue"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "enumValue"
+            ]
+        }
     },
     "PropertyDefinitionArrayItem": {
         "description": "A wrapper containing a property definition",

--- a/docs/archicad-addon/common_schema_definitions.js
+++ b/docs/archicad-addon/common_schema_definitions.js
@@ -1731,7 +1731,7 @@ var gSchemaDefinitions = {
     },
     "HotlinkOrigin": {
         "type": "object",
-        "description": "Where a hotlink instance's origin lands, in the project's coordinates. z is optional and defaults to 0.",
+        "description": "Where a hotlink instance's origin lands, in the project's coordinates. z is optional: CreateHotlinkInstances places at 0 when it is omitted, ChangeHotlinkInstances keeps the instance's current z.",
         "properties": {
             "x": {
                 "type": "number"
@@ -1782,6 +1782,12 @@ var gSchemaDefinitions = {
             },
             "ignoreTopFloorLinks": {
                 "type": "boolean"
+            },
+            "relinkWallOpenings": {
+                "type": "boolean"
+            },
+            "adjustLevelDiffs": {
+                "type": "boolean"
             }
         },
         "additionalProperties": false,
@@ -1791,6 +1797,32 @@ var gSchemaDefinitions = {
             "origin",
             "rotationAngle",
             "mirrored"
+        ]
+    },
+    "HotlinkNodeCreated": {
+        "type": "object",
+        "properties": {
+            "hotlinkNodeId": {
+                "$ref": "#/HotlinkNodeId"
+            },
+            "existing": {
+                "type": "boolean",
+                "description": "True when a node for the same source file already existed and was returned instead of created."
+            }
+        },
+        "additionalProperties": false,
+        "required": [ "hotlinkNodeId", "existing" ]
+    },
+    "HotlinkNodeCreatedOrError": {
+        "type": "object",
+        "description": "The created (or already existing) node's guid, or an error.",
+        "oneOf": [
+            {
+                "$ref": "#/HotlinkNodeCreated"
+            },
+            {
+                "$ref": "#/ErrorItem"
+            }
         ]
     },
     "SetGDLParameterArray": {


### PR DESCRIPTION
## What

Hotlink modules were read-only through Tapir: `GetHotlinks` listed the node paths and nothing could create a node, place an instance or move one. `MoveElements` / `RotateElements` on a placed instance return success and move nothing (the drag edit does not apply to hotlinks); an instance moves by changing its transformation.

New commands, project group, 1.5.9:

- **CreateHotlinkNodes** - nodes from source files (`.mod` / `.pln`). A node that already points at the same file is returned with `existing: true` instead of being duplicated.
- **CreateHotlinkInstances** - place instances of a node at an `origin`, `rotationAngle` and `mirrored` flag, on a story, with `floorDifference`, `skipNested`, `suspendFixAngle`, `ignoreTopFloorLinks`, `relinkWallOpenings`, `adjustLevelDiffs` and an optional `layerIndex`. Response is the usual `elements` list of ids or errors.
- **ChangeHotlinkInstances** - move, rotate or mirror placed instances; omitted fields keep their value.

Reads:

- `GetHotlinks` now carries `hotlinkNodeId`, `name` and `type` beside `location` (additive; schema updated).
- `GetDetailsOfElements` returns `HotlinkDetails` for a hotlink instance (node, origin, rotation, mirror, story options) instead of "Not yet supported element type", and any element that came in through a placed hotlink reports its instance as `hotlinkId` (those elements are read-only).

## How

Follows the DevKit's `Examples/Element_Test/Src/Element_Hotlink.cpp`: `ACAPI_Hotlink_CreateHotlinkNode`, `ACAPI_Element_Create` on an `API_HotlinkType` with an `API_Tranmat`, `ACAPI_Element_Change` on the transformation. The transformation helpers (origin + angle + mirror both ways) live in `CommandBase` and are shared with the details read. Mirroring reflects the module's local X axis before the rotation, which keeps the matrix orthogonal.

AC25 and AC26 go through `ACAPI_Database` with the `APIDb_*Hotlink*ID` codes via `MigrationHelper.hpp` (`CreateHotlinkNode`, `GetHotlinkNodes`, `GetHotlinkInstances`); `GetHotlinkStoryInfo` is 28+ only and is called under `#ifdef ServerMainVers_2800`.

## Testing

`Examples/hotlink_instances.py`: creates a node from `TAPIR_HOTLINK_SOURCE` if set (else uses the first placed node), places an instance, reads it, moves and mirrors it, reads it again, deletes it. Run on a live Archicad 28 with the AC28 CI build of this branch: the change round-trips exactly (see the comments). The expected output is recorded against `TestProject.pla` the way `test_examples.py` records it, and the docs are regenerated with `GenerateDocumentation` from that build. Archicad 25 and 26 cannot read a node that has never been placed, so on those versions a node created through the API cannot be placed in the same session; the descriptions say so.

Why: a layout engine that arranges a developer's module library needs to place and move hotlinks, and today the only route is a human with the Place Module dialog.


