### PR TITLE
Allow fork contributors to trigger the Claude PR review

### DIFF
--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -170,5 +170,5 @@ jobs:
 # -----------
 # This workflow only reviews. Merging is claude_auto_merge.yml, which requires
 # a collaborator author, every check green, and a diff touching none of the
-# release critical paths - see that file's header for why these gates are shell
+# release critical paths - see that file's header for why those gates are shell
 # rather than a model decision.

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -66,6 +66,16 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+          # The action gates on the triggering actor having write access to
+          # the repository, which every fork contributor by definition lacks -
+          # without this the review fails on exactly the pull requests this
+          # workflow exists for (see the pull_request_target note above). "*"
+          # is safe under the same rule that makes pull_request_target safe:
+          # the head is never checked out or executed, the diff is read as
+          # text, the token has only pull-request write, and the prompt treats
+          # the contributor's text as data, not instructions.
+          allowed_non_write_users: "*"
+
           # track_progress is deliberately NOT set. It creates a tracking
           # comment with progress checkboxes as soon as the run starts and
           # edits it as the review proceeds; the review should arrive as one
@@ -160,5 +170,5 @@ jobs:
 # -----------
 # This workflow only reviews. Merging is claude_auto_merge.yml, which requires
 # a collaborator author, every check green, and a diff touching none of the
-# release critical paths - see that file's header for why those gates are shell
+# release critical paths - see that file's header for why these gates are shell
 # rather than a model decision.


### PR DESCRIPTION
## What

The Claude PR Review workflow fails on every pull request from a fork before reviewing anything. On [PR #622](https://github.com/ENZYME-APD/tapir-archicad-automation/pull/622) the `review` job exited with:

```
Checking permissions for actor: kozure-dev
Permission level retrieved: read
Actor has insufficient permissions: read
Action failed with error: Actor does not have write permissions to the repository
```

The workflow already runs on `pull_request_target` precisely so fork PRs get reviewed, but `anthropics/claude-code-action` has its own gate on top: the triggering actor must have write access to the repository, which outside contributors by definition don't. So the review currently runs only for maintainers' own branches — the opposite of the workflow's stated intent.

## Fix

Set `allowed_non_write_users: "*"` on the action (it requires the `github_token` input, which the workflow already passes). This is covered by the same safety argument the workflow's header makes for `pull_request_target` itself:

- the PR head is never checked out or executed — checkout pins the base commit;
- the diff is read as text via `gh pr diff`, and the prompt explicitly treats it as data, not instructions;
- the job's token has only `contents: read` and `pull-requests: write`;
- allowed tools are restricted to read-only file access plus `gh pr` commenting.

With the input set, the action also does a best-effort scrub of Anthropic/cloud/Actions secrets from subprocess environments.

One side effect worth knowing: any GitHub account that opens a PR now consumes a review run against the `CLAUDE_CODE_OAUTH_TOKEN` subscription. That is the intended purpose of the workflow, but it is what "*" opts into.

## Testing

Workflow-file change only; it takes effect from `main` (the `pull_request_target` run uses the base branch's workflow), so the real test is the next fork PR — pushing a new commit to PR #622 after merge will re-trigger the review and it should proceed past the permission gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011J8sXeXkye3FdHRc2PUKX8

---
_Generated by [Claude Code](https://claude.ai/code/session_011J8sXeXkye3FdHRc2PUKX8)_