### PR TITLE
Add a GetDimensionData example

### DIFF
--- a/archicad-addon/Examples/get_dimension_data.py
+++ b/archicad-addon/Examples/get_dimension_data.py
@@ -41,7 +41,9 @@ def PrintDimensionData (dimensionId):
     data = aclib.RunTapirCommand ('GetDimensionData', {'elements': [dimensionId]}, debug = False)['dimensionsData'][0]
     print ('direction=({}, {}) witness points={}'.format (data['direction']['x'], data['direction']['y'], len (data['witnessPoints'])))
     for p in data['witnessPoints']:
-        baseElement = next ((i for i, wallId in enumerate (wallIds) if wallId['guid'] == p['baseElementId']['guid']), None)
+        # baseElementId is missing when the witness point is not attached to any element.
+        baseElementId = p.get ('baseElementId')
+        baseElement = next ((i for i, wallId in enumerate (wallIds) if baseElementId is not None and wallId['guid'] == baseElementId['guid']), None)
         print ('  wall {} at ({}, {}) value={} line={} inIndex={} special={} nodeType={} nodeStatus={} nodeId={}'.format (
             baseElement, p['coordinate']['x'], p['coordinate']['y'], p['dimensionValue'],
             p['line'], p['inIndex'], p['special'], p['nodeType'], p['nodeStatus'], p['nodeId']))
@@ -50,28 +52,32 @@ def PrintDimensionData (dimensionId):
 data = PrintDimensionData (dimensions[0])
 
 # The witness parameters read back are enough to rebuild the same dimension.
-rebuilt = aclib.RunTapirCommand ('CreateAssociativeDimensions', {
-    'dimensionsData': [
-        {
-            'referencePoint': {'x': 0.0, 'y': -57.0},
-            'direction': data['direction'],
-            'witnessPoints': [
-                {
-                    'elementId': p['baseElementId'],
-                    'line': p['line'],
-                    'inIndex': p['inIndex'],
-                    'special': p['special'],
-                    'nodeType': p['nodeType'],
-                    'nodeStatus': p['nodeStatus'],
-                    'nodeId': p['nodeId']
-                }
-                for p in data['witnessPoints']
-            ]
-        }
-    ]
-}, debug = False)['elements']
-rebuiltData = PrintDimensionData (rebuilt[0])
-print ('rebuilt dimension measures the same: {}'.format (
-    [p['coordinate'] for p in rebuiltData['witnessPoints']] == [p['coordinate'] for p in data['witnessPoints']]))
+rebuilt = []
+if all ('baseElementId' in p for p in data['witnessPoints']):
+    rebuilt = aclib.RunTapirCommand ('CreateAssociativeDimensions', {
+        'dimensionsData': [
+            {
+                'referencePoint': {'x': 0.0, 'y': -57.0},
+                'direction': data['direction'],
+                'witnessPoints': [
+                    {
+                        'elementId': p['baseElementId'],
+                        'line': p['line'],
+                        'inIndex': p['inIndex'],
+                        'special': p['special'],
+                        'nodeType': p['nodeType'],
+                        'nodeStatus': p['nodeStatus'],
+                        'nodeId': p['nodeId']
+                    }
+                    for p in data['witnessPoints']
+                ]
+            }
+        ]
+    }, debug = False)['elements']
+    rebuiltData = PrintDimensionData (rebuilt[0])
+    print ('rebuilt dimension measures the same: {}'.format (
+        [p['coordinate'] for p in rebuiltData['witnessPoints']] == [p['coordinate'] for p in data['witnessPoints']]))
+else:
+    print ('not every witness point is attached to a wall, nothing to rebuild')
 
 aclib.RunTapirCommand ('DeleteElements', {'elements': dimensions + rebuilt + walls}, debug = False)

--- a/archicad-addon/Examples/get_dimension_data.py
+++ b/archicad-addon/Examples/get_dimension_data.py
@@ -43,7 +43,7 @@ def Rounded (coordinate):
 
 def PrintDimensionData (dimensionId):
     data = aclib.RunTapirCommand ('GetDimensionData', {'elements': [dimensionId]}, debug = False)['dimensionsData'][0]
-    print ('direction=({}, {}) witness points={}'.format (data['direction']['x'], data['direction']['y'], len (data['witnessPoints'])))
+    print ('direction={} witness points={}'.format (Rounded (data['direction']), len (data['witnessPoints'])))
     for p in data['witnessPoints']:
         # baseElementId is missing when the witness point is not attached to any element.
         baseElementId = p.get ('baseElementId')

--- a/archicad-addon/Examples/get_dimension_data.py
+++ b/archicad-addon/Examples/get_dimension_data.py
@@ -37,6 +37,10 @@ dimensions = aclib.RunTapirCommand ('CreateAssociativeDimensions', {
     ]
 }, debug = False)['elements']
 
+# Coordinates and values are recomputed by Archicad, so they are rounded before printing or comparing.
+def Rounded (coordinate):
+    return (round (coordinate['x'], 6), round (coordinate['y'], 6))
+
 def PrintDimensionData (dimensionId):
     data = aclib.RunTapirCommand ('GetDimensionData', {'elements': [dimensionId]}, debug = False)['dimensionsData'][0]
     print ('direction=({}, {}) witness points={}'.format (data['direction']['x'], data['direction']['y'], len (data['witnessPoints'])))
@@ -44,8 +48,8 @@ def PrintDimensionData (dimensionId):
         # baseElementId is missing when the witness point is not attached to any element.
         baseElementId = p.get ('baseElementId')
         baseElement = next ((i for i, wallId in enumerate (wallIds) if baseElementId is not None and wallId['guid'] == baseElementId['guid']), None)
-        print ('  wall {} at ({}, {}) value={} line={} inIndex={} special={} nodeType={} nodeStatus={} nodeId={}'.format (
-            baseElement, p['coordinate']['x'], p['coordinate']['y'], p['dimensionValue'],
+        print ('  wall {} at {} value={} line={} inIndex={} special={} nodeType={} nodeStatus={} nodeId={}'.format (
+            baseElement, Rounded (p['coordinate']), round (p['dimensionValue'], 6),
             p['line'], p['inIndex'], p['special'], p['nodeType'], p['nodeStatus'], p['nodeId']))
     return data
 
@@ -76,7 +80,7 @@ if all ('baseElementId' in p for p in data['witnessPoints']):
     }, debug = False)['elements']
     rebuiltData = PrintDimensionData (rebuilt[0])
     print ('rebuilt dimension measures the same: {}'.format (
-        [p['coordinate'] for p in rebuiltData['witnessPoints']] == [p['coordinate'] for p in data['witnessPoints']]))
+        [Rounded (p['coordinate']) for p in rebuiltData['witnessPoints']] == [Rounded (p['coordinate']) for p in data['witnessPoints']]))
 else:
     print ('not every witness point is attached to a wall, nothing to rebuild')
 

--- a/archicad-addon/Examples/get_dimension_data.py
+++ b/archicad-addon/Examples/get_dimension_data.py
@@ -1,0 +1,77 @@
+import aclib
+
+# Dimension two walls with CreateAssociativeDimensions, then read the dimension back with
+# GetDimensionData. Each witness point reports the parameters CreateAssociativeDimensions takes
+# (line, inIndex, special, nodeType, nodeStatus, nodeId), so a dimension placed by hand in Archicad
+# can be read back to learn the values an element type needs, and a dimension can be rebuilt from
+# what was read.
+walls = aclib.RunTapirCommand ('CreateWalls', {
+    'wallsData': [
+        {
+            'begCoordinate': {'x': 0.0, 'y': -60.0},
+            'endCoordinate': {'x': 4.0, 'y': -60.0},
+            'height': 3.0,
+            'thickness': 0.3
+        },
+        {
+            'begCoordinate': {'x': 7.0, 'y': -60.0},
+            'endCoordinate': {'x': 11.0, 'y': -60.0},
+            'height': 3.0,
+            'thickness': 0.3
+        }
+    ]
+}, debug = False)['elements']
+wallIds = [w['elementId'] for w in walls]
+
+# inIndex 1 and 2 are the two end points of a wall's reference line.
+dimensions = aclib.RunTapirCommand ('CreateAssociativeDimensions', {
+    'dimensionsData': [
+        {
+            'referencePoint': {'x': 0.0, 'y': -58.0},
+            'direction': {'x': 1.0, 'y': 0.0},
+            'witnessPoints': [
+                {'elementId': wallIds[0], 'inIndex': 2},
+                {'elementId': wallIds[1], 'inIndex': 1}
+            ]
+        }
+    ]
+}, debug = False)['elements']
+
+def PrintDimensionData (dimensionId):
+    data = aclib.RunTapirCommand ('GetDimensionData', {'elements': [dimensionId]}, debug = False)['dimensionsData'][0]
+    print ('direction=({}, {}) witness points={}'.format (data['direction']['x'], data['direction']['y'], len (data['witnessPoints'])))
+    for p in data['witnessPoints']:
+        baseElement = next ((i for i, wallId in enumerate (wallIds) if wallId['guid'] == p['baseElementId']['guid']), None)
+        print ('  wall {} at ({}, {}) value={} line={} inIndex={} special={} nodeType={} nodeStatus={} nodeId={}'.format (
+            baseElement, p['coordinate']['x'], p['coordinate']['y'], p['dimensionValue'],
+            p['line'], p['inIndex'], p['special'], p['nodeType'], p['nodeStatus'], p['nodeId']))
+    return data
+
+data = PrintDimensionData (dimensions[0])
+
+# The witness parameters read back are enough to rebuild the same dimension.
+rebuilt = aclib.RunTapirCommand ('CreateAssociativeDimensions', {
+    'dimensionsData': [
+        {
+            'referencePoint': {'x': 0.0, 'y': -57.0},
+            'direction': data['direction'],
+            'witnessPoints': [
+                {
+                    'elementId': p['baseElementId'],
+                    'line': p['line'],
+                    'inIndex': p['inIndex'],
+                    'special': p['special'],
+                    'nodeType': p['nodeType'],
+                    'nodeStatus': p['nodeStatus'],
+                    'nodeId': p['nodeId']
+                }
+                for p in data['witnessPoints']
+            ]
+        }
+    ]
+}, debug = False)['elements']
+rebuiltData = PrintDimensionData (rebuilt[0])
+print ('rebuilt dimension measures the same: {}'.format (
+    [p['coordinate'] for p in rebuiltData['witnessPoints']] == [p['coordinate'] for p in data['witnessPoints']]))
+
+aclib.RunTapirCommand ('DeleteElements', {'elements': dimensions + rebuilt + walls}, debug = False)


### PR DESCRIPTION
## Summary

Follow-up to #638, which merged while this commit was being pushed. The review there noted that `GetDimensionData` had no Python example, so the witness parameters added for #633 were covered only by the manual test plan.

## Changes

- New example `archicad-addon/Examples/get_dimension_data.py`: creates two walls, dimensions their facing end points with `CreateAssociativeDimensions` (`inIndex` 1 and 2 are the wall reference line end points, as the reporter of #633 confirmed), reads the dimension back with `GetDimensionData` and prints each witness point's `line`, `inIndex`, `special`, `nodeType`, `nodeStatus` and `nodeId`. It then rebuilds a second dimension from the read-back parameters and prints whether both measure the same, and deletes everything it created. A witness point without `baseElementId` (not attached to any element) is printed as `wall None` and the rebuild is skipped.

## Not verified here

- No Archicad on this runner. The example has no golden yet: `Test/test_examples.py` records one on the first run and passes, so please check the recorded `get_dimension_data.py.output` before committing it.
- `create_elements.py` dimensions a wall with `nodeId` 1 and 2 instead of `inIndex`. The DevKit documents `node_id` as the polygon vertex id of polygon elements, and the reporter of #633 found `inIndex` 1 and 2 to be the working form on walls, so this example uses `inIndex`. `create_elements.py` has no golden either, so the Archicad run decides which of the two is right.

## Test plan

- [ ] `Test/test_examples.py` runs `get_dimension_data.py` against `TestProject.pla` twice in a row: the first run records the golden, the second must pass against it, which shows the printed `nodeId`, `nodeType` and `nodeStatus` values are stable
- [ ] The recorded golden shows two witness points per dimension, both `wall 0` / `wall 1` rather than `wall None`, and `rebuilt dimension measures the same: True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzydLZC8CGG62DDTCuRU83